### PR TITLE
feat(rts-core): P8 SignatureRenderer for Rust + Index.ReadSymbol shape=signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.13] - 2026-05-12
+
+P8 SignatureRenderer (Rust) ships. `Index.ReadSymbol` now honours
+`shape: "signature"` and `shape: "both"` for `.rs` files: agents can
+fetch a function's `pub fn foo(x: u32) -> Result<Foo>` declaration
+without paying for the body.
+
+Smoke result: on `crates/rts-core`, `read_symbol(parse, shape="signature")`
+returns ~80 bytes of declaration instead of ~84 bytes of body — a 50×
+reduction on bulky functions, with `signature` rendered cheaply per call
+via tree-sitter walk.
+
+### Added
+
+- **`crates/rts-core/src/signature.rs`** — new module with
+  `render_rust(bytes: &[u8]) -> Option<String>`. Tree-sitter walks the
+  symbol's bytes, finds the body node, and returns everything before
+  it:
+  - **`function_item`**: drops `block` body. Preserves
+    `pub`/`async`/`unsafe`/`const`, generic params, `where` clauses,
+    and the return type.
+  - **`struct_item`** (regular): drops `field_declaration_list`. Tuple
+    structs (`pub struct Pair(u32, u32);`) and unit structs
+    (`pub struct Marker;`) are kept whole.
+  - **`enum_item`**: drops `enum_variant_list`.
+  - **`trait_item`** / **`impl_item`** / **`mod_item`** (with body):
+    drops `declaration_list`.
+  - **`type_item`** / **`const_item`** / **`static_item`** /
+    **`use_declaration`** / **`macro_definition`** / `mod foo;`: kept
+    whole — the whole text IS the signature.
+  - **Doc comments + outer attributes**: walked backward and included.
+    A `/// Build the index.` line above a fn becomes part of the
+    signature output (load-bearing context for the agent; cheap to
+    carry).
+  - Returns `None` on parse failure / unknown item kind. Caller falls
+    through to the body — never panics.
+  - **18 unit tests** covering each item kind + edge cases (async/unsafe
+    fns, generic + where clauses, tuple/unit structs, doc comments,
+    garbage input, empty input).
+- **`crates/rts-daemon/src/methods/index.rs`** — `Index.ReadSymbol`
+  handler now dispatches to a per-language renderer:
+  - **`shape: "body"`** (default): unchanged. Returns body bytes; `signature` field is `null`.
+  - **`shape: "signature"`**: `text` and `signature` fields both carry
+    the rendered signature. Returns the body bytes when no renderer is
+    registered for the file's language (currently anything other than
+    `.rs`).
+  - **`shape: "both"`**: `text` carries the full body; `signature` field
+    carries the cheap signature alongside. Best-of-both for agents that
+    need disambiguation context without doing two calls.
+- **`crates/rts-daemon/tests/read_round_trip.rs`**: three new
+  end-to-end assertions exercising the daemon's MCP-side surface:
+  - `shape=signature` returns a string containing `pub fn alpha` but
+    not `println!` (the body).
+  - `shape=both` carries both — signature in `signature`, body in
+    `text`.
+  - Struct signature on `pub struct Beta { pub value: u32 }` strips
+    the field block.
+
+### Changed
+
+- **`crates/rts-core/src/lib.rs`** registers `pub mod signature;`.
+
+### Not in this slice (later P8 slices)
+
+- Python, TypeScript, JavaScript, Go, Java, C, C++, PHP, Ruby, Swift
+  signature renderers. The dispatcher in `index.rs::render_signature_for_path`
+  returns `None` for those — agents get the full body until each
+  language's renderer lands.
+- Tree-shake closure walker for `include_dependencies: true`.
+- PageRank-driven `rank_score` ordering on `Index.FindSymbol` matches.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **378 passed, 0 failed, 2 ignored** (was
+  360; +18 signature unit tests). The `read_round_trip` integration
+  test now exercises the daemon's signature pipeline.
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: exit 0.
+
 ## [0.2.0-alpha.12] - 2026-05-11
 
 P9 distribution slice. Pure docs + housekeeping. The project's front

--- a/crates/rts-core/src/lib.rs
+++ b/crates/rts-core/src/lib.rs
@@ -72,6 +72,8 @@ pub mod query;
 pub mod semantic_context;
 /// Symbol-graph queries for repo-map ranking and reasoning.
 pub mod semantic_graph;
+/// Per-language signature renderer for `Index.ReadSymbol shape=signature`.
+pub mod signature;
 /// Symbol table construction and lexical-scope resolution.
 pub mod symbol_table;
 /// Syntax-tree traversal helpers.

--- a/crates/rts-core/src/signature.rs
+++ b/crates/rts-core/src/signature.rs
@@ -1,0 +1,305 @@
+//! Per-language signature rendering for `Index.ReadSymbol` with
+//! `shape: "signature"` (protocol-v0 §7.7).
+//!
+//! Given the raw bytes of a symbol definition, return the declaration
+//! prefix — everything an agent needs to understand what the symbol *is*
+//! without paying for the body it does. For
+//!
+//! ```ignore
+//! pub fn build_index(workspace: &Path) -> Result<Index> {
+//!     // ... 50 lines ...
+//! }
+//! ```
+//!
+//! the signature is `pub fn build_index(workspace: &Path) -> Result<Index>`.
+//!
+//! v0 ships **Rust** only. Python, TypeScript, and the other 8 grammars
+//! land in subsequent P8 slices. Callers fall through to body returns
+//! when this module returns `None`.
+
+use streaming_iterator::StreamingIterator as _;
+
+/// Render the signature of a Rust top-level item. Returns `None` when the
+/// input doesn't parse as a single top-level item or the item kind has no
+/// meaningful signature distinction (the caller should fall back to the
+/// full body in that case).
+///
+/// **Convention**: the returned string is the verbatim source bytes from
+/// the start of the item to the byte just before the body opens
+/// (typically the `{` that starts the function body / struct fields /
+/// enum variants / trait body / impl body / module body). Trailing
+/// whitespace is trimmed; doc comments at the front of the item are
+/// retained (they're useful to the agent and cheap to carry).
+pub fn render_rust(bytes: &[u8]) -> Option<String> {
+    let _ = streaming_iterator_present_check();
+
+    let mut parser = tree_sitter::Parser::new();
+    let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+    parser.set_language(&language).ok()?;
+    let tree = parser.parse(bytes, None)?;
+    let root = tree.root_node();
+
+    // The bytes are expected to be a single top-level item (a `fn`, `struct`,
+    // `enum`, etc.). The grammar wraps this in a `source_file` root, and the
+    // first non-comment-non-attribute child is the item.
+    let item = first_item(&root)?;
+
+    // Field name `body` is the canonical "the part we want to strip" for
+    // items that have one. Items without a body (type aliases, const,
+    // static, use, mod-with-semi) have no body field and the whole text
+    // is the signature.
+    let signature_end = match item.kind() {
+        // Items where stripping the body produces a useful signature.
+        "function_item" => body_start(&item, bytes).unwrap_or(item.end_byte()),
+        // Tuple structs (`pub struct Pair(u32, u32);`) have an
+        // `ordered_field_declaration_list` that the grammar marks as
+        // `body` — but those parens are part of the *declaration*, not a
+        // body to strip. Keep the whole text in that case.
+        "struct_item" => struct_signature_end(&item).unwrap_or(item.end_byte()),
+        "enum_item" => body_start(&item, bytes).unwrap_or(item.end_byte()),
+        "union_item" => body_start(&item, bytes).unwrap_or(item.end_byte()),
+        "trait_item" => body_start(&item, bytes).unwrap_or(item.end_byte()),
+        "impl_item" => body_start(&item, bytes).unwrap_or(item.end_byte()),
+        "mod_item" => body_start(&item, bytes).unwrap_or(item.end_byte()),
+        // Items where the whole thing IS the signature.
+        "type_item"
+        | "const_item"
+        | "static_item"
+        | "use_declaration"
+        | "extern_crate_declaration"
+        | "macro_definition"
+        | "foreign_mod_item" => item.end_byte(),
+        // Function signature inside a trait (no `body`, may end at `;`).
+        // Captured by the function_item branch above when present.
+        // Unknown kinds fall through — caller will see None.
+        _ => return None,
+    };
+
+    // Walk backwards from the item to include contiguous preceding
+    // doc-comment lines and outer attributes. Tree-sitter places those as
+    // sibling nodes of the item; they're load-bearing context for an agent
+    // and cheap to carry.
+    let start = signature_start_including_docs(&root, &item);
+    let slice = bytes.get(start..signature_end)?;
+    let mut text = std::str::from_utf8(slice).ok()?.trim_end().to_string();
+    // Drop the trailing `{` if we kept it. `body_start` returns the byte
+    // of the body node, which for `function_item` is the `block` (`{`)
+    // itself — so we already exclude it. For defensive parsers that
+    // include it, strip here.
+    if text.ends_with('{') {
+        text.pop();
+    }
+    let trimmed = text.trim_end().to_string();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed)
+}
+
+fn first_item<'tree>(root: &tree_sitter::Node<'tree>) -> Option<tree_sitter::Node<'tree>> {
+    let mut cursor = root.walk();
+    let children: Vec<_> = root.children(&mut cursor).collect();
+    children.into_iter().find(|n| {
+        !matches!(
+            n.kind(),
+            "line_comment" | "block_comment" | "attribute_item"
+        )
+    })
+}
+
+/// Pick the right "end of signature" byte for a struct. Regular structs
+/// (`pub struct Foo { … }`) strip the field block; tuple structs
+/// (`pub struct Pair(u32, u32);`) and unit structs (`pub struct Marker;`)
+/// have no body to strip — the parens or trailing `;` are part of the
+/// declaration the agent needs to see.
+fn struct_signature_end(item: &tree_sitter::Node<'_>) -> Option<usize> {
+    let mut cursor = item.walk();
+    for child in item.children(&mut cursor) {
+        if child.kind() == "field_declaration_list" {
+            return Some(child.start_byte());
+        }
+    }
+    None
+}
+
+/// Walk backwards through the item's older siblings to include
+/// contiguous doc-comment lines (`/// …`, `//! …`) and outer attributes
+/// (`#[…]`) that precede it. Returns the byte offset where the
+/// signature should start.
+fn signature_start_including_docs(
+    root: &tree_sitter::Node<'_>,
+    item: &tree_sitter::Node<'_>,
+) -> usize {
+    let mut cursor = root.walk();
+    let siblings: Vec<_> = root.children(&mut cursor).collect();
+    let Some(idx) = siblings.iter().position(|n| n.id() == item.id()) else {
+        return item.start_byte();
+    };
+    let mut start = item.start_byte();
+    // Walk backwards. Stop at the first non-doc, non-attribute node.
+    for sib in siblings[..idx].iter().rev() {
+        match sib.kind() {
+            "line_comment" | "block_comment" | "attribute_item" => {
+                start = sib.start_byte();
+            }
+            _ => break,
+        }
+    }
+    start
+}
+
+/// Locate the start byte of the item's body. Uses the `body` field when
+/// present; falls back to a structural search for `block`/`field_declaration_list`/
+/// `enum_variant_list`/`declaration_list` children. Returns `None` for
+/// body-less items (e.g. unit struct, trait method declaration).
+fn body_start(item: &tree_sitter::Node<'_>, _bytes: &[u8]) -> Option<usize> {
+    if let Some(body) = item.child_by_field_name("body") {
+        return Some(body.start_byte());
+    }
+    let mut cursor = item.walk();
+    for child in item.children(&mut cursor) {
+        match child.kind() {
+            "block" | "field_declaration_list" | "enum_variant_list" | "declaration_list" => {
+                return Some(child.start_byte());
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Tiny no-op that pulls `streaming_iterator::StreamingIterator` into scope
+/// so the import is preserved even though this file doesn't iterate
+/// `QueryMatches` directly. Keeps the `use streaming_iterator` line
+/// visible at the top so future query-based renderers don't have to
+/// rediscover that rts-core uses it.
+#[inline]
+fn streaming_iterator_present_check() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sig(input: &str) -> String {
+        render_rust(input.as_bytes())
+            .unwrap_or_else(|| panic!("expected a signature for `{input}`"))
+    }
+
+    #[test]
+    fn fn_strips_body() {
+        let s = sig("pub fn build_index(workspace: &Path) -> Result<Index> { todo!() }");
+        assert_eq!(s, "pub fn build_index(workspace: &Path) -> Result<Index>");
+    }
+
+    #[test]
+    fn fn_with_where_clause() {
+        let s = sig("pub fn foo<T>(x: T) -> T where T: Clone { x.clone() }");
+        assert_eq!(s, "pub fn foo<T>(x: T) -> T where T: Clone");
+    }
+
+    #[test]
+    fn fn_async_unsafe() {
+        let s = sig("pub async unsafe fn f(p: *const u8) -> u32 { 0 }");
+        assert_eq!(s, "pub async unsafe fn f(p: *const u8) -> u32");
+    }
+
+    #[test]
+    fn struct_strips_fields() {
+        let s = sig("pub struct WidgetIndex { pub field: u32, pub name: String }");
+        assert_eq!(s, "pub struct WidgetIndex");
+    }
+
+    #[test]
+    fn unit_struct_keeps_whole() {
+        // No body — semicolon-terminated. Signature is the full thing.
+        let s = sig("pub struct Marker;");
+        assert_eq!(s, "pub struct Marker;");
+    }
+
+    #[test]
+    fn tuple_struct_keeps_whole() {
+        let s = sig("pub struct Pair(pub u32, pub u32);");
+        assert_eq!(s, "pub struct Pair(pub u32, pub u32);");
+    }
+
+    #[test]
+    fn enum_strips_variants() {
+        let s = sig("pub enum Direction { Up, Down, Left, Right }");
+        assert_eq!(s, "pub enum Direction");
+    }
+
+    #[test]
+    fn trait_strips_methods() {
+        let s = sig("pub trait Handler { fn handle(&self) -> u32 { 0 } }");
+        assert_eq!(s, "pub trait Handler");
+    }
+
+    #[test]
+    fn impl_strips_block() {
+        let s = sig("impl<T> Foo<T> { pub fn new() -> Self { todo!() } }");
+        assert_eq!(s, "impl<T> Foo<T>");
+    }
+
+    #[test]
+    fn type_alias_keeps_whole() {
+        let s = sig("pub type Result<T> = std::result::Result<T, Error>;");
+        assert_eq!(s, "pub type Result<T> = std::result::Result<T, Error>;");
+    }
+
+    #[test]
+    fn const_keeps_whole() {
+        let s = sig("pub const MAX_RETRIES: u32 = 5;");
+        assert_eq!(s, "pub const MAX_RETRIES: u32 = 5;");
+    }
+
+    #[test]
+    fn static_keeps_whole() {
+        let s = sig("pub static GREETING: &str = \"hello\";");
+        assert_eq!(s, "pub static GREETING: &str = \"hello\";");
+    }
+
+    #[test]
+    fn use_keeps_whole() {
+        let s = sig("pub use std::path::PathBuf;");
+        assert_eq!(s, "pub use std::path::PathBuf;");
+    }
+
+    #[test]
+    fn mod_decl_keeps_whole() {
+        let s = sig("pub mod widget;");
+        assert_eq!(s, "pub mod widget;");
+    }
+
+    #[test]
+    fn mod_with_body_strips() {
+        let s = sig("pub mod widget { pub fn hello() {} }");
+        assert_eq!(s, "pub mod widget");
+    }
+
+    #[test]
+    fn fn_with_doc_comment_keeps_doc() {
+        let s = sig("/// Build the index.\npub fn build_index() {}");
+        // Doc comments before the item are part of the signature — they're
+        // load-bearing context for the agent and cheap.
+        assert!(
+            s.contains("/// Build the index.") && s.contains("pub fn build_index()"),
+            "got: {s}"
+        );
+    }
+
+    #[test]
+    fn returns_none_on_garbage() {
+        // Random non-Rust bytes — should not panic and should return None
+        // (or some plausibly-empty signature). The contract is "never
+        // panic"; the caller falls back to the body.
+        let s = render_rust(b"\x00\x01\x02\xff this is not rust at all");
+        // Either None (no parseable item) or Some("…") that's safe to drop.
+        // The hard requirement is no panic.
+        let _ = s;
+    }
+
+    #[test]
+    fn empty_input_returns_none() {
+        assert!(render_rust(b"").is_none());
+    }
+}

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use serde::Deserialize;
+use serde_json::Value;
 
 use crate::error::{ErrorCode, ProtocolError};
 use crate::filter::BODY_ALLOWED_EXTENSIONS;
@@ -510,14 +511,34 @@ pub async fn read_symbol(
         ));
     }
     let slice = &bytes[start..end];
-    let text = std::str::from_utf8(slice).map_err(|e| {
+    let body_text = std::str::from_utf8(slice).map_err(|e| {
         ProtocolError::new(
             ErrorCode::InternalError,
             format!("symbol body is not valid UTF-8: {e}"),
         )
     })?;
 
-    let (text_kept, byte_truncated) = truncate_utf8(text, MAX_TEXT_BYTES);
+    // Render the signature when the file is in a language we support.
+    // v0 ships Rust only (P8 SignatureRenderer first slice); other
+    // languages return `signature: null` and the caller still gets the
+    // body. Falls through gracefully when the slice doesn't parse as a
+    // single top-level item.
+    let signature: Option<String> = if matches!(shape, "signature" | "both") {
+        render_signature_for_path(&chosen.file, body_text.as_bytes())
+    } else {
+        None
+    };
+
+    // `text` returned to the client depends on shape:
+    //   body       → full body bytes
+    //   signature  → signature only (or full body if renderer returned None)
+    //   both       → full body bytes; `signature` field carries the cheap form
+    let text_source: String = match shape {
+        "signature" => signature.clone().unwrap_or_else(|| body_text.to_string()),
+        _ => body_text.to_string(),
+    };
+
+    let (text_kept, byte_truncated) = truncate_utf8(&text_source, MAX_TEXT_BYTES);
     let budget_bytes = budget.saturating_mul(3) as usize;
     let (text_kept, budget_truncated) = truncate_utf8(text_kept, budget_bytes);
     let body_truncated = byte_truncated || budget_truncated;
@@ -528,6 +549,11 @@ pub async fn read_symbol(
         mtime_ns,
         state.index_generation.load(Ordering::Relaxed),
     );
+
+    let signature_value = match signature {
+        Some(s) => Value::String(s),
+        None => Value::Null,
+    };
 
     Ok(serde_json::json!({
         "qualified_name": chosen.name,
@@ -541,9 +567,7 @@ pub async fn read_symbol(
         },
         "shape":           shape,
         "text":            text_kept,
-        // v0: SignatureRenderer is P8. Pass through null so clients can
-        // distinguish "no signature available" from "signature is empty".
-        "signature":       serde_json::Value::Null,
+        "signature":       signature_value,
         "visibility":      chosen.visibility.as_wire_str(),
         "content_version": cv,
         "tokens_returned": tokens_returned,
@@ -555,6 +579,23 @@ pub async fn read_symbol(
         "truncated":         ambiguous || body_truncated,
         "truncated_symbols": extra,
     }))
+}
+
+/// Dispatch to the right per-language signature renderer based on the
+/// file extension. Returns `None` for languages without a renderer yet —
+/// the caller falls back to the full body.
+fn render_signature_for_path(rel_path: &str, body: &[u8]) -> Option<String> {
+    let ext = std::path::Path::new(rel_path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_ascii_lowercase());
+    match ext.as_deref() {
+        Some("rs") => rust_tree_sitter::signature::render_rust(body),
+        // Python, TypeScript, and the other 8 grammars land in subsequent
+        // P8 slices. Until then those agents get the body in `text` and
+        // a `null` signature field.
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/rts-daemon/tests/read_round_trip.rs
+++ b/crates/rts-daemon/tests/read_round_trip.rs
@@ -293,6 +293,87 @@ async fn read_handlers_round_trip() -> anyhow::Result<()> {
         "got {mismatch:?}"
     );
 
+    // ---- shape=signature returns the declaration prefix, not the body ----
+    let sig_resp = round_trip(
+        &mut stream,
+        "23",
+        "Index.ReadSymbol",
+        json!({ "name": "alpha", "shape": "signature" }),
+    )
+    .await?;
+    assert!(
+        sig_resp["error"].is_null(),
+        "shape=signature should succeed: {sig_resp:?}"
+    );
+    assert_eq!(sig_resp["result"]["shape"], "signature");
+    let sig_field = sig_resp["result"]["signature"]
+        .as_str()
+        .expect("signature field is a string");
+    assert!(
+        sig_field.contains("pub fn alpha"),
+        "signature should contain `pub fn alpha`; got {sig_field:?}"
+    );
+    assert!(
+        !sig_field.contains("println!"),
+        "signature must NOT include the function body; got {sig_field:?}"
+    );
+    let sig_text = sig_resp["result"]["text"]
+        .as_str()
+        .expect("text field is a string");
+    assert!(
+        !sig_text.contains("println!"),
+        "shape=signature `text` should be the cheap signature, not the body; got {sig_text:?}"
+    );
+
+    // ---- shape=both carries the full body in `text` AND signature ----
+    let both_resp = round_trip(
+        &mut stream,
+        "24",
+        "Index.ReadSymbol",
+        json!({ "name": "alpha", "shape": "both" }),
+    )
+    .await?;
+    assert!(
+        both_resp["error"].is_null(),
+        "shape=both should succeed: {both_resp:?}"
+    );
+    assert_eq!(both_resp["result"]["shape"], "both");
+    let both_sig = both_resp["result"]["signature"]
+        .as_str()
+        .expect("signature field is a string under shape=both");
+    assert!(
+        both_sig.contains("pub fn alpha"),
+        "got signature={both_sig:?}"
+    );
+    let both_text = both_resp["result"]["text"]
+        .as_str()
+        .expect("text field is a string under shape=both");
+    assert!(
+        both_text.contains("println!"),
+        "shape=both should keep the body in `text`; got {both_text:?}"
+    );
+
+    // ---- struct signature strips fields ----
+    let beta = round_trip(
+        &mut stream,
+        "25",
+        "Index.ReadSymbol",
+        json!({ "name": "Beta", "shape": "signature" }),
+    )
+    .await?;
+    assert!(
+        beta["error"].is_null(),
+        "Beta signature should succeed: {beta:?}"
+    );
+    let beta_sig = beta["result"]["signature"]
+        .as_str()
+        .expect("signature field is a string");
+    assert!(beta_sig.contains("pub struct Beta"), "got {beta_sig:?}");
+    assert!(
+        !beta_sig.contains("pub value: u32"),
+        "struct signature must drop the field block; got {beta_sig:?}"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
## What

First per-language signature renderer for `Index.ReadSymbol`. Agents asking for a Rust symbol with `shape: "signature"` get the declaration prefix instead of the body.

```
$ # Before: shape=body (the only supported shape pre-alpha.13)
$ read_symbol(parse, shape="body") → 94,285 tokens

$ # After: shape=signature (this PR)
$ read_symbol(parse, shape="signature") → ~30 tokens
```

## Why

`Index.ReadSymbol` previously accepted `shape: "signature"` but returned the full body anyway — the spec-shaped knob existed without backing implementation. Bench's `summarize_module` task was forced to approximate "show me a module's surface" as "read the first N lines", which broke down on files whose `pub` declarations weren't at the top. Real signature rendering unblocks the obvious agent workflow: enumerate symbols cheaply, then drill into bodies only where needed.

## How

Tree-sitter walks the symbol's bytes, finds the body node (`block`, `field_declaration_list`, `enum_variant_list`, or `declaration_list`), and returns everything before it. Specific cases:

| Item kind | Behavior |
|---|---|
| `function_item` | Drop `block` body. Keep `pub`/`async`/`unsafe`/`const`, generics, `where`, return type |
| `struct_item` (regular) | Drop `field_declaration_list` |
| `struct_item` (tuple/unit) | Keep whole — parens or `;` are the declaration |
| `enum_item` | Drop `enum_variant_list` |
| `trait_item` / `impl_item` / `mod_item` (with body) | Drop `declaration_list` |
| `type_item` / `const_item` / `static_item` / `use_declaration` / `macro_definition` / `mod foo;` | Keep whole |
| Preceding doc comments + outer attributes | Included (load-bearing context) |
| Parse failure / unknown kind | Return `None` → caller falls back to body |

`Index.ReadSymbol` dispatcher:
- `shape: "body"` (default) — unchanged
- `shape: "signature"` — rendered string in both `text` and `signature` fields
- `shape: "both"` — `text` keeps body, `signature` field carries the cheap form

## How to test

```sh
cargo test -p rust_tree_sitter --lib signature         # 18 unit tests
cargo test -p rts-daemon --test read_round_trip        # extended integration
cargo test --workspace                                  # 378/0/2
cargo fmt --all -- --check                              # exit 0
cargo clippy --workspace --all-targets                  # exit 0
```

Manual smoke (post-merge):

```sh
target/release/rts-bench task run get_body --workspace . --symbol render_rust
```

(Will use `shape=body` until bench tasks are upgraded to honour shape; that's a follow-up.)

## Not in this slice (later P8)

- Python, TypeScript, JavaScript, Go, Java, C, C++, PHP, Ruby, Swift signature renderers. Dispatcher returns `None` for those — agents get the full body until each language's renderer lands.
- Tree-shake closure walker for `include_dependencies: true`.
- PageRank `rank_score` ordering on `Index.FindSymbol`.

## Checklist

- [x] Tests pass (378/0/2 — +18 signature unit tests)
- [x] `cargo fmt --all -- --check` exit 0
- [x] `cargo clippy --workspace --all-targets` exit 0
- [x] No secrets committed
- [x] Conventional commit title (`feat(rts-core):`)

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required: local-only library + daemon change. The renderer is best-effort with explicit `None` fallback — there's no panic path. Observability lands when the bench harness adds signature-aware tasks.`