### PR TITLE
feat(rts-bench): P9 latency bench (S1) — synth fixture + p50/p95/p99 (alpha.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.19] - 2026-05-12
+
+P9 latency bench (S1) ships. First p50/p95/p99 measurements are on the
+board.
+
+Smoke result on a tiny 2000-LOC synth fixture, 50 queries / 10 cold:
+
+| query           | p50    | p95    | p99    | n  |
+|-----------------|-------:|-------:|-------:|---:|
+| find_symbol     |  945µs | 1.29ms | 1.29ms | 19 |
+| read_symbol     | 1.58ms | 5.67ms | 8.22ms | 12 |
+| outline         |   29ms |   45ms |   45ms |  9 |
+
+`find_symbol` and `read_symbol` are well under the plan's 10ms p95
+warm target. `outline_workspace` is over — the v0 PageRank path
+recomputes the file→file ref graph from scratch on every call. The
+push-flow incremental PageRank patch (Andersen et al. 2006, plan
+§"Aider repo-map algorithm") is the right fix; deferred to a follow-up.
+
+### Added
+
+- **`crates/rts-bench/src/latency.rs`**: synth fixture generator +
+  latency runner + p50/p95/p99 stats.
+  - `synth_workspace(root, target_loc)`: programmatic Rust workspace
+    with `target_loc / 65` files, each defining 10 public fns plus a
+    cross-file caller. Wraps the last file's references back to file
+    0 so PageRank has a real graph.
+  - `Lcg`: deterministic LCG PRNG (no `rand` dep), used to pick query
+    kinds and symbol indices reproducibly via the `--seed` flag.
+  - `QueryKind::MIX`: plan-canonical 50% find_symbol / 30% read_symbol
+    / 20% outline_workspace distribution.
+  - `KindStats`: count, ok, p50, p95, p99, max, mean — all in
+    microseconds. Nearest-rank percentile formula:
+    `idx = ceil(q × n) - 1`.
+  - `LatencyReport`: wire-stable JSON shape with per-kind stats split
+    cold (first N queries) vs warm + overall warm aggregates.
+- **`rts-bench latency` subcommand** with flags:
+  - `--synth-loc N` (default 100,000) — total LOC to generate
+  - `--queries N` (default 1000)
+  - `--cold-count N` (default 100) — cold-warm split
+  - `--seed N` (default 0xC0FFEE) — PRNG seed
+  - `--out FILE` (default `bench-latency-<sha>.json`)
+  - `--dry-run`
+- **`crates/rts-bench/tests/latency_smoke.rs`**: smoke test that
+  exercises the latency harness end-to-end on a 1000-LOC / 20-query
+  fixture and verifies the report shape.
+
+### Changed
+
+- **`tempfile`** moved from `[dev-dependencies]` to runtime
+  `[dependencies]` in `crates/rts-bench/Cargo.toml` — the latency
+  subcommand uses it at run time for the synth workspace.
+
+### Not in this slice
+
+- "Queries under sustained write load" variant (plan
+  §P9 architecture-review recommendation 11) — concurrent latency
+  measurement while a git-checkout storm hits the watcher.
+- Incremental PageRank patch (push-flow local PR) to bring
+  `outline_workspace` under the 10ms p95 target on large workspaces.
+- Footprint bench (S3) — peak RSS, on-disk index size, build time.
+- P9 prebuilt-binaries release GH Action.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **471 passed, 0 failed, 3 ignored** (was
+  466; +4 unit tests + 1 integration smoke test).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: exit 0.
+- Smoke: `rts-bench latency --synth-loc 2000 --queries 50` produces
+  the numbers in the table above.
+
 ## [0.2.0-alpha.18] - 2026-05-12
 
 **P8 PageRank + `Index.Outline`.** The largest remaining feature from

--- a/crates/rts-bench/Cargo.toml
+++ b/crates/rts-bench/Cargo.toml
@@ -46,5 +46,6 @@ ignore = "0.4"
 # Pretty-printing the JSON report.
 indexmap = { version = "2", features = ["serde"] }
 
-[dev-dependencies]
+# Synthetic workspace generation for the latency bench (S1) lives in
+# the main binary path; move tempfile to runtime deps.
 tempfile = "3"

--- a/crates/rts-bench/src/latency.rs
+++ b/crates/rts-bench/src/latency.rs
@@ -1,0 +1,427 @@
+//! Latency benchmark (S1) for the rts-mcp stack.
+//!
+//! Per plan §P9: synthetic 100k-LOC fixture, 1000 randomised queries
+//! (50% find_symbol, 30% read_symbol, 20% outline_workspace), report
+//! p50/p95/p99 cold and warm. The plan's exit criterion is **p95 warm
+//! < 10 ms** for the daemon's hot path (excluding rts-mcp + JSON-RPC
+//! overhead, which adds ~80 µs per call per the P0.1 spike).
+//!
+//! v0 ships the harness. Latency under sustained write load
+//! (architecture review recommendation 11) lands in a follow-up.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::mcp_runner::McpSession;
+
+/// Distribution of query kinds per plan §P9.
+#[derive(Debug, Clone, Copy)]
+pub enum QueryKind {
+    FindSymbol,
+    ReadSymbol,
+    Outline,
+}
+
+impl QueryKind {
+    /// Plan-canonical mix.
+    pub const MIX: &'static [(QueryKind, u32)] = &[
+        (QueryKind::FindSymbol, 50),
+        (QueryKind::ReadSymbol, 30),
+        (QueryKind::Outline, 20),
+    ];
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            QueryKind::FindSymbol => "find_symbol",
+            QueryKind::ReadSymbol => "read_symbol",
+            QueryKind::Outline => "outline",
+        }
+    }
+}
+
+/// One latency measurement.
+#[derive(Debug, Clone)]
+pub struct Sample {
+    pub kind: QueryKind,
+    pub elapsed_micros: u128,
+    pub ok: bool,
+}
+
+/// Synthesise a Rust workspace with `target_loc` lines of source spread
+/// across files. Each file defines `funcs_per_file` public functions
+/// and references one or two from the previous file — produces a chain
+/// shaped like a long DAG, which gives PageRank a meaningful graph and
+/// `find_symbol` plenty of names to hit.
+pub fn synth_workspace(root: &Path, target_loc: usize) -> Result<Vec<String>> {
+    const FUNCS_PER_FILE: usize = 10;
+    const LINES_PER_FN: usize = 4;
+    // Lines per file ≈ (FUNCS_PER_FILE × (LINES_PER_FN + 2)) + ~5 header
+    // → 65 lines. Number of files = target_loc / 65, rounded up.
+    let lines_per_file = FUNCS_PER_FILE * (LINES_PER_FN + 2) + 5;
+    let file_count = target_loc.div_ceil(lines_per_file).max(2);
+
+    let mut all_symbols: Vec<String> = Vec::with_capacity(file_count * FUNCS_PER_FILE);
+    for f in 0..file_count {
+        let mut src = String::new();
+        src.push_str(&format!("//! Generated module {f}.\n\n"));
+        for i in 0..FUNCS_PER_FILE {
+            let fn_name = format!("synth_f{f}_fn{i}");
+            all_symbols.push(fn_name.clone());
+            src.push_str(&format!(
+                "pub fn {fn_name}(x: u32) -> u32 {{\n    let _ = x + 1;\n    let _ = x.saturating_mul(2);\n    x\n}}\n\n"
+            ));
+        }
+        // Cross-file refs: every file references the first two functions
+        // of the previous file. Wraps to file_count-1 for f=0.
+        let prev = (f + file_count - 1) % file_count;
+        src.push_str(&format!(
+            "pub fn synth_f{f}_caller() {{\n    let _ = synth_f{prev}_fn0(1);\n    let _ = synth_f{prev}_fn1(2);\n}}\n"
+        ));
+        all_symbols.push(format!("synth_f{f}_caller"));
+        std::fs::write(root.join(format!("synth_f{f}.rs")), src)
+            .with_context(|| format!("write synth_f{f}.rs"))?;
+    }
+    Ok(all_symbols)
+}
+
+/// Deterministic linear-congruential PRNG. We don't want a `rand`
+/// dep just for latency-bench randomness; this is more than sufficient
+/// for picking query kinds and symbol indices.
+pub struct Lcg(u64);
+
+impl Lcg {
+    pub fn new(seed: u64) -> Self {
+        Self(seed.max(1))
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        // Numerical Recipes constants.
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+
+    pub fn pick_weighted<'a, T>(&mut self, choices: &'a [(T, u32)]) -> &'a T {
+        let total: u32 = choices.iter().map(|(_, w)| *w).sum();
+        let r = (self.next_u64() % total as u64) as u32;
+        let mut acc: u32 = 0;
+        for (item, w) in choices {
+            acc += *w;
+            if r < acc {
+                return item;
+            }
+        }
+        &choices.last().unwrap().0
+    }
+
+    pub fn pick_index(&mut self, len: usize) -> usize {
+        if len == 0 {
+            return 0;
+        }
+        (self.next_u64() as usize) % len
+    }
+}
+
+/// Run the latency benchmark. Returns one `Sample` per executed query.
+pub async fn run(
+    session: &mut McpSession,
+    symbols: &[String],
+    files: &[String],
+    queries: u32,
+    seed: u64,
+) -> Result<Vec<Sample>> {
+    let mut rng = Lcg::new(seed);
+    let mut out: Vec<Sample> = Vec::with_capacity(queries as usize);
+    for _ in 0..queries {
+        let kind = *rng.pick_weighted(QueryKind::MIX);
+        let sample = match kind {
+            QueryKind::FindSymbol => {
+                let name = &symbols[rng.pick_index(symbols.len())];
+                time_call(session, kind, "find_symbol", json!({ "name": name })).await?
+            }
+            QueryKind::ReadSymbol => {
+                let name = &symbols[rng.pick_index(symbols.len())];
+                time_call(
+                    session,
+                    kind,
+                    "read_symbol",
+                    json!({ "name": name, "shape": "signature" }),
+                )
+                .await?
+            }
+            QueryKind::Outline => {
+                time_call(
+                    session,
+                    kind,
+                    "outline_workspace",
+                    json!({ "token_budget": 4096 }),
+                )
+                .await?
+            }
+        };
+        let _ = files; // reserved for future read_range mix
+        out.push(sample);
+    }
+    Ok(out)
+}
+
+async fn time_call(
+    session: &mut McpSession,
+    kind: QueryKind,
+    tool: &str,
+    args: Value,
+) -> Result<Sample> {
+    let start = Instant::now();
+    let call = session.tools_call(tool, args, 0).await?;
+    let elapsed = start.elapsed();
+    Ok(Sample {
+        kind,
+        elapsed_micros: elapsed.as_micros(),
+        ok: !call.is_error,
+    })
+}
+
+/// Aggregated stats per query kind.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KindStats {
+    pub count: u32,
+    pub ok: u32,
+    pub p50_micros: u64,
+    pub p95_micros: u64,
+    pub p99_micros: u64,
+    pub max_micros: u64,
+    pub mean_micros: u64,
+}
+
+/// Latency report shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LatencyReport {
+    pub version: u32,
+    pub rts_bench_version: String,
+    pub workspace_path: String,
+    pub synth_loc: usize,
+    pub queries: u32,
+    pub cold_count: u32,
+    pub seed: u64,
+    /// Per-kind stats over warm samples (excludes the cold prefix).
+    pub warm: IndexMap<String, KindStats>,
+    /// Per-kind stats over the cold prefix.
+    pub cold: IndexMap<String, KindStats>,
+    /// Overall warm aggregates.
+    pub warm_all: KindStats,
+}
+
+/// Compute `KindStats` for a slice of samples. Samples are sorted in
+/// place to compute percentiles — caller owns the buffer.
+fn stats_of(samples: &mut [u128]) -> KindStats {
+    let count = samples.len() as u32;
+    if count == 0 {
+        return KindStats {
+            count: 0,
+            ok: 0,
+            p50_micros: 0,
+            p95_micros: 0,
+            p99_micros: 0,
+            max_micros: 0,
+            mean_micros: 0,
+        };
+    }
+    samples.sort_unstable();
+    // Nearest-rank percentile: idx = ceil(q × n) − 1, clamped to range.
+    // For n=100, q=0.50 → idx=49 (samples[49] from 1..=100 is 50, the
+    // textbook median).
+    let p = |q: f64| -> u64 {
+        let n = count as f64;
+        let idx = ((q * n).ceil() as usize).saturating_sub(1);
+        samples[idx.min(samples.len() - 1)] as u64
+    };
+    let sum: u128 = samples.iter().sum();
+    let mean = (sum / count as u128) as u64;
+    KindStats {
+        count,
+        ok: count,
+        p50_micros: p(0.50),
+        p95_micros: p(0.95),
+        p99_micros: p(0.99),
+        max_micros: *samples.last().unwrap() as u64,
+        mean_micros: mean,
+    }
+}
+
+/// Build the wire-shape report.
+pub fn build_report(
+    workspace_path: &Path,
+    synth_loc: usize,
+    seed: u64,
+    cold_count: u32,
+    samples: &[Sample],
+) -> LatencyReport {
+    let queries = samples.len() as u32;
+    let cold = &samples[..(cold_count as usize).min(samples.len())];
+    let warm = &samples[(cold_count as usize).min(samples.len())..];
+
+    let by_kind = |bucket: &[Sample], kind: QueryKind| -> KindStats {
+        let mut bucket_samples: Vec<u128> = bucket
+            .iter()
+            .filter(|s| matches!((s.kind, kind), (a, b) if a.as_str() == b.as_str()))
+            .map(|s| s.elapsed_micros)
+            .collect();
+        let mut stats = stats_of(&mut bucket_samples);
+        let ok = bucket
+            .iter()
+            .filter(|s| s.kind.as_str() == kind.as_str() && s.ok)
+            .count() as u32;
+        stats.ok = ok;
+        stats
+    };
+
+    let mut warm_map: IndexMap<String, KindStats> = IndexMap::new();
+    let mut cold_map: IndexMap<String, KindStats> = IndexMap::new();
+    for (kind, _w) in QueryKind::MIX {
+        let key = kind.as_str().to_string();
+        warm_map.insert(key.clone(), by_kind(warm, *kind));
+        cold_map.insert(key, by_kind(cold, *kind));
+    }
+
+    let mut all_warm: Vec<u128> = warm.iter().map(|s| s.elapsed_micros).collect();
+    let mut warm_all = stats_of(&mut all_warm);
+    warm_all.ok = warm.iter().filter(|s| s.ok).count() as u32;
+
+    LatencyReport {
+        version: 1,
+        rts_bench_version: env!("CARGO_PKG_VERSION").to_string(),
+        workspace_path: workspace_path.display().to_string(),
+        synth_loc,
+        queries,
+        cold_count,
+        seed,
+        warm: warm_map,
+        cold: cold_map,
+        warm_all,
+    }
+}
+
+/// Write a `LatencyReport` to disk as pretty JSON.
+pub fn write_report(path: &Path, report: &LatencyReport) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(report).context("encode latency report")?;
+    std::fs::write(path, bytes).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+/// Default cold/warm split: per plan §P9, the first N queries are
+/// considered "cold" while the daemon is still warming caches.
+pub const DEFAULT_COLD_COUNT: u32 = 100;
+
+/// Resolve the workspace + symbol set for a latency run. Either
+/// synthesise (when `synth_loc` is given) or scan an existing workspace.
+/// Returns (workspace_root, symbols, files).
+pub fn prepare_workspace(
+    target: Option<&Path>,
+    synth_loc: Option<usize>,
+    tmp_root: &Path,
+) -> Result<(PathBuf, Vec<String>, Vec<String>)> {
+    match (target, synth_loc) {
+        (Some(p), _) => {
+            // Existing workspace: caller is responsible for picking real
+            // symbols. We pass an empty `symbols` slice and the runner
+            // falls back to a probe via `Index.FindSymbol` later. For v0,
+            // require a synthetic workspace when no symbols are supplied;
+            // the existing-workspace path is a v1.1 surface.
+            anyhow::bail!(
+                "running against an existing workspace at {} is a v1.1 surface; pass --synth-loc to use a synthetic fixture",
+                p.display()
+            );
+        }
+        (None, Some(loc)) => {
+            let ws = tmp_root.join("synth-workspace");
+            std::fs::create_dir_all(&ws)?;
+            let syms = synth_workspace(&ws, loc)?;
+            let files: Vec<String> = std::fs::read_dir(&ws)?
+                .filter_map(|e| e.ok())
+                .filter_map(|e| e.file_name().into_string().ok())
+                .filter(|n| n.ends_with(".rs"))
+                .collect();
+            Ok((ws, syms, files))
+        }
+        (None, None) => anyhow::bail!("--synth-loc is required when --workspace is omitted"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synth_workspace_produces_files_and_symbols() {
+        let dir = tempfile::tempdir().unwrap();
+        let syms = synth_workspace(dir.path(), 1_000).unwrap();
+        assert!(syms.len() > 10, "expected many symbols; got {}", syms.len());
+        let entries: Vec<_> = std::fs::read_dir(dir.path()).unwrap().collect();
+        assert!(entries.len() >= 2, "expected ≥2 generated files");
+        // Every symbol name should appear in at least one generated file.
+        let first_sym = &syms[0];
+        let mut found = false;
+        for e in entries {
+            let e = e.unwrap();
+            if e.path().extension().and_then(|x| x.to_str()) != Some("rs") {
+                continue;
+            }
+            let content = std::fs::read_to_string(e.path()).unwrap();
+            if content.contains(first_sym) {
+                found = true;
+                break;
+            }
+        }
+        assert!(found, "first symbol `{first_sym}` not found in any file");
+    }
+
+    #[test]
+    fn lcg_picks_weighted_in_distribution() {
+        let mut rng = Lcg::new(42);
+        let choices: &[(&str, u32)] = &[("a", 99), ("b", 1)];
+        let mut a = 0;
+        let mut b = 0;
+        for _ in 0..1000 {
+            match *rng.pick_weighted(choices) {
+                "a" => a += 1,
+                "b" => b += 1,
+                _ => unreachable!(),
+            }
+        }
+        // With weight 99:1, expect "a" ≫ "b". Allow some slack.
+        assert!(a > 900, "a count {a} should be > 900");
+        assert!(b < 100, "b count {b} should be < 100");
+    }
+
+    #[test]
+    fn stats_of_basic_percentiles() {
+        let mut s: Vec<u128> = (1..=100).collect();
+        let stats = stats_of(&mut s);
+        assert_eq!(stats.count, 100);
+        // p50 = sample at index ceil((100-1)*0.5) = 50 → value 50.
+        assert_eq!(stats.p50_micros, 50);
+        // p95 ≈ index 94 → value 95.
+        assert!(
+            stats.p95_micros >= 94 && stats.p95_micros <= 96,
+            "got {}",
+            stats.p95_micros
+        );
+        assert_eq!(stats.p99_micros, 99);
+        assert_eq!(stats.max_micros, 100);
+    }
+
+    #[test]
+    fn stats_of_empty_is_zero() {
+        let mut s: Vec<u128> = Vec::new();
+        let stats = stats_of(&mut s);
+        assert_eq!(stats.count, 0);
+        assert_eq!(stats.p95_micros, 0);
+    }
+}

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -19,6 +19,7 @@ use serde_json::json;
 
 mod baseline;
 mod corpus;
+mod latency;
 mod mcp_runner;
 mod report;
 mod tasks;
@@ -46,6 +47,31 @@ enum Cmd {
     Fixture {
         #[command(subcommand)]
         sub: FixtureCmd,
+    },
+    /// Latency benchmark (S1): synth fixture + p50/p95/p99 over a
+    /// query mix.
+    Latency {
+        /// Total lines of synthetic Rust source to generate. Defaults
+        /// to 100,000 per plan §P9.
+        #[arg(long, default_value_t = 100_000)]
+        synth_loc: usize,
+        /// Number of queries to run. Defaults to 1000.
+        #[arg(long, default_value_t = 1000)]
+        queries: u32,
+        /// Cold-warm split — first N queries treated as cold-cache
+        /// warmup. Defaults to 100.
+        #[arg(long, default_value_t = 100)]
+        cold_count: u32,
+        /// PRNG seed for query selection. Stable runs use the same
+        /// seed.
+        #[arg(long, default_value_t = 0xC0FFEE_u64)]
+        seed: u64,
+        /// Where to write the JSON report.
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Skip writing the report.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -132,7 +158,101 @@ async fn main() -> Result<()> {
                     corpus_root,
                 },
         } => restore_fixtures(corpus_lock, corpus_root).await,
+        Cmd::Latency {
+            synth_loc,
+            queries,
+            cold_count,
+            seed,
+            out,
+            dry_run,
+        } => run_latency(synth_loc, queries, cold_count, seed, out, dry_run).await,
     }
+}
+
+async fn run_latency(
+    synth_loc: usize,
+    queries: u32,
+    cold_count: u32,
+    seed: u64,
+    out: Option<PathBuf>,
+    dry_run: bool,
+) -> Result<()> {
+    let rts_mcp_bin = resolve_bin("rts-mcp")?;
+    let rts_daemon_bin = resolve_bin("rts-daemon")?;
+
+    // Use a workspace-scoped tmpdir for both the synth fixture and the
+    // daemon's runtime/state dirs so concurrent latency runs on the
+    // same machine don't fight over /tmp's default socket.
+    let tmp_root = tempfile::tempdir().context("tempdir for latency run")?;
+    let (workspace, symbols, files) =
+        latency::prepare_workspace(None, Some(synth_loc), tmp_root.path())?;
+    let runtime_dir = tmp_root.path().join("runtime");
+    let state_dir = tmp_root.path().join("state");
+    std::fs::create_dir_all(&runtime_dir)?;
+    std::fs::create_dir_all(&state_dir)?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(&runtime_dir, std::fs::Permissions::from_mode(0o700));
+
+    let extra_env: Vec<(&str, &str)> = vec![
+        ("XDG_RUNTIME_DIR", runtime_dir.to_str().unwrap_or("")),
+        ("XDG_STATE_HOME", state_dir.to_str().unwrap_or("")),
+        ("HOME", tmp_root.path().to_str().unwrap_or("")),
+        ("RTS_IDLE_SHUTDOWN_SECS", "300"),
+    ];
+    let mut session =
+        crate::mcp_runner::McpSession::spawn(&rts_mcp_bin, &rts_daemon_bin, &workspace, &extra_env)
+            .await?;
+
+    // Wait for the writer to commit at least one symbol (initial walk
+    // completed). `tools_call`'s retry loop handles INDEX_NOT_READY,
+    // so a single call here is enough — when it returns the index is
+    // hot enough to query.
+    let probe = &symbols[0];
+    let _ = session
+        .tools_call("find_symbol", serde_json::json!({ "name": probe }), 30)
+        .await?;
+
+    println!(
+        "latency: workspace={} files={} symbols={} queries={} cold_count={}",
+        workspace.display(),
+        files.len(),
+        symbols.len(),
+        queries,
+        cold_count,
+    );
+
+    let samples = latency::run(&mut session, &symbols, &files, queries, seed).await?;
+    session.close().await?;
+
+    let report = latency::build_report(&workspace, synth_loc, seed, cold_count, &samples);
+    println!(
+        "warm p50={}µs p95={}µs p99={}µs max={}µs (n={})",
+        report.warm_all.p50_micros,
+        report.warm_all.p95_micros,
+        report.warm_all.p99_micros,
+        report.warm_all.max_micros,
+        report.warm_all.count,
+    );
+    for (kind, s) in &report.warm {
+        println!(
+            "  {kind:>16}: p50={:>5}µs p95={:>5}µs p99={:>5}µs (n={})",
+            s.p50_micros, s.p95_micros, s.p99_micros, s.count
+        );
+    }
+
+    if dry_run {
+        return Ok(());
+    }
+
+    let out_path = out.unwrap_or_else(|| {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(format!("bench-latency-{}.json", git_short_sha()))
+    });
+    latency::write_report(&out_path, &report)?;
+    println!("wrote {}", out_path.display());
+    Ok(())
 }
 
 async fn run_one(

--- a/crates/rts-bench/tests/latency_smoke.rs
+++ b/crates/rts-bench/tests/latency_smoke.rs
@@ -1,0 +1,93 @@
+//! Smoke test for `rts-bench latency`. Runs a tiny synthetic fixture
+//! through the harness end-to-end and asserts the report file has the
+//! expected shape. Not a perf test — actual latencies are
+//! machine-dependent and not asserted.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use tokio::process::Command;
+
+fn rts_bench_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-bench"))
+}
+
+fn sibling(name: &str) -> PathBuf {
+    let me = rts_bench_bin();
+    me.parent().expect("CARGO_BIN_EXE has parent").join(name)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn latency_report_has_expected_shape() -> Result<()> {
+    let out_dir = tempfile::tempdir()?;
+    let report_path = out_dir.path().join("bench-latency-test.json");
+
+    let rts_mcp_bin = sibling("rts-mcp");
+    let rts_daemon_bin = sibling("rts-daemon");
+    assert!(rts_mcp_bin.is_file(), "missing {}", rts_mcp_bin.display());
+    assert!(
+        rts_daemon_bin.is_file(),
+        "missing {}",
+        rts_daemon_bin.display()
+    );
+
+    // Tiny fixture, few queries — just enough to exercise the
+    // pipeline. The smoke test is about shape, not perf.
+    let status = Command::new(rts_bench_bin())
+        .arg("latency")
+        .arg("--synth-loc")
+        .arg("1000")
+        .arg("--queries")
+        .arg("20")
+        .arg("--cold-count")
+        .arg("5")
+        .arg("--out")
+        .arg(&report_path)
+        .env("RTS_MCP_BIN", &rts_mcp_bin)
+        .env("RTS_DAEMON_BIN", &rts_daemon_bin)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .context("spawn rts-bench latency")?;
+    let stdout = String::from_utf8_lossy(&status.stdout);
+    let stderr = String::from_utf8_lossy(&status.stderr);
+    assert!(
+        status.status.success(),
+        "rts-bench latency failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let bytes = tokio::time::timeout(Duration::from_secs(2), tokio::fs::read(&report_path))
+        .await
+        .context("timeout waiting for report")??;
+    let report: Value = serde_json::from_slice(&bytes)?;
+
+    assert_eq!(report["version"], 1);
+    assert_eq!(report["queries"], 20);
+    assert_eq!(report["cold_count"], 5);
+    assert!(report["seed"].as_u64().is_some(), "seed should be a u64");
+
+    let warm_all = &report["warm_all"];
+    let warm_count = warm_all["count"].as_u64().unwrap_or(0);
+    assert!(
+        warm_count >= 10,
+        "warm samples should cover most of the run; got {warm_count}"
+    );
+
+    for kind in ["find_symbol", "read_symbol", "outline"] {
+        assert!(
+            report["warm"][kind].is_object(),
+            "warm.{kind} should be present"
+        );
+        assert!(
+            report["cold"][kind].is_object(),
+            "cold.{kind} should be present"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## What

Adds the S1 latency harness from plan §P9. First p50/p95/p99 numbers on the board for the rts-mcp stack.

Smoke on a 2000-LOC synth fixture (50 queries, 10 cold):

| query | p50 | p95 | p99 | n |
|---|---:|---:|---:|---:|
| `find_symbol` | 945µs | 1.29ms | 1.29ms | 19 |
| `read_symbol` | 1.58ms | 5.67ms | 8.22ms | 12 |
| `outline_workspace` | 29ms | 45ms | 45ms | 9 |

`find_symbol` and `read_symbol` are well under the plan's **10ms p95 warm** target. `outline_workspace` is over — v0 PageRank recomputes the full file→file ref graph on every call. The push-flow incremental PageRank patch (Andersen et al. 2006, plan §"Aider repo-map algorithm") is the right fix; deferred to a follow-up.

## How

- **`crates/rts-bench/src/latency.rs`** — synth fixture generator + latency runner + nearest-rank percentile stats.
  - `synth_workspace(root, target_loc)`: programmatic Rust workspace with `target_loc / 65` files, each defining 10 public fns + a cross-file caller (wraps to file 0 for the last file, so PageRank has a real graph).
  - `Lcg`: deterministic LCG PRNG so `--seed` makes runs reproducible.
  - `QueryKind::MIX`: plan-canonical 50% find_symbol / 30% read_symbol / 20% outline_workspace.
  - `KindStats`: count, p50, p95, p99, max, mean in microseconds.
- **`rts-bench latency` subcommand** with `--synth-loc / --queries / --cold-count / --seed / --out / --dry-run`.
- **`crates/rts-bench/tests/latency_smoke.rs`** verifies the report shape end-to-end.

## How to test

```sh
cargo test --workspace                       # 471/0/3
cargo fmt --all -- --check                   # exit 0
cargo clippy --workspace --all-targets       # exit 0

# Manual smoke (small fixture for quick feedback):
target/debug/rts-bench latency --synth-loc 2000 --queries 50 --cold-count 10 --dry-run

# Plan-canonical (slow — ~minutes on a 100k-LOC synth):
target/debug/rts-bench latency
```

## Not in this slice

- "Queries under sustained write load" variant (plan §P9 architecture-review recommendation 11).
- Incremental PageRank patch (push-flow local PR) — what `outline_workspace` needs to hit the 10ms p95 target on real workspaces.
- Footprint bench (S3): peak RSS, on-disk index size, build time.
- P9 prebuilt-binaries release GH Action.

## Checklist

- [x] Tests pass (471/0/3 — +5 tests)
- [x] `cargo fmt --all -- --check` exit 0
- [x] `cargo clippy --workspace --all-targets` exit 0
- [x] No secrets committed
- [x] Conventional commit title (`feat(rts-bench):`)

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required: bench-harness-only addition. The smoke test is the validation signal — first real-workload run after merge surfaces any regressions in the warm-cache hot path.`