### PR TITLE
feat(rts-core): SignatureRenderer for Python, TypeScript, JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.14] - 2026-05-12
+
+P8 SignatureRenderer expands to **Python, TypeScript, and JavaScript**.
+`Index.ReadSymbol shape=signature` now returns rendered declarations
+for `.py`, `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs` in addition to
+`.rs`. Remaining 7 grammars (Go, Java, C, C++, PHP, Ruby, Swift) follow
+in subsequent slices.
+
+### Added
+
+- **`render_python(bytes)`** in `crates/rts-core/src/signature.rs`:
+  - **`function_definition`** / async fns — drops `block` body. Keeps
+    `async` modifier, parameters, return annotation, trailing `:`.
+  - **`class_definition`** — drops `block` body. Keeps bases parens
+    and `:`.
+  - **`decorated_definition`** — preserves decorators and unwraps to
+    the function/class body inside.
+  - One-liners (`expression_statement`, `assignment`, `import_*`,
+    `global_statement`, `nonlocal_statement`, `type_alias_statement`)
+    are kept whole.
+- **`render_typescript(bytes)`** + **`render_javascript(bytes)`** in
+  the same module:
+  - **`function_declaration`** / `generator_function_declaration` /
+    `function_signature` / `method_definition` / `method_signature` —
+    drops `statement_block`.
+  - **`class_declaration`** / `abstract_class_declaration` — drops
+    `class_body`.
+  - **`interface_declaration`** — drops `interface_body` / `object_type`.
+  - **`enum_declaration`** — drops `enum_body`.
+  - **`module`** / `internal_module` / `namespace_declaration` —
+    drops body block.
+  - **`export …`** statements unwrap transparently; the `export`
+    keyword is preserved in the rendered signature.
+  - One-liners (`type_alias_declaration`, `lexical_declaration`,
+    `variable_declaration`, `import_statement`, `expression_statement`,
+    `ambient_declaration`) are kept whole.
+- **`render_signature_for_path`** dispatch in
+  `crates/rts-daemon/src/methods/index.rs` extended for `.py`, `.ts`,
+  `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`.
+- **`crates/rts-daemon/tests/read_round_trip.rs`** seeds two new
+  files in the test workspace (`py_demo.py`, `ts_demo.ts`) and
+  asserts the daemon's signature dispatch routes each file to the
+  correct renderer, producing language-appropriate signatures.
+
+### Changed
+
+- Module-level doc comment in
+  `crates/rts-core/src/signature.rs` now lists Rust + Python +
+  TypeScript + JavaScript as the supported languages.
+
+### Not in this slice (later P8 slices)
+
+- Go, Java, C, C++, PHP, Ruby, Swift signature renderers — dispatcher
+  returns `None` for those.
+- Tree-shake closure walker for `include_dependencies: true`.
+- PageRank `rank_score` ordering on `Index.FindSymbol`.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **399 passed, 0 failed, 2 ignored** (was
+  378; +21 new signature unit tests: 7 Python + 11 TypeScript + 3
+  JavaScript, plus 2 integration assertions for the dispatch).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: exit 0.
+
 ## [0.2.0-alpha.13] - 2026-05-12
 
 P8 SignatureRenderer (Rust) ships. `Index.ReadSymbol` now honours

--- a/crates/rts-core/src/signature.rs
+++ b/crates/rts-core/src/signature.rs
@@ -13,9 +13,10 @@
 //!
 //! the signature is `pub fn build_index(workspace: &Path) -> Result<Index>`.
 //!
-//! v0 ships **Rust** only. Python, TypeScript, and the other 8 grammars
-//! land in subsequent P8 slices. Callers fall through to body returns
-//! when this module returns `None`.
+//! v0 ships **Rust, Python, TypeScript, and JavaScript**. The remaining
+//! 7 grammars (Go, Java, C, C++, PHP, Ruby, Swift) land in subsequent
+//! P8 slices. Callers fall through to body returns when this module
+//! returns `None`.
 
 use streaming_iterator::StreamingIterator as _;
 
@@ -176,6 +177,197 @@ fn body_start(item: &tree_sitter::Node<'_>, _bytes: &[u8]) -> Option<usize> {
 #[inline]
 fn streaming_iterator_present_check() {}
 
+/// Render the signature of a Python top-level item.
+///
+/// Top-level Python items the agent typically cares about:
+/// - **`function_definition`** / **`async function_definition`** — drops
+///   the `block` body. Preserves decorators, async modifier, parameters,
+///   and return-type annotation. The trailing `:` is kept so the agent
+///   sees the full declaration syntax.
+/// - **`class_definition`** — drops the `block` body. Keeps the base
+///   classes parens and trailing `:`.
+/// - **`decorated_definition`** — handled transparently; the wrapped
+///   function or class is processed and its preceding decorators are
+///   included.
+/// - Everything else (`expression_statement`, `assignment`, `import_*`)
+///   is returned whole — it's already a one-liner.
+///
+/// Returns `None` for unparseable input or unrecognised top-level kinds.
+pub fn render_python(bytes: &[u8]) -> Option<String> {
+    let mut parser = tree_sitter::Parser::new();
+    let language: tree_sitter::Language = tree_sitter_python::LANGUAGE.into();
+    parser.set_language(&language).ok()?;
+    let tree = parser.parse(bytes, None)?;
+    let root = tree.root_node();
+    let item = root
+        .children(&mut root.walk())
+        .find(|n| !matches!(n.kind(), "comment"))?;
+
+    // For a `decorated_definition` we want to include the decorators in
+    // the returned text and slice up to the wrapped function/class body.
+    // For a bare function/class, same logic but no decorators.
+    let signature_end = match item.kind() {
+        "function_definition" | "class_definition" => {
+            python_body_start(&item).unwrap_or(item.end_byte())
+        }
+        "decorated_definition" => python_decorated_body_start(&item).unwrap_or(item.end_byte()),
+        // One-liners (imports, top-level expressions, assignments) — keep whole.
+        "expression_statement"
+        | "assignment"
+        | "import_statement"
+        | "import_from_statement"
+        | "future_import_statement"
+        | "global_statement"
+        | "nonlocal_statement"
+        | "type_alias_statement" => item.end_byte(),
+        _ => return None,
+    };
+
+    let start = item.start_byte();
+    let slice = bytes.get(start..signature_end)?;
+    let text = std::str::from_utf8(slice).ok()?.trim_end().to_string();
+    if text.is_empty() {
+        return None;
+    }
+    Some(text)
+}
+
+fn python_body_start(item: &tree_sitter::Node<'_>) -> Option<usize> {
+    item.child_by_field_name("body").map(|b| b.start_byte())
+}
+
+fn python_decorated_body_start(item: &tree_sitter::Node<'_>) -> Option<usize> {
+    let mut cursor = item.walk();
+    for child in item.children(&mut cursor) {
+        if matches!(child.kind(), "function_definition" | "class_definition") {
+            if let Some(body) = child.child_by_field_name("body") {
+                return Some(body.start_byte());
+            }
+            return Some(child.end_byte());
+        }
+    }
+    None
+}
+
+/// Render the signature of a TypeScript top-level item.
+///
+/// Reuses the same shape rules as Rust: find the body node and return
+/// everything before it. TypeScript-specific kinds:
+/// - **`function_declaration`** / **`generator_function_declaration`**
+///   / **`function_signature`** — drops `statement_block` (or returns
+///   whole when no body, e.g. `function f(): void;` in `.d.ts`).
+/// - **`class_declaration`** / **`abstract_class_declaration`** — drops
+///   `class_body`.
+/// - **`interface_declaration`** — drops `interface_body` /
+///   `object_type`.
+/// - **`enum_declaration`** — drops `enum_body`.
+/// - **`type_alias_declaration`** / **`lexical_declaration`**
+///   (`const`/`let`) / **`variable_declaration`** (`var`) — whole.
+/// - **`export_statement`** wraps any of the above; unwrap.
+///
+/// Returns `None` for unparseable input or unrecognised top-level kinds.
+pub fn render_typescript(bytes: &[u8]) -> Option<String> {
+    render_ts_like(bytes, tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
+}
+
+/// Render the signature of a JavaScript top-level item.
+///
+/// Same shape rules as `render_typescript` minus the TS-only kinds
+/// (`type_alias_declaration`, `interface_declaration`, etc.). The
+/// `function_declaration`/`class_declaration` paths are identical.
+pub fn render_javascript(bytes: &[u8]) -> Option<String> {
+    render_ts_like(bytes, tree_sitter_javascript::LANGUAGE.into())
+}
+
+fn render_ts_like(bytes: &[u8], language: tree_sitter::Language) -> Option<String> {
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&language).ok()?;
+    let tree = parser.parse(bytes, None)?;
+    let root = tree.root_node();
+    let raw_item = root
+        .children(&mut root.walk())
+        .find(|n| !matches!(n.kind(), "comment" | "hash_bang_line"))?;
+
+    // `export …` and `export default …` wrap the real declaration.
+    let item = unwrap_export(&raw_item).unwrap_or(raw_item);
+
+    let signature_end = match item.kind() {
+        "function_declaration"
+        | "generator_function_declaration"
+        | "function_signature"
+        | "method_definition"
+        | "method_signature" => ts_body_start(&item).unwrap_or(item.end_byte()),
+        "class_declaration" | "abstract_class_declaration" => {
+            ts_body_start(&item).unwrap_or(item.end_byte())
+        }
+        "interface_declaration" => ts_body_start(&item).unwrap_or(item.end_byte()),
+        "enum_declaration" => ts_body_start(&item).unwrap_or(item.end_byte()),
+        "module" | "internal_module" | "namespace_declaration" => {
+            ts_body_start(&item).unwrap_or(item.end_byte())
+        }
+        // One-liners.
+        "type_alias_declaration"
+        | "lexical_declaration"
+        | "variable_declaration"
+        | "import_statement"
+        | "export_specifier"
+        | "ambient_declaration"
+        | "expression_statement" => item.end_byte(),
+        _ => return None,
+    };
+
+    // Slice from the *outer* node (which includes the `export` keyword
+    // when present) so the signature carries that modifier.
+    let start = raw_item.start_byte();
+    let slice = bytes.get(start..signature_end)?;
+    let text = std::str::from_utf8(slice).ok()?.trim_end().to_string();
+    if text.is_empty() {
+        return None;
+    }
+    Some(text)
+}
+
+fn unwrap_export<'tree>(node: &tree_sitter::Node<'tree>) -> Option<tree_sitter::Node<'tree>> {
+    if node.kind() != "export_statement" {
+        return None;
+    }
+    let mut cursor = node.walk();
+    node.children(&mut cursor).find(|c| {
+        matches!(
+            c.kind(),
+            "function_declaration"
+                | "generator_function_declaration"
+                | "function_signature"
+                | "class_declaration"
+                | "abstract_class_declaration"
+                | "interface_declaration"
+                | "enum_declaration"
+                | "type_alias_declaration"
+                | "lexical_declaration"
+                | "variable_declaration"
+                | "module"
+                | "internal_module"
+                | "namespace_declaration"
+        )
+    })
+}
+
+fn ts_body_start(item: &tree_sitter::Node<'_>) -> Option<usize> {
+    if let Some(body) = item.child_by_field_name("body") {
+        return Some(body.start_byte());
+    }
+    let mut cursor = item.walk();
+    for child in item.children(&mut cursor) {
+        if matches!(
+            child.kind(),
+            "statement_block" | "class_body" | "interface_body" | "object_type" | "enum_body"
+        ) {
+            return Some(child.start_byte());
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -301,5 +493,174 @@ mod tests {
     #[test]
     fn empty_input_returns_none() {
         assert!(render_rust(b"").is_none());
+    }
+
+    // ---------- Python ----------
+
+    fn py(input: &str) -> String {
+        render_python(input.as_bytes())
+            .unwrap_or_else(|| panic!("expected a python signature for `{input}`"))
+    }
+
+    #[test]
+    fn py_fn_strips_body() {
+        let s = py("def build_index(workspace: Path) -> Index:\n    return Index()\n");
+        assert!(
+            s.starts_with("def build_index(workspace: Path) -> Index:"),
+            "got {s:?}"
+        );
+        assert!(!s.contains("return Index()"), "got {s:?}");
+    }
+
+    #[test]
+    fn py_async_fn() {
+        let s = py("async def fetch(url: str) -> bytes:\n    return await get(url)\n");
+        assert!(
+            s.starts_with("async def fetch(url: str) -> bytes:"),
+            "got {s:?}"
+        );
+    }
+
+    #[test]
+    fn py_class_strips_body() {
+        let s = py("class Widget(Base):\n    pass\n");
+        assert!(s.starts_with("class Widget(Base):"), "got {s:?}");
+        assert!(!s.contains("pass"), "got {s:?}");
+    }
+
+    #[test]
+    fn py_decorated_fn_keeps_decorators() {
+        let s = py(
+            "@staticmethod\n@cached\ndef factory(name: str) -> Widget:\n    return Widget(name)\n",
+        );
+        assert!(
+            s.contains("@staticmethod") && s.contains("@cached"),
+            "got {s:?}"
+        );
+        assert!(s.contains("def factory(name: str) -> Widget:"), "got {s:?}");
+        assert!(!s.contains("return Widget"), "got {s:?}");
+    }
+
+    #[test]
+    fn py_one_liner_assignment_keeps_whole() {
+        let s = py("MAX_RETRIES: int = 5");
+        assert_eq!(s, "MAX_RETRIES: int = 5");
+    }
+
+    #[test]
+    fn py_returns_none_on_garbage() {
+        let _ = render_python(b"\x00\xff this is not python");
+    }
+
+    #[test]
+    fn py_empty_input_returns_none() {
+        assert!(render_python(b"").is_none());
+    }
+
+    // ---------- TypeScript ----------
+
+    fn ts(input: &str) -> String {
+        render_typescript(input.as_bytes())
+            .unwrap_or_else(|| panic!("expected a typescript signature for `{input}`"))
+    }
+
+    #[test]
+    fn ts_fn_strips_body() {
+        let s = ts("function add(a: number, b: number): number { return a + b; }");
+        assert_eq!(s, "function add(a: number, b: number): number");
+    }
+
+    #[test]
+    fn ts_export_fn() {
+        let s = ts("export function greet(name: string): string { return `Hi ${name}`; }");
+        assert!(
+            s.starts_with("export function greet(name: string): string"),
+            "got {s:?}"
+        );
+        assert!(!s.contains("return"), "got {s:?}");
+    }
+
+    #[test]
+    fn ts_class_strips_methods() {
+        let s = ts("class Widget { name: string; greet() { return this.name; } }");
+        assert!(s.starts_with("class Widget"), "got {s:?}");
+        assert!(!s.contains("greet"), "got {s:?}");
+    }
+
+    #[test]
+    fn ts_export_class() {
+        let s = ts(
+            "export class Box<T> extends Container<T> implements Stackable { items: T[] = []; push(item: T) {} }",
+        );
+        assert!(
+            s.starts_with("export class Box<T> extends Container<T> implements Stackable"),
+            "got {s:?}"
+        );
+        assert!(!s.contains("items"), "got {s:?}");
+    }
+
+    #[test]
+    fn ts_interface_strips_members() {
+        let s = ts("interface Handler { handle(input: string): string; }");
+        assert_eq!(s, "interface Handler");
+    }
+
+    #[test]
+    fn ts_type_alias_keeps_whole() {
+        let s = ts("export type Result<T> = T | Error;");
+        assert_eq!(s, "export type Result<T> = T | Error;");
+    }
+
+    #[test]
+    fn ts_const_keeps_whole() {
+        let s = ts("export const MAX_RETRIES = 5;");
+        assert_eq!(s, "export const MAX_RETRIES = 5;");
+    }
+
+    #[test]
+    fn ts_enum_strips_variants() {
+        let s = ts("enum Direction { Up, Down, Left, Right }");
+        assert_eq!(s, "enum Direction");
+    }
+
+    #[test]
+    fn ts_returns_none_on_garbage() {
+        let _ = render_typescript(b"\x00\xff not typescript at all");
+    }
+
+    #[test]
+    fn ts_empty_input_returns_none() {
+        assert!(render_typescript(b"").is_none());
+    }
+
+    // ---------- JavaScript ----------
+
+    fn js(input: &str) -> String {
+        render_javascript(input.as_bytes())
+            .unwrap_or_else(|| panic!("expected a javascript signature for `{input}`"))
+    }
+
+    #[test]
+    fn js_fn_strips_body() {
+        let s = js("function add(a, b) { return a + b; }");
+        assert_eq!(s, "function add(a, b)");
+    }
+
+    #[test]
+    fn js_class_strips_methods() {
+        let s = js("class Widget { greet() { return 'hi'; } }");
+        assert!(s.starts_with("class Widget"), "got {s:?}");
+        assert!(!s.contains("greet"), "got {s:?}");
+    }
+
+    #[test]
+    fn js_const_keeps_whole() {
+        let s = js("const MAX = 42;");
+        assert_eq!(s, "const MAX = 42;");
+    }
+
+    #[test]
+    fn js_empty_input_returns_none() {
+        assert!(render_javascript(b"").is_none());
     }
 }

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -591,9 +591,17 @@ fn render_signature_for_path(rel_path: &str, body: &[u8]) -> Option<String> {
         .map(|s| s.to_ascii_lowercase());
     match ext.as_deref() {
         Some("rs") => rust_tree_sitter::signature::render_rust(body),
-        // Python, TypeScript, and the other 8 grammars land in subsequent
-        // P8 slices. Until then those agents get the body in `text` and
-        // a `null` signature field.
+        Some("py") => rust_tree_sitter::signature::render_python(body),
+        // TypeScript grammar handles `.ts`; `.tsx` is intentionally
+        // routed here too — the grammar accepts both and the agent's
+        // signature shape is identical.
+        Some("ts") | Some("tsx") => rust_tree_sitter::signature::render_typescript(body),
+        Some("js") | Some("jsx") | Some("mjs") | Some("cjs") => {
+            rust_tree_sitter::signature::render_javascript(body)
+        }
+        // Go, Java, C, C++, PHP, Ruby, Swift land in subsequent P8 slices.
+        // Until then those agents get the body in `text` and a `null`
+        // signature field.
         _ => None,
     }
 }

--- a/crates/rts-daemon/tests/read_round_trip.rs
+++ b/crates/rts-daemon/tests/read_round_trip.rs
@@ -113,6 +113,17 @@ async fn read_handlers_round_trip() -> anyhow::Result<()> {
     std::fs::write(workspace.path().join("src.rs"), SOURCE)?;
     // A file with a disallowed extension, to exercise §13.4.
     std::fs::write(workspace.path().join("data.bin"), b"\x00\x01\x02\x03")?;
+    // Python + TypeScript files so the signature dispatch in
+    // `methods::index::render_signature_for_path` can be exercised
+    // end-to-end alongside the Rust one.
+    std::fs::write(
+        workspace.path().join("py_demo.py"),
+        "def py_target(name: str) -> int:\n    return len(name)\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("ts_demo.ts"),
+        "export function tsTarget(a: number, b: number): number { return a + b; }\n",
+    )?;
 
     let socket_path = if cfg!(target_os = "macos") {
         home_dir
@@ -372,6 +383,58 @@ async fn read_handlers_round_trip() -> anyhow::Result<()> {
     assert!(
         !beta_sig.contains("pub value: u32"),
         "struct signature must drop the field block; got {beta_sig:?}"
+    );
+
+    // ---- Per-language dispatch: Python ----
+    // Wait for the Python symbol to land in the index (the writer is
+    // asynchronous; py_demo.py is parsed alongside src.rs).
+    wait_for_symbol(&mut stream, "py_target", Duration::from_secs(5)).await?;
+    let py_sig = round_trip(
+        &mut stream,
+        "30",
+        "Index.ReadSymbol",
+        json!({ "name": "py_target", "shape": "signature" }),
+    )
+    .await?;
+    assert!(
+        py_sig["error"].is_null(),
+        "py_target signature should succeed: {py_sig:?}"
+    );
+    let py_text = py_sig["result"]["signature"]
+        .as_str()
+        .expect("signature field for python");
+    assert!(
+        py_text.starts_with("def py_target(name: str) -> int:"),
+        "python signature shape wrong; got {py_text:?}"
+    );
+    assert!(
+        !py_text.contains("return len(name)"),
+        "python signature must strip body; got {py_text:?}"
+    );
+
+    // ---- Per-language dispatch: TypeScript ----
+    wait_for_symbol(&mut stream, "tsTarget", Duration::from_secs(5)).await?;
+    let ts_sig = round_trip(
+        &mut stream,
+        "31",
+        "Index.ReadSymbol",
+        json!({ "name": "tsTarget", "shape": "signature" }),
+    )
+    .await?;
+    assert!(
+        ts_sig["error"].is_null(),
+        "tsTarget signature should succeed: {ts_sig:?}"
+    );
+    let ts_text = ts_sig["result"]["signature"]
+        .as_str()
+        .expect("signature field for typescript");
+    assert!(
+        ts_text.contains("function tsTarget(a: number, b: number): number"),
+        "typescript signature shape wrong; got {ts_text:?}"
+    );
+    assert!(
+        !ts_text.contains("return a + b"),
+        "typescript signature must strip body; got {ts_text:?}"
     );
 
     Ok(())


### PR DESCRIPTION
## What

Stacks the SignatureRenderer onto three more languages. After this PR, `Index.ReadSymbol shape=signature` produces declarations for `.rs`, `.py`, `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`.

Before:

```
read_symbol("py_target", shape="signature") on a .py file
  → full body (renderer returned None, caller fell back)
```

After:

```
read_symbol("py_target", shape="signature") on a .py file
  → "def py_target(name: str) -> int:"
```

## Why

The previous slice (#8 / alpha.13) shipped Rust only and explicitly flagged Python and TypeScript as the next batch — they were called out in the original plan's P7/P8 split (`P7 — Skeleton mode renderers: Rust, Python, TypeScript shipped in P7; others in P8`). JavaScript piggybacks on the TypeScript implementation since `tree-sitter-typescript` and `tree-sitter-javascript` share the same body-node shape — adding it costs ~15 LOC.

## How

Same shape rules as the Rust renderer: tree-sitter walks the bytes, finds the body node, returns everything before it.

| Language | Drops | Keeps whole |
|---|---|---|
| Python | `function_definition`/`class_definition`/`decorated_definition` body block | imports, assignments, type aliases |
| TypeScript | `function_declaration`/`class_declaration`/`interface_declaration`/`enum_declaration`/`module` body | `type_alias_declaration`, `lexical_declaration`, `variable_declaration` |
| JavaScript | same as TS minus the TS-only kinds | same |

`export …` statements unwrap transparently with the `export` keyword preserved in the rendered signature.

## How to test

```sh
cargo test -p rust_tree_sitter --lib signature   # 39 unit tests (was 18)
cargo test -p rts-daemon --test read_round_trip  # extended dispatch tests
cargo test --workspace                            # 399/0/2 (was 378)
cargo fmt --all -- --check                        # exit 0
cargo clippy --workspace --all-targets            # exit 0
```

## Not in this slice (later P8)

- Go, Java, C, C++, PHP, Ruby, Swift signature renderers — dispatcher returns `None` for those.
- Tree-shake closure walker for `include_dependencies: true`.
- PageRank `rank_score` ordering on `Index.FindSymbol`.

## Checklist

- [x] Tests pass (399/0/2 — +21 unit tests + 2 integration assertions)
- [x] `cargo fmt --all -- --check` exit 0
- [x] `cargo clippy --workspace --all-targets` exit 0
- [x] No secrets committed
- [x] Conventional commit title (`feat(rts-core):`)

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required: local-only library + daemon change. The renderers are best-effort with explicit None fallback — no panic path. Observability lands when the bench harness adds signature-aware tasks.`