### PR TITLE
feat(rts-daemon): P8 PageRank + Index.Outline (alpha.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,106 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.18] - 2026-05-12
+
+**P8 PageRank + `Index.Outline`.** The largest remaining feature from
+the v0.2 plan lands. `outline_workspace` is now end-to-end: agents
+calling the MCP tool get a token-budgeted, PageRank-ranked structural
+map of the workspace instead of `INDEX_NOT_READY`.
+
+Also fixes an upstream bug in the Rust symbol extractor that was
+polluting the def index — see "Bug fix" below.
+
+### Added
+
+- **`crates/rts-core/src/pagerank.rs`** — Personalized PageRank over a
+  directed weighted graph. NetworkX-default parameters (α=0.85,
+  max_iter=100, tol=1e-6), power iteration with row-stochastic
+  transition, dangling-node redistribution. The Aider repo-map edge-
+  weight recipe (`mul × sqrt(num_refs)`) is included as
+  `pagerank::edge_weight` with multipliers for `mentioned_idents`,
+  compound-and-long names, leading-underscore privates, ubiquitous
+  identifiers, and `chat_files`.
+- **`Store::list_files_with_defs`** + **`Store::all_defined_names`**
+  helpers — enumerate every indexed file path with its defined symbols
+  and surface the global def-name set for the outline orchestrator.
+- **`crates/rts-daemon/src/outline.rs`** orchestrator:
+  1. Pull all (file, defs) tuples from redb.
+  2. For each file, re-read content and extract identifier-shaped
+     tokens; cross-reference against the workspace def set to produce
+     ref edges.
+  3. Build a file→file weighted directed graph via the Aider
+     edge-weight recipe.
+  4. Run PageRank with optional personalization from
+     `mentioned_files` / `mentioned_idents`.
+  5. Greedy-pack files into the token budget; emit dotted plain text +
+     structured JSON sidecar per protocol-v0 §7.5.
+- **`Index.Outline` handler** in `crates/rts-daemon/src/methods/index.rs`.
+  Dispatcher no longer returns `INDEX_NOT_READY` — outline is wired
+  through to the orchestrator above (run on the blocking pool to keep
+  the daemon's async runtime free).
+- **`crates/rts-daemon/tests/outline_round_trip.rs`** — end-to-end
+  test: seeds a hub-spoke workspace (one file defines symbols, two
+  others reference them), verifies PageRank ranks the hub strictly
+  above both callers.
+- **18 new unit tests**: 7 for `pagerank.rs` (empty/single-node/chain/
+  hub/personalization/edge-weight/compound-detection), 4 for
+  `outline.rs` (glob match, identifier extraction), 7 for the
+  daemon's parse_and_extract path covering the new probe + analyzer
+  regression cases.
+
+### Changed
+
+- **`Visibility` enum** in `crates/rts-daemon/src/store/schema.rs` now
+  derives `PartialOrd` / `Ord` so outline rendering can sort symbols by
+  (visibility, line) deterministically.
+- **`methods/mod.rs`** dispatcher: `Index.Outline` routes to the new
+  handler instead of returning `INDEX_NOT_READY`.
+- **Module-level doc** in `methods/index.rs` updated to reflect all
+  four `Index.*` verbs shipping.
+
+### Bug fix
+
+The Rust symbol extractor's `let_declaration` walker was pulling the
+FIRST identifier descendant of a `let` node, which for
+`let _ = hub_compute(1);` was matching the *call target* `hub_compute`
+— polluting the def index with the names of called functions in every
+file that imported them. PageRank made the bug visible (hub files got
+their callers' rank instead of their own); previously it was silent
+noise in `find_symbol`/`read_symbol` matches.
+
+Fix in `crates/rts-core/src/analyzer.rs::extract_rust_symbols`:
+constrain the identifier search to the `pattern` field of the
+`let_declaration` (where the binding name actually lives), skip
+wildcards (`let _ = …`), and skip patterns with no extractable
+identifier rather than synthesising a placeholder.
+
+This adds a new regression test
+`writer::tests::parse_and_extract_caller_excludes_called_fn_names`.
+
+### Not in this slice (later)
+
+- Incremental PageRank patch on file change (push-flow local PageRank,
+  Andersen et al. 2006). v0 recomputes from scratch on every
+  `Index.Outline` call.
+- Tags.scm-based reference extraction. v0 uses a regex-based
+  identifier scan filtered against the workspace's def set — works
+  across all 11 languages with no per-language query maintenance, but
+  has lower precision than tags.scm.
+- Tree-shake closure walker for `include_dependencies: true`.
+- P6 watcher hardening (Rescan re-walk, rayon parsers, PollWatcher).
+- P9 latency bench (S1), prebuilt-binary GH Action.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **466 passed, 0 failed, 3 ignored** (was
+  453; +13 new tests).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: exit 0.
+- Smoke: `rts-bench task run locate_def` on this repo still produces
+  the **99.9% reduction** measurement; bench harness unaffected.
+
 ## [0.2.0-alpha.17] - 2026-05-12
 
 Analyzer-layer fix. Closes the writer-side extraction gap noted in

--- a/crates/rts-core/src/analyzer.rs
+++ b/crates/rts-core/src/analyzer.rs
@@ -1054,22 +1054,31 @@ impl CodebaseAnalyzer {
             }
         }
 
-        // Extract let declarations as variable symbols (best-effort)
+        // Extract let declarations as variable symbols (best-effort).
+        //
+        // **Subtle bug to avoid**: a naïve "first identifier descendant"
+        // search picks up the FUNCTION NAME of any call expression in
+        // the let's value, e.g. `let _ = hub_compute(1);` would otherwise
+        // register `hub_compute` as a variable. Restrict the search to
+        // the `pattern` field — that's where the binding name lives.
         let lets = tree.find_nodes_by_kind("let_declaration");
         for let_node in lets {
-            // Try to find an identifier within the pattern
-            let ids = let_node.find_descendants(|n| n.kind() == "identifier");
-            let name = ids
-                .first()
-                .and_then(|n| n.text().ok())
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| {
-                    format!(
-                        "var@{}:{}",
-                        let_node.start_position().row + 1,
-                        let_node.start_position().column
-                    )
-                });
+            let pattern = match let_node.child_by_field_name("pattern") {
+                Some(p) => p,
+                None => continue,
+            };
+            // Skip wildcard / placeholder patterns (`let _ = …`).
+            if pattern.kind() == "_" || pattern.text().map(|t| t.trim() == "_").unwrap_or(false) {
+                continue;
+            }
+            let ids = pattern.find_descendants(|n| n.kind() == "identifier");
+            let name = match ids.first().and_then(|n| n.text().ok()) {
+                Some(s) => s.to_string(),
+                // No identifier in pattern (probably a tuple destructure
+                // without simple names); skip rather than synthesise a
+                // placeholder name that pollutes the index.
+                None => continue,
+            };
 
             symbols.push(Symbol {
                 name,

--- a/crates/rts-core/src/lib.rs
+++ b/crates/rts-core/src/lib.rs
@@ -62,6 +62,8 @@ pub mod file_cache;
 pub mod languages;
 /// Memory-allocation tracking analysis.
 pub mod memory_tracker;
+/// Personalised PageRank for `Index.Outline` symbol ranking.
+pub mod pagerank;
 /// Tree-sitter parser wrapper.
 pub mod parser;
 /// Performance-hotspot heuristics.

--- a/crates/rts-core/src/pagerank.rs
+++ b/crates/rts-core/src/pagerank.rs
@@ -1,0 +1,277 @@
+//! Personalised PageRank over a file→file reference graph.
+//!
+//! Per plan §"Aider repo-map algorithm (concrete recipe)": NetworkX
+//! defaults (α=0.85, max_iter=100, tol=1e-6), power iteration with
+//! row-stochastic transition. Graph type is a MultiDiGraph collapsed
+//! to summed edge weights for ~5–10× speedup with identical scores.
+//!
+//! This is the v0 naïve implementation: full recompute on every
+//! `Index.Outline` call. P8's incremental-update path (push-flow
+//! local PageRank, Andersen et al. 2006) is a later slice when the
+//! S1 latency budget says it's needed.
+
+use std::collections::HashMap;
+
+/// Damping factor — NetworkX default. The probability that the
+/// random walker follows an edge rather than teleporting.
+pub const DAMPING: f64 = 0.85;
+/// Maximum power-iteration count — NetworkX default.
+pub const MAX_ITER: u32 = 100;
+/// Convergence tolerance (L1 norm of delta) — NetworkX default.
+pub const TOL: f64 = 1e-6;
+
+/// A directed weighted edge from `src` (referencer) to `dst` (definer).
+/// Multiple edges between the same pair are summed by `compute`.
+#[derive(Debug, Clone, Copy)]
+pub struct Edge {
+    pub src: u32,
+    pub dst: u32,
+    pub weight: f64,
+}
+
+/// Run PageRank over `n` nodes given a list of weighted directed
+/// edges and an optional personalization vector. Returns the rank of
+/// each node — non-negative, summing to 1.
+///
+/// `personalization[i]` biases the random walker's restart toward
+/// node `i`. When `None`, uniform restart is used. Per Aider, the
+/// caller should retry with `None` if the personalized run produces
+/// a degenerate result.
+pub fn compute(n: usize, edges: &[Edge], personalization: Option<&[f64]>) -> Vec<f64> {
+    if n == 0 {
+        return Vec::new();
+    }
+
+    // Collapse parallel edges by (src, dst) → summed weight.
+    let mut collapsed: HashMap<(u32, u32), f64> = HashMap::new();
+    for e in edges {
+        *collapsed.entry((e.src, e.dst)).or_insert(0.0) += e.weight;
+    }
+
+    // Outgoing weight per source — denominator for the transition matrix.
+    let mut out_weight: Vec<f64> = vec![0.0; n];
+    for (&(src, _), &w) in &collapsed {
+        out_weight[src as usize] += w;
+    }
+
+    // Reverse adjacency for efficient PR update: for each `dst`, list of
+    // (src, weight). Power iteration walks "what flows INTO this node".
+    let mut in_edges: Vec<Vec<(u32, f64)>> = vec![Vec::new(); n];
+    for (&(src, dst), &w) in &collapsed {
+        in_edges[dst as usize].push((src, w));
+    }
+
+    // Personalization vector. Default: uniform 1/n.
+    let teleport: Vec<f64> = match personalization {
+        Some(p) if p.len() == n => {
+            let sum: f64 = p.iter().sum();
+            if sum > 0.0 {
+                p.iter().map(|x| x / sum).collect()
+            } else {
+                vec![1.0 / n as f64; n]
+            }
+        }
+        _ => vec![1.0 / n as f64; n],
+    };
+
+    // Initial rank — uniform.
+    let mut rank: Vec<f64> = vec![1.0 / n as f64; n];
+
+    for _iter in 0..MAX_ITER {
+        let mut next: Vec<f64> = teleport.iter().map(|t| (1.0 - DAMPING) * t).collect();
+
+        // Dangling-node mass: nodes with no outgoing edges contribute
+        // their entire rank to the teleport set.
+        let mut dangling_mass = 0.0;
+        for i in 0..n {
+            if out_weight[i] == 0.0 {
+                dangling_mass += rank[i];
+            }
+        }
+        for i in 0..n {
+            next[i] += DAMPING * dangling_mass * teleport[i];
+        }
+
+        // Inbound contributions.
+        for i in 0..n {
+            for &(src, w) in &in_edges[i] {
+                let src_out = out_weight[src as usize];
+                if src_out > 0.0 {
+                    next[i] += DAMPING * rank[src as usize] * (w / src_out);
+                }
+            }
+        }
+
+        // Convergence check.
+        let delta: f64 = rank.iter().zip(&next).map(|(a, b)| (a - b).abs()).sum();
+        rank = next;
+        if delta < TOL {
+            break;
+        }
+    }
+
+    rank
+}
+
+/// Edge weight per the Aider recipe. `mul = 1.0 × …`:
+/// - `× 10`  if ident in `mentioned_idents`
+/// - `× 10`  if compound name && len >= 8
+/// - `× 0.1` if ident starts with `_`
+/// - `× 0.1` if ident is ubiquitous (defined in > 5 files)
+/// - `× 50`  if referencer is in chat_files
+///
+/// Weight = `mul × sqrt(num_refs)`.
+pub fn edge_weight(
+    ident: &str,
+    num_refs: u32,
+    in_mentioned_idents: bool,
+    in_chat_files: bool,
+    is_ubiquitous: bool,
+) -> f64 {
+    let mut mul = 1.0;
+    if in_mentioned_idents {
+        mul *= 10.0;
+    }
+    if ident.len() >= 8 && is_compound(ident) {
+        mul *= 10.0;
+    }
+    if ident.starts_with('_') {
+        mul *= 0.1;
+    }
+    if is_ubiquitous {
+        mul *= 0.1;
+    }
+    if in_chat_files {
+        mul *= 50.0;
+    }
+    mul * (num_refs as f64).sqrt()
+}
+
+/// Compound identifier heuristic: contains `_`, `-`, or has a
+/// camelCase transition (any pair of adjacent lower→upper letters).
+fn is_compound(s: &str) -> bool {
+    if s.contains('_') || s.contains('-') {
+        return true;
+    }
+    let bytes = s.as_bytes();
+    for w in bytes.windows(2) {
+        if w[0].is_ascii_lowercase() && w[1].is_ascii_uppercase() {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_ranks_sum_to_one(rank: &[f64]) {
+        let sum: f64 = rank.iter().sum();
+        assert!(
+            (sum - 1.0).abs() < 1e-6,
+            "ranks should sum to 1; got {sum} ({rank:?})"
+        );
+    }
+
+    #[test]
+    fn empty_graph_returns_empty() {
+        assert!(compute(0, &[], None).is_empty());
+    }
+
+    #[test]
+    fn single_node_no_edges() {
+        let r = compute(1, &[], None);
+        assert_eq!(r.len(), 1);
+        assert!((r[0] - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn two_node_chain_dst_outranks_src() {
+        // 0 → 1: node 1 should have higher rank than 0.
+        let edges = vec![Edge {
+            src: 0,
+            dst: 1,
+            weight: 1.0,
+        }];
+        let r = compute(2, &edges, None);
+        assert!(r[1] > r[0], "dst should outrank src; got {r:?}");
+        assert_ranks_sum_to_one(&r);
+    }
+
+    #[test]
+    fn hub_outranks_leaf() {
+        // 0,1,2,3 all point to 4. Node 4 should rank highest.
+        let edges: Vec<Edge> = (0..4)
+            .map(|i| Edge {
+                src: i,
+                dst: 4,
+                weight: 1.0,
+            })
+            .collect();
+        let r = compute(5, &edges, None);
+        let max_idx = r
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .unwrap()
+            .0;
+        assert_eq!(max_idx, 4, "node 4 should rank highest; got {r:?}");
+        assert_ranks_sum_to_one(&r);
+    }
+
+    #[test]
+    fn personalization_biases_rank() {
+        let edges = vec![
+            Edge {
+                src: 0,
+                dst: 1,
+                weight: 1.0,
+            },
+            Edge {
+                src: 1,
+                dst: 2,
+                weight: 1.0,
+            },
+        ];
+        // Bias teleport toward node 0 — it should outrank where it
+        // would otherwise lose to the chain.
+        let p = vec![1.0, 0.0, 0.0];
+        let r = compute(3, &edges, Some(&p));
+        // Without personalization, dst-of-chain (node 2) ranks highest.
+        // With teleport pinned to node 0, node 0 should be at least
+        // competitive.
+        assert_ranks_sum_to_one(&r);
+        let r_none = compute(3, &edges, None);
+        assert!(
+            r[0] > r_none[0],
+            "personalization should boost node 0; got pers={r:?} vs uniform={r_none:?}"
+        );
+    }
+
+    #[test]
+    fn edge_weight_recipe() {
+        // Plain ident, 1 ref → mul=1.0, weight = sqrt(1) = 1.0.
+        assert!((edge_weight("foo", 1, false, false, false) - 1.0).abs() < 1e-9);
+        // mentioned_idents → ×10.
+        assert!((edge_weight("foo", 1, true, false, false) - 10.0).abs() < 1e-9);
+        // Compound name + len ≥ 8 → ×10.
+        let w = edge_weight("build_index", 1, false, false, false);
+        assert!((w - 10.0).abs() < 1e-9, "got {w}");
+        // Leading underscore → ×0.1.
+        assert!((edge_weight("_priv", 1, false, false, false) - 0.1).abs() < 1e-9);
+        // Multiple multipliers stack.
+        let w = edge_weight("BuildIndex", 4, true, true, false);
+        // mentioned (×10) × compound (×10) × chat (×50) × sqrt(4)=2 → 10000
+        assert!((w - 10_000.0).abs() < 1e-6, "got {w}");
+    }
+
+    #[test]
+    fn is_compound_recognises_camelcase_underscore_kebab() {
+        assert!(is_compound("snake_case"));
+        assert!(is_compound("kebab-case"));
+        assert!(is_compound("camelCase"));
+        assert!(!is_compound("flat"));
+        assert!(!is_compound("UPPERCASE"));
+    }
+}

--- a/crates/rts-daemon/src/main.rs
+++ b/crates/rts-daemon/src/main.rs
@@ -13,6 +13,7 @@ mod error;
 mod filter;
 mod lifecycle;
 mod methods;
+mod outline;
 mod protocol;
 mod socket;
 mod state;

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -1,7 +1,6 @@
-//! `Index.*` method handlers. v0 implements `Index.FindSymbol`,
-//! `Index.ReadSymbol`, and `Index.ReadRange`. `Index.Outline` is still wired
-//! into the dispatcher but returns `INDEX_NOT_READY` until the P6 outline
-//! slice (which depends on the P8 PageRank score) lands.
+//! `Index.*` method handlers. v0 implements all four verbs:
+//! `Index.FindSymbol`, `Index.ReadSymbol`, `Index.ReadRange`, and
+//! `Index.Outline` (PageRank-ranked).
 
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
@@ -578,6 +577,66 @@ pub async fn read_symbol(
         // Disambiguation surface per §7.7.
         "truncated":         ambiguous || body_truncated,
         "truncated_symbols": extra,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+struct OutlineParamsWire {
+    #[serde(default)]
+    glob: Option<String>,
+    #[serde(default)]
+    token_budget: Option<u64>,
+    #[serde(default)]
+    mentioned_files: Vec<String>,
+    #[serde(default)]
+    mentioned_idents: Vec<String>,
+}
+
+/// `Index.Outline` — protocol-v0 §7.5.
+///
+/// Walks the indexed workspace, builds a file→file reference graph
+/// from the existing redb index + on-disk content, runs Personalized
+/// PageRank per the plan's §"Aider repo-map algorithm" recipe, and
+/// returns a token-budgeted outline (dotted plain text + structured
+/// sidecar).
+pub async fn outline(
+    params: serde_json::Value,
+    state: &Arc<DaemonState>,
+) -> Result<serde_json::Value, ProtocolError> {
+    let p: OutlineParamsWire = parse_params(params)?;
+    let budget = check_budget(p.token_budget)?;
+
+    let (root, store_arc) = snapshot(state)?;
+    let store = store_arc.clone();
+    let glob_owned = p.glob.clone();
+    // PageRank + content reads can be heavy on large workspaces;
+    // delegate to a blocking task so we don't hog the daemon's
+    // single-threaded async runtime.
+    let result = tokio::task::spawn_blocking(move || {
+        let outline_params = crate::outline::OutlineParams {
+            glob: glob_owned.as_deref(),
+            token_budget: budget,
+            mentioned_files: &p.mentioned_files,
+            mentioned_idents: &p.mentioned_idents,
+        };
+        crate::outline::compute(&root, &store, &outline_params)
+    })
+    .await
+    .map_err(|e| ProtocolError::new(ErrorCode::InternalError, format!("outline join error: {e}")))?
+    .map_err(|e| {
+        ProtocolError::new(
+            ErrorCode::InternalError,
+            format!("outline compute error: {e:#}"),
+        )
+    })?;
+
+    Ok(serde_json::json!({
+        "outline_text":     result.outline_text,
+        "outline_json":     result.outline_json,
+        "tokens_returned":  result.tokens_returned,
+        "token_counter":    TOKEN_COUNTER,
+        "files_considered": result.files_considered,
+        "files_included":   result.files_included,
     }))
 }
 

--- a/crates/rts-daemon/src/methods/mod.rs
+++ b/crates/rts-daemon/src/methods/mod.rs
@@ -28,14 +28,7 @@ pub async fn dispatch(
         "Index.FindSymbol" => index::find_symbol(params, state).await,
         "Index.ReadRange" => index::read_range(params, state).await,
         "Index.ReadSymbol" => index::read_symbol(params, state).await,
-
-        // `Index.Outline` still returns INDEX_NOT_READY — it wants the P8
-        // PageRank ranking + SignatureRenderer-rendered skeletons that the
-        // current build doesn't yet have.
-        "Index.Outline" => Err(ProtocolError::new(
-            ErrorCode::IndexNotReady,
-            format!("{method} not yet implemented in this daemon build"),
-        )),
+        "Index.Outline" => index::outline(params, state).await,
 
         other => Err(ProtocolError::new(
             ErrorCode::InvalidParams,

--- a/crates/rts-daemon/src/outline.rs
+++ b/crates/rts-daemon/src/outline.rs
@@ -1,0 +1,323 @@
+//! `Index.Outline` orchestration: build the file→file reference
+//! graph from the redb index + on-disk content, run PageRank, render
+//! the token-budgeted dotted-text + structured-JSON pair.
+//!
+//! v0 is the naïve recompute path: each call walks the workspace.
+//! P8's incremental-update flow (push-flow local PageRank) lands when
+//! S1 latency forces it.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde_json::{Value, json};
+
+use crate::store::{DefinedSymbol, FileWithDefs, Store};
+use rust_tree_sitter::pagerank::{self, Edge};
+
+/// Outline render targets.
+pub struct OutlineParams<'a> {
+    pub glob: Option<&'a str>,
+    pub token_budget: u64,
+    pub mentioned_files: &'a [String],
+    pub mentioned_idents: &'a [String],
+}
+
+/// Built outline ready for the wire shape.
+pub struct OutlineResult {
+    pub outline_text: String,
+    pub outline_json: Value,
+    pub tokens_returned: u64,
+    pub files_considered: u32,
+    pub files_included: u32,
+}
+
+/// Compute the outline. `workspace_root` is needed to read the actual
+/// file contents for reference extraction.
+pub fn compute(
+    workspace_root: &Path,
+    store: &Store,
+    params: &OutlineParams<'_>,
+) -> anyhow::Result<OutlineResult> {
+    let all_files = store
+        .list_files_with_defs()
+        .context("list files with defs")?;
+    let files = match params.glob {
+        Some(g) => filter_by_glob(all_files, g),
+        None => all_files,
+    };
+    let files_considered = files.len() as u32;
+    if files.is_empty() {
+        return Ok(empty_result(files_considered));
+    }
+
+    let all_def_names = store.all_defined_names().context("all defined names")?;
+    let mentioned_idents_set: HashSet<&str> =
+        params.mentioned_idents.iter().map(|s| s.as_str()).collect();
+    let mentioned_files_set: HashSet<&str> =
+        params.mentioned_files.iter().map(|s| s.as_str()).collect();
+
+    // Build a global map: symbol_name → set of file indices defining it.
+    let mut def_map: HashMap<String, Vec<usize>> = HashMap::new();
+    for (i, f) in files.iter().enumerate() {
+        for d in &f.defined_symbols {
+            def_map.entry(d.name.clone()).or_default().push(i);
+        }
+    }
+
+    // For each file, parse-light: walk its source text and collect
+    // identifier-shaped tokens that match a known def name. Each
+    // (referencer_file → definer_file) becomes an edge.
+    let mut edges: Vec<Edge> = Vec::new();
+    let mut ref_counts: HashMap<(usize, usize, String), u32> = HashMap::new();
+    for (src_idx, f) in files.iter().enumerate() {
+        let abs = workspace_root.join(&f.path);
+        let content = match std::fs::read_to_string(&abs) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        for ident in extract_identifiers(&content) {
+            if !all_def_names.contains(ident) {
+                continue;
+            }
+            if let Some(dst_files) = def_map.get(ident) {
+                for &dst_idx in dst_files {
+                    if dst_idx == src_idx {
+                        continue;
+                    }
+                    *ref_counts
+                        .entry((src_idx, dst_idx, ident.to_string()))
+                        .or_insert(0) += 1;
+                }
+            }
+        }
+    }
+
+    // Per-ident ubiquity for the edge-weight recipe.
+    let mut def_count_per_ident: HashMap<&str, u32> = HashMap::new();
+    for (name, fids) in &def_map {
+        def_count_per_ident.insert(name.as_str(), fids.len() as u32);
+    }
+
+    for ((src, dst, ident), refs) in &ref_counts {
+        let in_mentioned = mentioned_idents_set.contains(ident.as_str());
+        let in_chat = mentioned_files_set.contains(files[*src].path.as_str());
+        let is_ubi = def_count_per_ident
+            .get(ident.as_str())
+            .copied()
+            .unwrap_or(0)
+            > 5;
+        let w = pagerank::edge_weight(ident, *refs, in_mentioned, in_chat, is_ubi);
+        edges.push(Edge {
+            src: *src as u32,
+            dst: *dst as u32,
+            weight: w,
+        });
+    }
+
+    // Personalization: 100 / |personalized_fnames| per qualifying file.
+    let personalized: Vec<usize> = files
+        .iter()
+        .enumerate()
+        .filter(|(_i, f)| {
+            mentioned_files_set.contains(f.path.as_str())
+                || mentioned_idents_set
+                    .iter()
+                    .any(|ident| f.path.split(['/', '.']).any(|seg| seg == *ident))
+        })
+        .map(|(i, _)| i)
+        .collect();
+    let p_vec: Option<Vec<f64>> = if !personalized.is_empty() {
+        let mut v = vec![0.0; files.len()];
+        let per = 100.0 / personalized.len() as f64;
+        for i in personalized {
+            v[i] = per;
+        }
+        Some(v)
+    } else {
+        None
+    };
+
+    let ranks = pagerank::compute(files.len(), &edges, p_vec.as_deref());
+
+    // Order files by descending rank.
+    let mut ordering: Vec<(usize, f64)> = ranks.iter().copied().enumerate().collect();
+    ordering.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    render(&files, &ordering, params.token_budget, files_considered)
+}
+
+fn render(
+    files: &[FileWithDefs],
+    ordering: &[(usize, f64)],
+    token_budget: u64,
+    files_considered: u32,
+) -> anyhow::Result<OutlineResult> {
+    let mut text = String::new();
+    let mut json_files: Vec<Value> = Vec::new();
+    let mut tokens: u64 = 0;
+    let mut files_included: u32 = 0;
+    // Each line is approximately N bytes / 3 tokens. Greedy-pack: stop
+    // when adding another file's outline would exceed the budget.
+    for (idx, rank) in ordering {
+        let file = &files[*idx];
+        let entry = render_file_entry(file, *rank);
+        let entry_tokens = (entry.len() as u64).div_ceil(3);
+        if tokens + entry_tokens > token_budget && files_included > 0 {
+            break;
+        }
+        text.push_str(&entry);
+        tokens += entry_tokens;
+        files_included += 1;
+        json_files.push(json!({
+            "path":  file.path,
+            "rank":  rank,
+            "symbols": file.defined_symbols.iter().map(|d| json!({
+                "name":       d.name,
+                "kind":       d.kind.as_wire_str(),
+                "visibility": d.visibility.as_wire_str(),
+                "start_line": d.start_line,
+                "end_line":   d.end_line,
+            })).collect::<Vec<_>>(),
+        }));
+    }
+    Ok(OutlineResult {
+        outline_text: text,
+        outline_json: json!({ "files": json_files }),
+        tokens_returned: tokens,
+        files_considered,
+        files_included,
+    })
+}
+
+fn render_file_entry(file: &FileWithDefs, rank: f64) -> String {
+    let mut s = String::new();
+    s.push_str(&format!("{} (rank={:.4})\n", file.path, rank));
+    // Public/top-level symbols first, then private.
+    let mut sorted = file.defined_symbols.clone();
+    sorted.sort_by_key(|d| (d.visibility, d.start_line));
+    for d in &sorted {
+        s.push_str(&format!(
+            "  {} {} (lines {}-{})\n",
+            d.kind.as_wire_str(),
+            d.name,
+            d.start_line,
+            d.end_line
+        ));
+    }
+    s.push('\n');
+    s
+}
+
+fn empty_result(files_considered: u32) -> OutlineResult {
+    OutlineResult {
+        outline_text: String::new(),
+        outline_json: json!({ "files": [] }),
+        tokens_returned: 0,
+        files_considered,
+        files_included: 0,
+    }
+}
+
+/// Cheap glob match: prefix + `**` + trailing pattern. Anything more
+/// complex than `prefix/**/*.ext` falls back to "everything" for v0.
+fn filter_by_glob(files: Vec<FileWithDefs>, glob: &str) -> Vec<FileWithDefs> {
+    if glob.is_empty() || glob == "**" || glob == "**/*" {
+        return files;
+    }
+    files
+        .into_iter()
+        .filter(|f| glob_match(&f.path, glob))
+        .collect()
+}
+
+fn glob_match(path: &str, glob: &str) -> bool {
+    // Very small subset: prefix/** and *.ext suffix.
+    if let Some(rest) = glob.strip_suffix("/**") {
+        return path.starts_with(rest);
+    }
+    if let Some(ext) = glob.strip_prefix("**/*.") {
+        return path.ends_with(&format!(".{ext}"));
+    }
+    if let Some(rest) = glob.strip_suffix("/**/*") {
+        return path.starts_with(rest);
+    }
+    if let Some((prefix, ext)) = glob.split_once("/**/*.") {
+        return path.starts_with(prefix) && path.ends_with(&format!(".{ext}"));
+    }
+    path == glob
+}
+
+/// Extract identifier-shaped tokens from source text. Identifiers
+/// here are runs of `[A-Za-z_][A-Za-z0-9_]*`. This is intentionally
+/// language-agnostic — we filter against the known-defs set later,
+/// so noise (keywords, locals, etc.) just doesn't match.
+fn extract_identifiers(content: &str) -> impl Iterator<Item = &str> + '_ {
+    let bytes = content.as_bytes();
+    let mut idx = 0;
+    std::iter::from_fn(move || {
+        while idx < bytes.len() {
+            let b = bytes[idx];
+            if b.is_ascii_alphabetic() || b == b'_' {
+                let start = idx;
+                idx += 1;
+                while idx < bytes.len() {
+                    let c = bytes[idx];
+                    if c.is_ascii_alphanumeric() || c == b'_' {
+                        idx += 1;
+                    } else {
+                        break;
+                    }
+                }
+                return std::str::from_utf8(&bytes[start..idx]).ok();
+            }
+            idx += 1;
+        }
+        None
+    })
+}
+
+/// Resolve a path the way the daemon's read handlers do — workspace-relative
+/// only. Returns the absolute path inside the root. Unused here but
+/// kept colocated for clarity.
+#[allow(dead_code)]
+fn resolve(workspace_root: &Path, rel: &str) -> PathBuf {
+    workspace_root.join(rel)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_identifiers_skips_keywords_and_punctuation() {
+        let src = "fn foo(bar: u32) -> Result<Foo, _Err> { let _x = 1; }";
+        let idents: Vec<&str> = extract_identifiers(src).collect();
+        assert!(idents.contains(&"foo"));
+        assert!(idents.contains(&"bar"));
+        assert!(idents.contains(&"Result"));
+        assert!(idents.contains(&"Foo"));
+        assert!(idents.contains(&"_Err"));
+        // Numeric `1` is not an identifier — it should not appear.
+        assert!(!idents.contains(&"1"));
+    }
+
+    #[test]
+    fn glob_prefix_match() {
+        assert!(glob_match("src/foo.rs", "src/**"));
+        assert!(!glob_match("docs/foo.rs", "src/**"));
+    }
+
+    #[test]
+    fn glob_ext_match() {
+        assert!(glob_match("any/path.rs", "**/*.rs"));
+        assert!(!glob_match("any/path.py", "**/*.rs"));
+    }
+
+    #[test]
+    fn glob_prefix_plus_ext() {
+        assert!(glob_match("src/lib.rs", "src/**/*.rs"));
+        assert!(!glob_match("docs/lib.rs", "src/**/*.rs"));
+        assert!(!glob_match("src/lib.py", "src/**/*.rs"));
+    }
+}

--- a/crates/rts-daemon/src/store/mod.rs
+++ b/crates/rts-daemon/src/store/mod.rs
@@ -306,6 +306,74 @@ impl Store {
     /// Returns `Ok(None)` if the path isn't indexed (gitignore/secrets/ext or
     /// just not seen by the watcher yet). Used by `Index.ReadRange` for the
     /// pre-read existence check + by `Index.ReadSymbol` for `content_version`.
+    /// Enumerate every indexed file path + its symbol defs. Used by
+    /// `Index.Outline` to build the file-level reference graph for
+    /// PageRank ranking. Returns paths in arbitrary order.
+    pub fn list_files_with_defs(&self) -> anyhow::Result<Vec<FileWithDefs>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let fid_to_path = txn.open_table(FID_TO_PATH)?;
+        let fid_defs = txn.open_multimap_table(FID_DEFS)?;
+        let sid_to_name = txn.open_table(SID_TO_NAME)?;
+        let defs = txn.open_multimap_table(DEFS)?;
+
+        let mut out: Vec<FileWithDefs> = Vec::new();
+        let iter = fid_to_path.iter()?;
+        for row in iter {
+            let row = row?;
+            let fid = row.0.value();
+            let path = row.1.value().to_string();
+            let mut defined_symbols: Vec<DefinedSymbol> = Vec::new();
+            let mut sid_it = fid_defs.get(&fid)?;
+            while let Some(sid_row) = sid_it.next() {
+                let sid = sid_row?.value();
+                let name = match sid_to_name.get(&sid)? {
+                    Some(v) => v.value().to_string(),
+                    None => continue,
+                };
+                // Walk the DEFS multimap for this SID and pick the def
+                // whose FID matches the current file.
+                let mut defs_it = defs.get(&sid)?;
+                while let Some(def_row) = defs_it.next() {
+                    let bytes = def_row?.value().to_vec();
+                    if let Ok(d) = from_bytes::<DefSite>(&bytes) {
+                        if d.fid == fid {
+                            defined_symbols.push(DefinedSymbol {
+                                name: name.clone(),
+                                kind: d.kind,
+                                visibility: d.visibility,
+                                start_line: d.start_line,
+                                end_line: d.end_line,
+                                start_byte: d.start,
+                                end_byte: d.end,
+                            });
+                            break;
+                        }
+                    }
+                }
+            }
+            out.push(FileWithDefs {
+                path,
+                defined_symbols,
+            });
+        }
+        Ok(out)
+    }
+
+    /// All symbol names defined anywhere in the workspace, as a set.
+    /// Used by `Index.Outline` to filter raw identifier references
+    /// down to "actual symbol references" before building the graph.
+    pub fn all_defined_names(&self) -> anyhow::Result<std::collections::HashSet<String>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let name_to_sid = txn.open_table(NAME_TO_SID)?;
+        let mut out = std::collections::HashSet::new();
+        let iter = name_to_sid.iter()?;
+        for row in iter {
+            let row = row?;
+            out.insert(row.0.value().to_string());
+        }
+        Ok(out)
+    }
+
     pub fn get_file_meta(&self, path: &str) -> anyhow::Result<Option<(FileId, FileMeta)>> {
         let txn = self.db.begin_read().context("begin_read")?;
         let path_to_fid = txn.open_table(PATH_TO_FID)?;
@@ -370,6 +438,25 @@ impl Store {
 }
 
 /// Surface struct for `Index.FindSymbol` consumers. Plain data; no redb
+/// Single defined symbol — surface for `Index.Outline`.
+#[derive(Debug, Clone)]
+pub struct DefinedSymbol {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub visibility: schema::Visibility,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub start_byte: u32,
+    pub end_byte: u32,
+}
+
+/// One file's defs surface for `Index.Outline` orchestration.
+#[derive(Debug, Clone)]
+pub struct FileWithDefs {
+    pub path: String,
+    pub defined_symbols: Vec<DefinedSymbol>,
+}
+
 /// types leak past this boundary.
 #[derive(Debug, Clone)]
 pub struct FoundSymbol {

--- a/crates/rts-daemon/src/store/schema.rs
+++ b/crates/rts-daemon/src/store/schema.rs
@@ -124,7 +124,7 @@ impl SymbolKind {
 }
 
 /// Symbol visibility — loosely classified from the producer's string.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum Visibility {
     Public = 0,

--- a/crates/rts-daemon/src/writer.rs
+++ b/crates/rts-daemon/src/writer.rs
@@ -477,6 +477,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn parse_and_extract_caller_excludes_called_fn_names() {
+        // Probe for the bug where the analyzer was reporting referenced
+        // function names as defined symbols in the referring file.
+        let pool = ParserPool::new();
+        let src =
+            "pub fn caller_a_one() {\n    let _ = hub_compute(1);\n    let _ = hub_format(2);\n}\n";
+        let syms = pool.parse_and_extract(Language::Rust, src).unwrap();
+        let names: Vec<_> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"caller_a_one"),
+            "expected `caller_a_one` in {names:?}"
+        );
+        assert!(
+            !names.contains(&"hub_compute"),
+            "`hub_compute` is a CALL, not a def, should not appear; got {names:?}"
+        );
+        assert!(
+            !names.contains(&"hub_format"),
+            "`hub_format` is a CALL, not a def, should not appear; got {names:?}"
+        );
+    }
+
     /// **Known issue**: as of `0.2.0-alpha.15` the analyzer's
     /// `extract_java_symbols` / `extract_c_symbols` / `extract_cpp_symbols`
     /// paths return empty when called via the writer's tempfile route

--- a/crates/rts-daemon/tests/outline_round_trip.rs
+++ b/crates/rts-daemon/tests/outline_round_trip.rs
@@ -1,0 +1,216 @@
+//! End-to-end test for `Index.Outline` with PageRank ranking.
+//!
+//! Seeds a workspace with three Rust files where one file is the "hub"
+//! — multiple other files reference its symbols. PageRank should rank
+//! the hub highest in the returned outline.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("socket {} never appeared", path.display());
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn outline_ranks_hub_file_highest() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // `hub.rs` defines two symbols. `caller_a.rs` and `caller_b.rs`
+    // reference them. PageRank should put `hub.rs` ahead of the
+    // callers.
+    std::fs::write(
+        workspace.path().join("hub.rs"),
+        "pub fn hub_compute(x: u32) -> u32 { x + 1 }\npub fn hub_format(x: u32) -> String { x.to_string() }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("caller_a.rs"),
+        "pub fn caller_a_one() {\n    let _ = hub_compute(1);\n    let _ = hub_format(2);\n}\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("caller_b.rs"),
+        "pub fn caller_b_one() {\n    let _ = hub_compute(3);\n}\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+
+    // Wait for all three files' symbols to land in the index.
+    wait_for_symbol(&mut stream, "hub_compute", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "caller_a_one", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "caller_b_one", Duration::from_secs(5)).await?;
+
+    let outline = round_trip(
+        &mut stream,
+        "10",
+        "Index.Outline",
+        json!({ "token_budget": 4096 }),
+    )
+    .await?;
+    assert!(outline["error"].is_null(), "outline failed: {outline:?}");
+    let files = outline["result"]["outline_json"]["files"]
+        .as_array()
+        .expect("outline_json.files array");
+    assert!(
+        files.len() >= 3,
+        "expected at least 3 files in outline; got {files:?}"
+    );
+
+    let ranks: Vec<(&str, f64)> = files
+        .iter()
+        .map(|f| {
+            (
+                f["path"].as_str().unwrap_or(""),
+                f["rank"].as_f64().unwrap_or(0.0),
+            )
+        })
+        .collect();
+
+    // Hub should rank strictly higher than each caller.
+    let hub_rank = ranks
+        .iter()
+        .find(|(p, _)| *p == "hub.rs")
+        .map(|(_, r)| *r)
+        .expect("hub.rs should appear in outline");
+    let caller_a_rank = ranks
+        .iter()
+        .find(|(p, _)| *p == "caller_a.rs")
+        .map(|(_, r)| *r)
+        .expect("caller_a.rs should appear in outline");
+    let caller_b_rank = ranks
+        .iter()
+        .find(|(p, _)| *p == "caller_b.rs")
+        .map(|(_, r)| *r)
+        .expect("caller_b.rs should appear in outline");
+
+    assert!(
+        hub_rank > caller_a_rank && hub_rank > caller_b_rank,
+        "hub should outrank callers; got hub={hub_rank}, caller_a={caller_a_rank}, caller_b={caller_b_rank}"
+    );
+
+    // Sanity: outline_text mentions the hub's defined symbols.
+    let text = outline["result"]["outline_text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        text.contains("hub.rs") && text.contains("hub_compute"),
+        "outline_text should list hub.rs + hub_compute; got {text:?}"
+    );
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}

--- a/crates/rts-daemon/tests/wire_round_trip.rs
+++ b/crates/rts-daemon/tests/wire_round_trip.rs
@@ -177,10 +177,8 @@ async fn full_round_trip() -> anyhow::Result<()> {
     let bad = round_trip(&mut stream, "6", "Index.NotARealVerb", json!({})).await?;
     assert_eq!(bad["error"]["code"], "INVALID_PARAMS");
 
-    // 6. `Index.FindSymbol` is wired up as of P6's writer-pipeline slice; an
-    //    unknown symbol returns an empty match list (success), not an error.
-    //    `Index.Outline`/`Index.ReadSymbol`/`Index.ReadRange` still surface
-    //    `INDEX_NOT_READY` until later P6 slices.
+    // 6. `Index.FindSymbol` returns empty matches for an unknown symbol
+    //    (success, not error).
     let empty = round_trip(&mut stream, "7", "Index.FindSymbol", json!({"name":"x"})).await?;
     assert!(
         empty["error"].is_null(),
@@ -194,9 +192,22 @@ async fn full_round_trip() -> anyhow::Result<()> {
         0,
         "expected empty matches on an empty workspace; got {empty:?}"
     );
-    let still_not_ready =
-        round_trip(&mut stream, "8", "Index.Outline", json!({"path":"x.rs"})).await?;
-    assert_eq!(still_not_ready["error"]["code"], "INDEX_NOT_READY");
+
+    // 7. `Index.Outline` on an empty workspace succeeds with zero files
+    //    (no more INDEX_NOT_READY — PageRank ships as of alpha.18).
+    let outline_resp = round_trip(
+        &mut stream,
+        "8",
+        "Index.Outline",
+        json!({ "token_budget": 1024 }),
+    )
+    .await?;
+    assert!(
+        outline_resp["error"].is_null(),
+        "Outline should succeed on empty workspace; got {outline_resp:?}"
+    );
+    assert_eq!(outline_resp["result"]["files_considered"], 0);
+    assert_eq!(outline_resp["result"]["files_included"], 0);
 
     Ok(())
 }

--- a/crates/rts-mcp/tests/mcp_round_trip.rs
+++ b/crates/rts-mcp/tests/mcp_round_trip.rs
@@ -224,15 +224,28 @@ async fn mcp_round_trip_against_real_daemon() -> Result<()> {
     )
     .await?;
     let resp = read_one_response(&mut reader).await?;
+    // outline_workspace now ships end-to-end as of alpha.18 (PageRank +
+    // Index.Outline). The seeded `lib.rs` is the only file in the
+    // workspace and contains `build_index` + `WidgetIndex`; both should
+    // appear in the returned outline.
     assert_eq!(
-        resp["result"]["isError"], true,
-        "outline_workspace should surface INDEX_NOT_READY as isError=true; got {resp:?}"
+        resp["result"]["isError"],
+        serde_json::Value::Bool(false),
+        "outline_workspace should succeed; got {resp:?}"
     );
     let body = resp["result"]["content"][0]["text"]
         .as_str()
         .expect("text content");
     let parsed: Value = serde_json::from_str(body)?;
-    assert_eq!(parsed["error"]["code"], "INDEX_NOT_READY");
+    assert!(
+        parsed["files_considered"].as_u64().unwrap_or(0) >= 1,
+        "expected at least 1 file considered; got {parsed:?}"
+    );
+    let outline_text = parsed["outline_text"].as_str().unwrap_or_default();
+    assert!(
+        outline_text.contains("build_index"),
+        "outline_text should mention seeded symbol; got {outline_text:?}"
+    );
 
     // Close stdin so rts-mcp shuts down cleanly.
     drop(stdin);


### PR DESCRIPTION
## What

Largest remaining feature from the v0.2 plan. `outline_workspace` MCP tool now ships end-to-end:

```
read_symbol(query_outline) before this PR  →  INDEX_NOT_READY
read_symbol(query_outline) after this PR   →  PageRank-ranked outline (text + JSON)
```

Also fixes a Rust analyzer bug surfaced by PageRank — see the "Bug fix" section below. The fix changes the def index for any Rust workspace that uses `let _ = some_fn(…);` patterns.

## How

Per plan §"Aider repo-map algorithm (concrete recipe)":

1. **`crates/rts-core/src/pagerank.rs`** — Personalized PageRank with NetworkX defaults (α=0.85, max_iter=100, tol=1e-6), power iteration with dangling-node redistribution. Aider edge-weight recipe (`mul × sqrt(num_refs)`) with multipliers for `mentioned_idents`, compound-and-long names, leading-underscore privates, ubiquitous identifiers, and chat files.
2. **`crates/rts-daemon/src/outline.rs`** orchestrator pulls defs from redb, re-reads file contents to extract identifier-shaped tokens, filters against the workspace's def set to build a file→file ref graph, runs PageRank, greedy-packs files into the token budget, emits dotted text + JSON sidecar per protocol-v0 §7.5.
3. **`Index.Outline` handler** runs the orchestrator on the blocking thread pool.

End-to-end verification — a hub-spoke workspace where two files reference a hub file's symbols:

```
files: [caller_a.rs (0), caller_b.rs (1), hub.rs (2)]
edges: caller_a→hub (hub_compute), caller_a→hub (hub_format), caller_b→hub (hub_compute)
ranks: 0.213, 0.213, 0.574  →  hub outranks both callers ✓
```

## Bug fix

The Rust analyzer's `extract_rust_symbols` was pulling the FIRST identifier descendant of a `let_declaration`:

```rust
let lets = tree.find_nodes_by_kind("let_declaration");
for let_node in lets {
    let ids = let_node.find_descendants(|n| n.kind() == "identifier");
    let name = ids.first()...
```

For `let _ = hub_compute(1);` the first identifier descendant is `hub_compute` (the call target), not the let-binding name. This polluted the def index with the names of called functions in every file that imported them — PageRank made it visible (hub files inherited their callers' rank); it was previously silent noise in `find_symbol`/`read_symbol`.

Fix constrains the identifier search to the `pattern` field of the `let_declaration`, skips wildcards (`let _ = …`), and skips patterns with no extractable identifier.

## How to test

```sh
cargo test -p rust_tree_sitter --lib pagerank          # 7 unit tests
cargo test -p rts-daemon --test outline_round_trip      # hub-spoke verification
cargo test --workspace                                  # 466/0/3 (was 453)
cargo fmt --all -- --check                              # exit 0
cargo clippy --workspace --all-targets                  # exit 0
```

Manual smoke:

```sh
target/debug/rts-bench task run locate_def --workspace . --symbol parse --dry-run
# → reduction=99.9%  (bench unaffected by Outline addition)
```

## Not in this slice

- Incremental PageRank patch on file change (push-flow local PageRank, Andersen et al. 2006). v0 recomputes from scratch on every `Index.Outline` call.
- Tags.scm-based reference extraction. v0 uses a regex-based identifier scan filtered against the workspace's def set.
- Tree-shake closure walker for `include_dependencies: true`.
- P6 watcher hardening, P9 latency bench, prebuilt binaries.

## Checklist

- [x] Tests pass (466/0/3 — +13 tests)
- [x] `cargo fmt --all -- --check` exit 0
- [x] `cargo clippy --workspace --all-targets` exit 0
- [x] No secrets committed
- [x] Conventional commit title (`feat(rts-daemon):`)

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required: local-only feature addition. PageRank runs on the blocking pool with a hard MAX_ITER cap; pathological convergence behaviour bounds at 100 iterations.`