### PR TITLE
fix(rts-core): analyzer-layer extraction for all 11 grammars (alpha.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.17] - 2026-05-12
+
+Analyzer-layer fix. Closes the writer-side extraction gap noted in
+alphas 15 + 16: `Index.ReadSymbol shape=signature` now works
+end-to-end for **all 11 supported grammars**, not just 5.
+
+Root cause was two bugs upstream of the SignatureRenderer:
+
+1. **`detect_language_from_extension`** in `crates/rts-core/src/lib.rs`
+   was missing entries for **Java, PHP, Ruby, Swift**. Files with
+   those extensions silently fell through to `None`, so
+   `analyze_file_internal` returned `Ok(())` without ever calling
+   `extract_symbols` — symbols never made it into the index.
+2. **`extract_c_symbols`** in `crates/rts-core/src/analyzer.rs`
+   walked the C function tree assuming a `function_definition >
+   declarator > function_declarator > declarator` chain, but
+   tree-sitter-c's typical shape is `function_definition >
+   declarator(function_declarator) > declarator(identifier)`. The
+   nested search never found `function_declarator` so C and C++
+   functions never registered.
+3. **`render_php`** in `crates/rts-core/src/signature.rs` couldn't
+   parse the writer-stored byte slice because the slice doesn't
+   include the `<?php` opening tag. tree-sitter-php only parses
+   content wrapped in `<?php … ?>`. Fix synthesises the tag when
+   absent (cheap textual probe).
+
+### Added
+
+- **Extension mappings** in `detect_language_from_extension`:
+  - `java` → `Language::Java`
+  - `php`, `phtml` → `Language::Php`
+  - `rb`, `rake` → `Language::Ruby`
+  - `swift` → `Language::Swift`
+  - Bonus: `cjs` → `Language::JavaScript`, `hh` → `Language::Cpp`
+    (filling small gaps in the existing entries).
+- **`looks_like_php_tag(bytes)`** helper in `signature.rs`: cheap
+  textual scan for the `<?php` opening tag (with BOM tolerance). Used
+  by `render_php` to decide whether to synthesise the tag before
+  parsing.
+- **6 new writer-layer unit tests** in `crates/rts-daemon/src/writer.rs`
+  verifying `parse_and_extract` returns symbols for Java, C, C++, PHP,
+  Ruby, Swift (joining the existing Rust + Go tests).
+- **7 new integration assertions** in
+  `crates/rts-daemon/tests/read_round_trip.rs`: the test now seeds
+  one file per language (Go, Java, C, C++, PHP, Ruby, Swift) and
+  verifies each routes to its renderer end-to-end, producing a
+  body-free signature.
+
+### Changed
+
+- **`extract_c_symbols`** function walker rewritten to handle both
+  the direct `function_declarator` case and the pointer-wrapped
+  variant.
+- **`render_php`** prepends `<?php\n` to symbol-only byte slices
+  before parsing. The parse path is otherwise unchanged.
+- Module-level doc comment in `crates/rts-core/src/signature.rs` now
+  states all 11 grammars are end-to-end as of alpha.17.
+
+### Not in this slice
+
+- P8 PageRank + `Index.Outline` — the largest remaining feature.
+- Tree-shake closure walker for `include_dependencies: true`.
+- P6 watcher hardening (Rescan re-walk, rayon parsers, PollWatcher).
+- P9 latency bench (S1).
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **453 passed, 0 failed, 2 ignored** (was
+  447; +6 writer-layer parse_and_extract tests). The
+  `read_round_trip` integration test grows from 1 language coverage
+  to 7 (Rust+Python+TS shipped earlier; Go+Java+C+C++/PHP/Ruby/Swift
+  added here).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: exit 0.
+
 ## [0.2.0-alpha.16] - 2026-05-12
 
 Final P8 SignatureRenderer slice. **All 11 supported grammars now have

--- a/crates/rts-core/src/analyzer.rs
+++ b/crates/rts-core/src/analyzer.rs
@@ -1291,29 +1291,48 @@ impl CodebaseAnalyzer {
         // Extract function definitions
         let functions = tree.find_nodes_by_kind("function_definition");
         for func in functions {
-            if let Some(declarator) = func.child_by_field_name("declarator") {
-                if let Some(func_declarator) = declarator
+            // The grammar tree for a C function looks like:
+            //   function_definition
+            //     type:      primitive_type / type_identifier
+            //     declarator: function_declarator       ← usually here
+            //                   declarator: identifier  ← the name
+            //                   parameters: ...
+            //     body:      compound_statement
+            //
+            // …but pointer-returning functions wrap the function_declarator
+            // in a pointer_declarator, so we search for the
+            // `function_declarator` whether it's the direct child or one
+            // level deeper.
+            let Some(declarator) = func.child_by_field_name("declarator") else {
+                continue;
+            };
+            let func_declarator = if declarator.kind() == "function_declarator" {
+                declarator
+            } else {
+                match declarator
                     .children()
-                    .iter()
+                    .into_iter()
                     .find(|child| child.kind() == "function_declarator")
                 {
-                    if let Some(name_node) = func_declarator.child_by_field_name("declarator") {
-                        if let Ok(name) = name_node.text() {
-                            let docs =
-                                self.extract_c_doc_comments(content, func.start_position().row);
-                            symbols.push(Symbol {
-                                name: name.to_string(),
-                                kind: "function".to_string(),
-                                start_line: func.start_position().row + 1,
-                                end_line: func.end_position().row + 1,
-                                start_column: func.start_position().column,
-                                end_column: func.end_position().column,
-                                visibility: "public".to_string(),
-                                documentation: docs,
-                            });
-                        }
-                    }
+                    Some(d) => d,
+                    None => continue,
                 }
+            };
+            let Some(name_node) = func_declarator.child_by_field_name("declarator") else {
+                continue;
+            };
+            if let Ok(name) = name_node.text() {
+                let docs = self.extract_c_doc_comments(content, func.start_position().row);
+                symbols.push(Symbol {
+                    name: name.to_string(),
+                    kind: "function".to_string(),
+                    start_line: func.start_position().row + 1,
+                    end_line: func.end_position().row + 1,
+                    start_column: func.start_position().column,
+                    end_column: func.end_position().column,
+                    visibility: "public".to_string(),
+                    documentation: docs,
+                });
             }
         }
 

--- a/crates/rts-core/src/lib.rs
+++ b/crates/rts-core/src/lib.rs
@@ -182,12 +182,16 @@ pub fn supported_languages() -> Vec<LanguageInfo> {
 pub fn detect_language_from_extension(extension: &str) -> Option<Language> {
     match extension.to_lowercase().as_str() {
         "rs" => Some(Language::Rust),
-        "js" | "mjs" | "jsx" => Some(Language::JavaScript),
+        "js" | "mjs" | "jsx" | "cjs" => Some(Language::JavaScript),
         "ts" | "tsx" | "mts" | "cts" => Some(Language::TypeScript),
         "py" | "pyi" => Some(Language::Python),
         "c" | "h" => Some(Language::C),
-        "cpp" | "cxx" | "cc" | "hpp" | "hxx" => Some(Language::Cpp),
+        "cpp" | "cxx" | "cc" | "hpp" | "hxx" | "hh" => Some(Language::Cpp),
         "go" => Some(Language::Go),
+        "java" => Some(Language::Java),
+        "php" | "phtml" => Some(Language::Php),
+        "rb" | "rake" => Some(Language::Ruby),
+        "swift" => Some(Language::Swift),
         _ => None,
     }
 }

--- a/crates/rts-core/src/signature.rs
+++ b/crates/rts-core/src/signature.rs
@@ -15,18 +15,9 @@
 //!
 //! v0 ships renderers for all 11 supported grammars: **Rust, Python,
 //! TypeScript, JavaScript, Go, Java, C, C++, PHP, Ruby, and Swift**.
-//! Callers fall through to body returns when this module returns
-//! `None`.
-//!
-//! **Note**: Java / C / C++ have working renderers here, but their
-//! end-to-end `Index.ReadSymbol shape=signature` path also needs the
-//! daemon's writer (via `rust_tree_sitter::analyzer::extract_*_symbols`)
-//! to put the symbol into the index in the first place. Those
-//! extractors are currently incomplete for Java / C / C++ in some
-//! cases; a follow-up analyzer-layer PR will close the gap. Go and
-//! the four already-shipped languages (Rust / Python / TS / JS) work
-//! end-to-end. PHP / Ruby / Swift writer-side coverage depends on the
-//! same upstream extractor work.
+//! All 11 reach `Index.ReadSymbol shape=signature` end-to-end as of
+//! `0.2.0-alpha.17`. Callers fall through to body returns when this
+//! module returns `None`.
 
 use streaming_iterator::StreamingIterator as _;
 
@@ -741,11 +732,25 @@ fn render_cpp_template(bytes: &[u8]) -> Option<String> {
 /// - **`const_declaration`** / **`namespace_use_declaration`**:
 ///   kept whole.
 pub fn render_php(bytes: &[u8]) -> Option<String> {
+    // The PHP grammar only parses content wrapped in `<?php … ?>`.
+    // Symbol bytes extracted from the index don't carry the opening
+    // tag, so we synthesise it for parsing — and remember to shift
+    // offsets back into the original byte range when we return.
+    let needs_tag = !looks_like_php_tag(bytes);
+    let synthesised: Vec<u8>;
+    let parse_bytes: &[u8] = if needs_tag {
+        synthesised = [b"<?php\n", bytes].concat();
+        &synthesised
+    } else {
+        bytes
+    };
+    let prefix_len = if needs_tag { 6 } else { 0 };
+
     let mut parser = tree_sitter::Parser::new();
     parser
         .set_language(&tree_sitter_php::LANGUAGE_PHP.into())
         .ok()?;
-    let tree = parser.parse(bytes, None)?;
+    let tree = parser.parse(parse_bytes, None)?;
     let root = tree.root_node();
 
     // PHP wraps content in a `<?php ... ?>` tag pair; the actual
@@ -784,12 +789,25 @@ pub fn render_php(bytes: &[u8]) -> Option<String> {
     };
 
     let start = item.start_byte();
-    let slice = bytes.get(start..signature_end)?;
+    let slice = parse_bytes.get(start..signature_end)?;
     let text = std::str::from_utf8(slice).ok()?.trim_end().to_string();
     if text.is_empty() {
         return None;
     }
+    let _ = prefix_len; // offsets already aligned via parse_bytes
     Some(text)
+}
+
+/// Cheap textual probe: does this look like PHP source that starts with
+/// `<?php` (possibly preceded by a BOM or whitespace)? Used to decide
+/// whether to synthesise an opening tag before parsing.
+fn looks_like_php_tag(bytes: &[u8]) -> bool {
+    bytes
+        .iter()
+        .skip_while(|b| matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0xEF | 0xBB | 0xBF))
+        .take(5)
+        .copied()
+        .eq([b'<', b'?', b'p', b'h', b'p'].iter().copied())
 }
 
 fn find_descendant_by_kind<'tree>(

--- a/crates/rts-daemon/src/writer.rs
+++ b/crates/rts-daemon/src/writer.rs
@@ -499,6 +499,78 @@ mod tests {
     }
 
     #[test]
+    fn parse_and_extract_returns_java_symbols() {
+        let pool = ParserPool::new();
+        let src = "package demo;\n\npublic class JavaTarget {\n    public int compute(int x) { return x + 1; }\n}\n";
+        let syms = pool.parse_and_extract(Language::Java, src).unwrap();
+        let names: Vec<_> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"JavaTarget"),
+            "expected `JavaTarget` in symbols; got {names:?}"
+        );
+    }
+
+    #[test]
+    fn parse_and_extract_returns_c_symbols() {
+        let pool = ParserPool::new();
+        let src = "int c_target(int a, int b) { return a + b; }\n";
+        let syms = pool.parse_and_extract(Language::C, src).unwrap();
+        let names: Vec<_> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"c_target"),
+            "expected `c_target` in symbols; got {names:?}"
+        );
+    }
+
+    #[test]
+    fn parse_and_extract_returns_cpp_symbols() {
+        let pool = ParserPool::new();
+        let src = "int cpp_target(int a, int b) { return a + b; }\n";
+        let syms = pool.parse_and_extract(Language::Cpp, src).unwrap();
+        let names: Vec<_> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"cpp_target"),
+            "expected `cpp_target` in symbols; got {names:?}"
+        );
+    }
+
+    #[test]
+    fn parse_and_extract_returns_php_symbols() {
+        let pool = ParserPool::new();
+        let src = "<?php\nfunction phpTarget($a, $b) { return $a + $b; }\n";
+        let syms = pool.parse_and_extract(Language::Php, src).unwrap();
+        let names: Vec<_> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"phpTarget"),
+            "expected `phpTarget` in symbols; got {names:?}"
+        );
+    }
+
+    #[test]
+    fn parse_and_extract_returns_ruby_symbols() {
+        let pool = ParserPool::new();
+        let src = "def ruby_target(name)\n  name.length\nend\n";
+        let syms = pool.parse_and_extract(Language::Ruby, src).unwrap();
+        let names: Vec<_> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"ruby_target"),
+            "expected `ruby_target` in symbols; got {names:?}"
+        );
+    }
+
+    #[test]
+    fn parse_and_extract_returns_swift_symbols() {
+        let pool = ParserPool::new();
+        let src = "func swiftTarget(_ a: Int, _ b: Int) -> Int { return a + b }\n";
+        let syms = pool.parse_and_extract(Language::Swift, src).unwrap();
+        let names: Vec<_> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"swiftTarget"),
+            "expected `swiftTarget` in symbols; got {names:?}"
+        );
+    }
+
+    #[test]
     fn line_col_translation_is_consistent_with_str_bytes() {
         let content = "abc\ndef\nghij\n";
         let sym = Symbol {

--- a/crates/rts-daemon/tests/read_round_trip.rs
+++ b/crates/rts-daemon/tests/read_round_trip.rs
@@ -124,14 +124,37 @@ async fn read_handlers_round_trip() -> anyhow::Result<()> {
         workspace.path().join("ts_demo.ts"),
         "export function tsTarget(a: number, b: number): number { return a + b; }\n",
     )?;
-    // Go end-to-end. Java / C / C++ have working SignatureRenderers but
-    // their writer-side symbol extraction in `rust_tree_sitter::analyzer`
-    // is TODO-stubbed for some kinds — those will be covered by an
-    // analyzer-layer follow-up PR. Until then they're verified only
-    // through unit tests in `rust_tree_sitter::signature::tests`.
+    // Go + Java + C + C++ + PHP + Ruby + Swift — all 7 non-Rust/Python/TS
+    // languages now reach Index.ReadSymbol end-to-end after the
+    // analyzer-layer fix in alpha.17. Each gets a one-symbol seed file
+    // and a `shape: "signature"` assertion below.
     std::fs::write(
         workspace.path().join("go_demo.go"),
         "package demo\n\nfunc GoTarget(name string) (int, error) {\n    return len(name), nil\n}\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("JavaDemo.java"),
+        "package demo;\n\npublic class JavaTarget {\n    public int compute(int x) { return x + 1; }\n}\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("c_demo.c"),
+        "int c_target(int a, int b) { return a + b; }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("cpp_demo.cpp"),
+        "int cpp_target(int a, int b) { return a + b; }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("php_demo.php"),
+        "<?php\nfunction phpTarget($a, $b) { return $a + $b; }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("ruby_demo.rb"),
+        "def ruby_target(name)\n  name.length\nend\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("swift_demo.swift"),
+        "func swiftTarget(_ a: Int, _ b: Int) -> Int { return a + b }\n",
     )?;
 
     let socket_path = if cfg!(target_os = "macos") {
@@ -446,30 +469,67 @@ async fn read_handlers_round_trip() -> anyhow::Result<()> {
         "typescript signature must strip body; got {ts_text:?}"
     );
 
-    // ---- Per-language dispatch: Go ----
-    wait_for_symbol(&mut stream, "GoTarget", Duration::from_secs(5)).await?;
-    let go_sig = round_trip(
-        &mut stream,
-        "32",
-        "Index.ReadSymbol",
-        json!({ "name": "GoTarget", "shape": "signature" }),
-    )
-    .await?;
-    assert!(
-        go_sig["error"].is_null(),
-        "GoTarget signature should succeed: {go_sig:?}"
-    );
-    let go_text = go_sig["result"]["signature"]
-        .as_str()
-        .expect("signature field for go");
-    assert!(
-        go_text.contains("func GoTarget(name string) (int, error)"),
-        "go signature shape wrong; got {go_text:?}"
-    );
-    assert!(
-        !go_text.contains("return len"),
-        "go signature must strip body; got {go_text:?}"
-    );
+    // Per-language dispatch — all 7 newly-end-to-end languages route
+    // correctly to their signature renderer + the result is body-free.
+    let cases: &[(&str, &str, &str, &str)] = &[
+        (
+            "32",
+            "GoTarget",
+            "func GoTarget(name string) (int, error)",
+            "return len",
+        ),
+        ("33", "JavaTarget", "public class JavaTarget", "compute"),
+        (
+            "34",
+            "c_target",
+            "int c_target(int a, int b)",
+            "return a + b",
+        ),
+        (
+            "35",
+            "cpp_target",
+            "int cpp_target(int a, int b)",
+            "return a + b",
+        ),
+        (
+            "36",
+            "phpTarget",
+            "function phpTarget($a, $b)",
+            "return $a + $b",
+        ),
+        ("37", "ruby_target", "def ruby_target(name)", "name.length"),
+        (
+            "38",
+            "swiftTarget",
+            "func swiftTarget(_ a: Int, _ b: Int) -> Int",
+            "return a + b",
+        ),
+    ];
+    for (id, symbol, expected_substring, forbidden_substring) in cases {
+        wait_for_symbol(&mut stream, symbol, Duration::from_secs(5)).await?;
+        let resp = round_trip(
+            &mut stream,
+            id,
+            "Index.ReadSymbol",
+            json!({ "name": symbol, "shape": "signature" }),
+        )
+        .await?;
+        assert!(
+            resp["error"].is_null(),
+            "{symbol} signature should succeed: {resp:?}"
+        );
+        let sig = resp["result"]["signature"]
+            .as_str()
+            .unwrap_or_else(|| panic!("signature field for {symbol}; got {resp:?}"));
+        assert!(
+            sig.contains(expected_substring),
+            "{symbol} signature wrong; expected `{expected_substring}` in {sig:?}"
+        );
+        assert!(
+            !sig.contains(forbidden_substring),
+            "{symbol} signature must strip body; expected `{forbidden_substring}` to be absent from {sig:?}"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## What

Closes the writer-side gap noted in alphas 15+16. `Index.ReadSymbol shape=signature` now works end-to-end for **all 11 supported languages**, not just 5.

| Language | Before this PR | After |
|---|---|---|
| Rust | ✅ | ✅ |
| Python | ✅ | ✅ |
| TypeScript | ✅ | ✅ |
| JavaScript | ✅ | ✅ |
| Go | ✅ | ✅ |
| **Java** | renderer-only | **✅ end-to-end** |
| **C** | renderer-only | **✅ end-to-end** |
| **C++** | renderer-only | **✅ end-to-end** |
| **PHP** | renderer-only | **✅ end-to-end** |
| **Ruby** | renderer-only | **✅ end-to-end** |
| **Swift** | renderer-only | **✅ end-to-end** |

## Why

Three upstream bugs were blocking 6 of the 11 SignatureRenderers from reaching `Index.ReadSymbol`:

1. **Missing extension mappings.** `detect_language_from_extension` in `crates/rts-core/src/lib.rs` didn't know about `.java`, `.php`, `.phtml`, `.rb`, `.rake`, `.swift`. Files with those extensions returned `None` from the detector, so `analyze_file_internal` silently exited before calling `extract_symbols`.
2. **Broken C extractor walker.** `extract_c_symbols` assumed `function_definition > declarator(non-function) > function_declarator > declarator` nesting. tree-sitter-c's typical shape is `function_definition > declarator(function_declarator) > declarator(identifier)`. The nested search never matched, so C and C++ functions never registered.
3. **`render_php` couldn't parse symbol bytes.** The writer stores symbol-only slices (no `<?php` opening tag). tree-sitter-php requires the tag. Fix synthesises it via a cheap textual probe.

## How to test

```sh
cargo test -p rts-daemon --bin rts-daemon writer::tests::parse_and_extract    # 8/8 pass
cargo test -p rts-daemon --test read_round_trip                                 # extended dispatch
cargo test --workspace                                                          # 453/0/2 (was 447)
cargo fmt --all -- --check                                                      # exit 0
cargo clippy --workspace --all-targets                                          # exit 0
```

## Checklist

- [x] Tests pass (453/0/2 — +6 writer-layer tests + 7 integration assertions)
- [x] `cargo fmt --all -- --check` exit 0
- [x] `cargo clippy --workspace --all-targets` exit 0
- [x] No secrets committed
- [x] Conventional commit title (`fix(rts-core):`)

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required: bug fixes restoring intended behaviour. The three bugs were silent — extraction simply produced empty Vecs. Post-merge any project mounted in a daemon will start producing signatures for the 6 newly-fixed languages.`