### PR TITLE
feat(rts-bench): 0.2.0-alpha.21 — footprint bench (S3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.21] - 2026-05-12
+
+**Footprint bench (S3) ships.** Companion to alpha.19's S1 latency bench;
+together they answer "is this daemon production-ready for my repo size?".
+
+Three numbers operators care about, all measured against a synthetic
+workspace of N LOC:
+
+| metric              | target (100k LOC) | measured (100k LOC) |
+|---------------------|------------------:|--------------------:|
+| `build_time_ms`     |           < 30000 |                 196 |
+| `full_index_time_ms`|        (new field)|                 610 |
+| `peak_rss_bytes`    |        < 1 000 MB |             19.2 MB |
+| `index_size_bytes`  |          < 200 MB |              1.5 MB |
+
+`build_time_ms` is "time until the daemon answers a query" — this is what
+agents care about for startup latency. `full_index_time_ms` is "time
+until the writer is done with the initial walk" — 3× larger than
+build_time on these numbers because the writer keeps ingesting in the
+background after the first symbol becomes queryable. The peak RSS sampler
+runs across the full window, so it now captures the high-water mark
+during background indexing — not just the time-to-first-query.
+
+### Caught a measurement bug during dev
+
+Initial implementation stopped the RSS sampler at first-query-ok. At
+100k LOC, this *underreported* peak RSS (16.9 MiB) vs the 10k LOC run
+(18.8 MiB) — because the harness stopped sooner on the larger fixture
+even though the daemon kept working. Fix: poll `outline_workspace.
+files_considered` until it stops growing across two consecutive 200ms
+checks. Peak RSS at 100k LOC jumped from 16.9 → 19.2 MiB after the fix,
+correctly reflecting the true high-water mark.
+
+### Added
+
+- **`crates/rts-bench/src/footprint.rs`**: full module —
+  `FootprintReport` wire shape, `run()` orchestrator, peak-RSS sampler
+  loop, `pgrep`-driven daemon PID discovery, `/proc/<pid>/status:VmHWM`
+  fallback for Linux, `db.redb` locator, and `wait_for_index_settled`
+  poll loop. 7 unit tests covering: ps RSS for current process,
+  `db.redb` location (positive + negative), `linux_vm_hwm_bytes`
+  optionality, serialization stability, `extract_files_considered`
+  (positive + negative).
+- **`rts-bench footprint` subcommand** with flags:
+  - `--synth-loc N` (default 100_000) — total LOC to generate
+  - `--out FILE` (default `bench-footprint-<sha>.json`)
+  - `--dry-run`
+- **`crates/rts-bench/tests/footprint_smoke.rs`**: end-to-end smoke
+  test that exercises the harness on a 1000-LOC fixture and verifies
+  the wire-stable report shape, including the
+  `full_index_time_ms >= build_time_ms` invariant.
+
+### Changed
+
+- **`crates/rts-bench/src/mcp_runner.rs`**: `McpCall` now exposes
+  `result_body: Option<Value>` — the parsed JSON object from the first
+  text content item. Consumers that need to read response fields beyond
+  `tokens_returned` (the footprint bench polls
+  `outline_workspace.files_considered`) reach into this. `McpSession`
+  gains `child_pid() -> Option<u32>` for callers that need to walk the
+  process tree.
+
+### Not in this slice
+
+- Footprint under churn (re-indexing after `git checkout` of a
+  different ref) — v1.1 surface.
+- Real-corpus footprint runs against the pinned corpus.lock fixtures
+  (deferred behind tarball-download in §P9).
+- Multi-language synth fixtures — the synth workspace is Rust-only
+  today; a TypeScript/Python variant lands when the corpus pipeline
+  does.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **486 passed, 0 failed, 3 ignored** (was
+  478; +7 footprint unit tests + 1 smoke test).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: no new warnings on changed
+  files (`footprint.rs`, `mcp_runner.rs`, `main.rs`).
+- Release bench: `rts-bench footprint --synth-loc 100000` produces the
+  numbers in the table above on a developer macOS (M-series).
+
 ## [0.2.0-alpha.20] - 2026-05-12
 
 **Outline cache (incremental PageRank, v0).** `Index.Outline` p95 drops

--- a/crates/rts-bench/src/footprint.rs
+++ b/crates/rts-bench/src/footprint.rs
@@ -1,0 +1,514 @@
+//! Footprint benchmark (S3) for the rts-mcp stack.
+//!
+//! Companion to S1 latency (`latency.rs`). Measures the *cost*
+//! dimensions of running an indexed daemon against a real-sized
+//! workspace:
+//!
+//! - **`build_time_ms`** — wall-clock from `Workspace.Mount` until the
+//!   first `Index.FindSymbol` for a known synth symbol returns OK. This
+//!   is the time an agent waits before the daemon stops returning
+//!   `INDEX_NOT_READY`.
+//! - **`peak_rss_bytes`** — high-water-mark resident set size of the
+//!   `rts-daemon` child during the build window, sampled at 25ms
+//!   intervals via `ps -o rss=`. On Linux we also read
+//!   `/proc/<pid>/status:VmHWM` once at the end and take the larger
+//!   of the two — kernel-tracked HWM is more accurate than sampling.
+//! - **`index_size_bytes`** — on-disk size of the daemon's redb file
+//!   (`${XDG_STATE_HOME}/rts/<workspace_id>/db.redb`), measured after
+//!   the index is ready.
+//!
+//! These are the three numbers an operator needs to answer "is this
+//! daemon production-ready for my repo size?". The plan's targets are:
+//!
+//! | metric          | target (100k LOC)        |
+//! |-----------------|--------------------------|
+//! | build_time_ms   | < 30 000 (30 s)          |
+//! | peak_rss_bytes  | < 1 000 000 000 (1 GiB)  |
+//! | index_size_bytes| < 200 000 000 (200 MiB)  |
+//!
+//! v0 ships the harness. Footprint under churn (re-indexing after
+//! `git checkout` of a different ref) is a v1.1 surface.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::mcp_runner::McpSession;
+
+/// Wire-stable footprint report. One run produces one of these.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FootprintReport {
+    pub version: u32,
+    pub rts_bench_version: String,
+    pub workspace_path: String,
+    pub synth_loc: usize,
+    pub files: u32,
+    pub symbols: u32,
+    /// Wall-clock from `Workspace.Mount` to first non-INDEX_NOT_READY
+    /// response for a known synth symbol. This is "time until the
+    /// daemon answers", which agents care about for their startup
+    /// latency — separate from full-index time below.
+    pub build_time_ms: u128,
+    /// Wall-clock from `Workspace.Mount` to the full index settling
+    /// (no new files appearing in `outline_workspace.files_considered`
+    /// across two consecutive 200ms polls). On a healthy run this is
+    /// 2× to 10× build_time_ms because the writer keeps indexing in
+    /// the background after the first symbol is queryable.
+    pub full_index_time_ms: u128,
+    /// High-water-mark RSS of the daemon child observed across the
+    /// *full* index window (mount → settled). Sampled at 25ms
+    /// intervals via `ps -o rss=`; on Linux we also consult
+    /// `/proc/<pid>/status:VmHWM` and take the max.
+    pub peak_rss_bytes: u64,
+    /// Size of `db.redb` on disk after the index has fully settled.
+    pub index_size_bytes: u64,
+    /// Derived ratio: `index_size_bytes / symbols`. Useful for sizing
+    /// expectations on bigger repos. Zero when symbols is 0.
+    pub bytes_per_symbol: u64,
+}
+
+/// Run the footprint benchmark.
+///
+/// Steps:
+/// 1. Generate (or use the cached) synth workspace at `target_loc` LOC.
+/// 2. Launch `rts-mcp` (which spawns `rts-daemon`) and grab the daemon's
+///    PID via `ps` walking back from the mcp child.
+/// 3. Poll RSS at 25ms intervals while waiting for `find_symbol` to
+///    return OK on a known synth symbol. Record build_time when it does.
+/// 4. Walk the state dir to find `db.redb` and stat it.
+/// 5. Compose the report.
+pub async fn run(
+    rts_mcp_bin: &Path,
+    rts_daemon_bin: &Path,
+    target_loc: usize,
+    tmp_root: &Path,
+) -> Result<FootprintReport> {
+    let (workspace, symbols, files) =
+        crate::latency::prepare_workspace(None, Some(target_loc), tmp_root)?;
+    let runtime_dir = tmp_root.join("runtime");
+    let state_dir = tmp_root.join("state");
+    std::fs::create_dir_all(&runtime_dir)?;
+    std::fs::create_dir_all(&state_dir)?;
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(&runtime_dir, std::fs::Permissions::from_mode(0o700));
+
+    let extra_env: Vec<(&str, &str)> = vec![
+        ("XDG_RUNTIME_DIR", runtime_dir.to_str().unwrap_or("")),
+        ("XDG_STATE_HOME", state_dir.to_str().unwrap_or("")),
+        ("HOME", tmp_root.to_str().unwrap_or("")),
+        ("RTS_IDLE_SHUTDOWN_SECS", "300"),
+    ];
+
+    let probe = symbols
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("synth workspace produced no symbols"))?
+        .clone();
+
+    // Mount handshake happens inside `McpSession::spawn`. We treat
+    // *that* moment as t0 — it's when the daemon receives the mount
+    // and starts its initial walk.
+    let mount_t0 = Instant::now();
+    let mut session =
+        McpSession::spawn(rts_mcp_bin, rts_daemon_bin, &workspace, &extra_env).await?;
+
+    // Resolve the daemon PID. The mcp child forks rts-daemon as a
+    // grandchild; we walk `pgrep -P <mcp_pid>` to find it. If pgrep is
+    // unavailable or we can't find the daemon, peak RSS is reported as
+    // 0 and the rest of the metrics still ship.
+    let daemon_pid = session
+        .child_pid()
+        .and_then(|mcp_pid| find_child_pid(mcp_pid, "rts-daemon"));
+
+    // Start the peak-RSS sampler. The sampler runs until we drop the
+    // sentinel `Arc` — done via the `stop` flag and joining the task.
+    let peak_rss = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicU64::new(0));
+    let sampler = if let Some(pid) = daemon_pid {
+        let peak_clone = peak_rss.clone();
+        let stop_clone = stop.clone();
+        Some(tokio::spawn(async move {
+            sample_rss_loop(pid, peak_clone, stop_clone).await;
+        }))
+    } else {
+        None
+    };
+
+    // Wait for the first non-INDEX_NOT_READY response. The mcp_runner
+    // retries internally on INDEX_NOT_READY, so a 60-retry budget gives
+    // us up to ~7s of slack at the default 120ms backoff.
+    let probe_call = session
+        .tools_call("find_symbol", json!({ "name": probe }), 60)
+        .await
+        .context("probe find_symbol")?;
+    anyhow::ensure!(
+        !probe_call.is_error,
+        "probe `find_symbol({})` errored after retries",
+        probe
+    );
+    let build_time = mount_t0.elapsed();
+
+    // Now wait for the *full* index to settle. The writer keeps
+    // ingesting files after the first symbol is queryable, so
+    // build_time only answers "can the agent start using us?".
+    // For peak RSS and final index size we need to keep sampling
+    // until the index stops growing. The signal we use is
+    // `outline_workspace.files_considered` — when two consecutive
+    // 200ms polls return the same number, the writer is done with
+    // the initial walk. Bounded by a 60s ceiling so a broken writer
+    // can't hang the bench forever.
+    let full_index_time = wait_for_index_settled(&mut session, mount_t0).await;
+
+    // Tell the sampler to stop, give it a beat to wind down, and pull
+    // the peak. The sampler ran across the full mount → settled
+    // window, so peak_rss now reflects the high-water mark of the
+    // entire build (not just the time-to-first-query).
+    stop.store(1, Ordering::Relaxed);
+    if let Some(handle) = sampler {
+        let _ = tokio::time::timeout(Duration::from_millis(200), handle).await;
+    }
+    // On Linux, prefer the kernel-tracked HWM when available — it
+    // catches transient peaks that the 25ms sampler may have missed.
+    if let Some(pid) = daemon_pid {
+        if let Some(hwm) = linux_vm_hwm_bytes(pid) {
+            let current = peak_rss.load(Ordering::Relaxed);
+            if hwm > current {
+                peak_rss.store(hwm, Ordering::Relaxed);
+            }
+        }
+    }
+
+    // Walk the state dir to find db.redb. The path is
+    // `<state>/rts/<workspace_id>/db.redb`; we don't know the
+    // workspace_id (it's a hash) so we scan one level deep under
+    // `<state>/rts/`.
+    let index_size = locate_index_size(&state_dir).unwrap_or(0);
+
+    session.close().await?;
+
+    let symbols_count = symbols.len() as u32;
+    let index_size_bytes = index_size;
+    let bytes_per_symbol = if symbols_count > 0 {
+        index_size_bytes / symbols_count as u64
+    } else {
+        0
+    };
+    Ok(FootprintReport {
+        version: 1,
+        rts_bench_version: env!("CARGO_PKG_VERSION").to_string(),
+        workspace_path: workspace.display().to_string(),
+        synth_loc: target_loc,
+        files: files.len() as u32,
+        symbols: symbols_count,
+        build_time_ms: build_time.as_millis(),
+        full_index_time_ms: full_index_time.as_millis(),
+        peak_rss_bytes: peak_rss.load(Ordering::Relaxed),
+        index_size_bytes,
+        bytes_per_symbol,
+    })
+}
+
+/// Poll `outline_workspace` until `files_considered` stops growing
+/// across two consecutive 200ms checks (the writer is done with the
+/// initial walk), or until a 60s hard deadline elapses.
+///
+/// Returns elapsed wall-clock from `mount_t0` to settle. The bench
+/// continues even if we time out — the report will carry the elapsed
+/// number as-is, which is itself useful signal ("this workspace size
+/// did not settle in 60s").
+async fn wait_for_index_settled(session: &mut McpSession, mount_t0: Instant) -> Duration {
+    const POLL_INTERVAL: Duration = Duration::from_millis(200);
+    const DEADLINE: Duration = Duration::from_secs(60);
+    let mut last_seen: i64 = -1;
+    loop {
+        let call = session
+            .tools_call("outline_workspace", json!({ "token_budget": 256 }), 0)
+            .await;
+        let files_considered = match call {
+            Ok(c) if !c.is_error => extract_files_considered(&c).unwrap_or(-1),
+            _ => -1,
+        };
+        if files_considered >= 0 && files_considered == last_seen && files_considered > 0 {
+            return mount_t0.elapsed();
+        }
+        last_seen = files_considered;
+        if mount_t0.elapsed() >= DEADLINE {
+            return mount_t0.elapsed();
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Pull `outline_workspace.files_considered` out of an `McpCall`. The
+/// daemon returns this as a top-level integer in the JSON body of the
+/// first content item. Returns `None` if the response wasn't JSON, the
+/// field is missing, or it isn't an integer.
+fn extract_files_considered(call: &crate::mcp_runner::McpCall) -> Option<i64> {
+    call.result_body
+        .as_ref()
+        .and_then(|v| v["files_considered"].as_i64())
+}
+
+/// Write a report to disk as pretty JSON.
+pub fn write_report(path: &Path, report: &FootprintReport) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(report).context("encode footprint report")?;
+    std::fs::write(path, bytes).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+/// Best-effort: find the first child process of `parent_pid` whose
+/// executable name contains `needle`. Uses `pgrep -P <pid>` then `ps -o
+/// comm=` for each candidate. Returns `None` if pgrep is missing,
+/// returns no rows, or no candidate matches.
+fn find_child_pid(parent_pid: u32, needle: &str) -> Option<u32> {
+    // Retry briefly — the daemon child may take a few ms to appear
+    // after the mcp handshake returns.
+    let deadline = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < deadline {
+        if let Some(pid) = pgrep_first_match(parent_pid, needle) {
+            return Some(pid);
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    None
+}
+
+fn pgrep_first_match(parent_pid: u32, needle: &str) -> Option<u32> {
+    let out = std::process::Command::new("pgrep")
+        .arg("-P")
+        .arg(parent_pid.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    for line in String::from_utf8_lossy(&out.stdout).lines() {
+        let pid: u32 = match line.trim().parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if let Some(comm) = ps_comm(pid) {
+            if comm.contains(needle) {
+                return Some(pid);
+            }
+        }
+    }
+    None
+}
+
+fn ps_comm(pid: u32) -> Option<String> {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "comm=", "-p"])
+        .arg(pid.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Sample RSS at 25ms cadence until `stop` is set.
+async fn sample_rss_loop(pid: u32, peak: Arc<AtomicU64>, stop: Arc<AtomicU64>) {
+    while stop.load(Ordering::Relaxed) == 0 {
+        if let Some(rss) = ps_rss_bytes(pid) {
+            let cur = peak.load(Ordering::Relaxed);
+            if rss > cur {
+                peak.store(rss, Ordering::Relaxed);
+            }
+        } else {
+            // Daemon went away; stop sampling.
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// `ps -o rss= -p <pid>` returns RSS in kilobytes on both macOS and
+/// Linux. Convert to bytes. Returns `None` when the process is gone
+/// or `ps` is unavailable.
+fn ps_rss_bytes(pid: u32) -> Option<u64> {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p"])
+        .arg(pid.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    let kib: u64 = s.trim().parse().ok()?;
+    Some(kib.saturating_mul(1024))
+}
+
+/// On Linux, parse `/proc/<pid>/status:VmHWM` (kilobytes). Returns
+/// `None` on macOS / when /proc is unavailable.
+fn linux_vm_hwm_bytes(pid: u32) -> Option<u64> {
+    let path = format!("/proc/{pid}/status");
+    let content = std::fs::read_to_string(&path).ok()?;
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("VmHWM:") {
+            let kib: u64 = rest.split_whitespace().next()?.parse().ok()?;
+            return Some(kib.saturating_mul(1024));
+        }
+    }
+    None
+}
+
+/// Walk `<state>/rts/<workspace_id>/db.redb` for the first match.
+/// Returns the file size in bytes, or `None` if no db.redb is found.
+fn locate_index_size(state_dir: &Path) -> Option<u64> {
+    let rts_dir = state_dir.join("rts");
+    let entries = std::fs::read_dir(&rts_dir).ok()?;
+    for e in entries.flatten() {
+        let candidate = e.path().join("db.redb");
+        if let Ok(meta) = candidate.metadata() {
+            if meta.is_file() {
+                return Some(meta.len());
+            }
+        }
+    }
+    None
+}
+
+/// Default target LOC for the footprint bench.
+pub const DEFAULT_TARGET_LOC: usize = 100_000;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn ps_rss_for_current_process_is_nonzero() {
+        // `std::process::id()` returns the test process's PID. ps must
+        // be on PATH on Unix CI runners (it is on both macOS and
+        // ubuntu-latest).
+        let pid = std::process::id();
+        let rss = ps_rss_bytes(pid).expect("ps -o rss= should work for current pid");
+        assert!(
+            rss > 0,
+            "expected nonzero RSS for current process; got {rss}"
+        );
+        // Sanity: tests don't usually exceed 4 GiB.
+        assert!(rss < 4u64 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn locate_index_size_finds_db_redb() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nested = tmp.path().join("rts").join("ws-abc123");
+        fs::create_dir_all(&nested).unwrap();
+        let db = nested.join("db.redb");
+        fs::write(&db, vec![0u8; 4096]).unwrap();
+        let sz = locate_index_size(tmp.path()).expect("should find db.redb");
+        assert_eq!(sz, 4096);
+    }
+
+    #[test]
+    fn locate_index_size_returns_none_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(locate_index_size(tmp.path()).is_none());
+        // Even if rts/ exists but no db.redb inside.
+        fs::create_dir_all(tmp.path().join("rts").join("ws-empty")).unwrap();
+        assert!(locate_index_size(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn report_serializes_with_stable_field_names() {
+        let r = FootprintReport {
+            version: 1,
+            rts_bench_version: "0.0.0-test".into(),
+            workspace_path: "/tmp/ws".into(),
+            synth_loc: 1000,
+            files: 17,
+            symbols: 170,
+            build_time_ms: 1234,
+            full_index_time_ms: 5678,
+            peak_rss_bytes: 50_000_000,
+            index_size_bytes: 1_000_000,
+            bytes_per_symbol: 5_882,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        // The names below are the wire contract that operators write
+        // dashboards against — keep them stable across bench-tool
+        // versions.
+        for needle in [
+            "\"version\":1",
+            "\"workspace_path\":",
+            "\"build_time_ms\":1234",
+            "\"full_index_time_ms\":5678",
+            "\"peak_rss_bytes\":50000000",
+            "\"index_size_bytes\":1000000",
+            "\"bytes_per_symbol\":5882",
+            "\"files\":17",
+            "\"symbols\":170",
+        ] {
+            assert!(json.contains(needle), "missing `{needle}` in {json}");
+        }
+    }
+
+    #[test]
+    fn linux_vm_hwm_is_optional() {
+        // On macOS this returns None and that's expected. On Linux
+        // it should return Some for the current pid. Either way, the
+        // call must not panic — that's all we assert.
+        let pid = std::process::id();
+        let _ = linux_vm_hwm_bytes(pid);
+    }
+
+    #[test]
+    fn extract_files_considered_reads_field() {
+        use crate::mcp_runner::McpCall;
+        let call = McpCall {
+            tokens: 0,
+            content_items: 1,
+            response_text_len: 0,
+            elapsed_ms: 0,
+            is_error: false,
+            result_body: Some(serde_json::json!({
+                "outline_text": "...",
+                "files_considered": 42
+            })),
+        };
+        assert_eq!(extract_files_considered(&call), Some(42));
+    }
+
+    #[test]
+    fn extract_files_considered_returns_none_when_missing() {
+        use crate::mcp_runner::McpCall;
+        let call = McpCall {
+            tokens: 0,
+            content_items: 0,
+            response_text_len: 0,
+            elapsed_ms: 0,
+            is_error: false,
+            result_body: None,
+        };
+        assert!(extract_files_considered(&call).is_none());
+
+        let call2 = McpCall {
+            tokens: 0,
+            content_items: 0,
+            response_text_len: 0,
+            elapsed_ms: 0,
+            is_error: false,
+            result_body: Some(serde_json::json!({ "other": "value" })),
+        };
+        assert!(extract_files_considered(&call2).is_none());
+    }
+}

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -19,6 +19,7 @@ use serde_json::json;
 
 mod baseline;
 mod corpus;
+mod footprint;
 mod latency;
 mod mcp_runner;
 mod report;
@@ -66,6 +67,21 @@ enum Cmd {
         /// seed.
         #[arg(long, default_value_t = 0xC0FFEE_u64)]
         seed: u64,
+        /// Where to write the JSON report.
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Skip writing the report.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Footprint benchmark (S3): build time, peak RSS, on-disk index
+    /// size on a synthetic workspace. Companion to `latency` for the
+    /// "is this production-ready?" question.
+    Footprint {
+        /// Total lines of synthetic Rust source to generate. Defaults
+        /// to 100,000 per plan §P9.
+        #[arg(long, default_value_t = footprint::DEFAULT_TARGET_LOC)]
+        synth_loc: usize,
         /// Where to write the JSON report.
         #[arg(long)]
         out: Option<PathBuf>,
@@ -166,6 +182,64 @@ async fn main() -> Result<()> {
             out,
             dry_run,
         } => run_latency(synth_loc, queries, cold_count, seed, out, dry_run).await,
+        Cmd::Footprint {
+            synth_loc,
+            out,
+            dry_run,
+        } => run_footprint(synth_loc, out, dry_run).await,
+    }
+}
+
+async fn run_footprint(synth_loc: usize, out: Option<PathBuf>, dry_run: bool) -> Result<()> {
+    let rts_mcp_bin = resolve_bin("rts-mcp")?;
+    let rts_daemon_bin = resolve_bin("rts-daemon")?;
+
+    // Workspace-scoped tmpdir for both the synth fixture and the
+    // daemon's runtime/state dirs — matches the latency bench so a
+    // local `footprint` and `latency` run don't share state.
+    let tmp_root = tempfile::tempdir().context("tempdir for footprint run")?;
+    let report = footprint::run(&rts_mcp_bin, &rts_daemon_bin, synth_loc, tmp_root.path()).await?;
+
+    println!(
+        "footprint: workspace={} files={} symbols={}",
+        report.workspace_path, report.files, report.symbols,
+    );
+    println!(
+        "  build_time={}ms full_index={}ms peak_rss={} index_size={} bytes/symbol={}",
+        report.build_time_ms,
+        report.full_index_time_ms,
+        human_bytes(report.peak_rss_bytes),
+        human_bytes(report.index_size_bytes),
+        report.bytes_per_symbol,
+    );
+
+    if dry_run {
+        return Ok(());
+    }
+    let out_path = out.unwrap_or_else(|| {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(format!("bench-footprint-{}.json", git_short_sha()))
+    });
+    footprint::write_report(&out_path, &report)?;
+    println!("wrote {}", out_path.display());
+    Ok(())
+}
+
+/// Compact "1.2 MiB" style for the bench summary line. Operator-facing
+/// only; the JSON report keeps raw bytes for downstream dashboards.
+fn human_bytes(n: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = KIB * 1024;
+    const GIB: u64 = MIB * 1024;
+    if n >= GIB {
+        format!("{:.2} GiB", n as f64 / GIB as f64)
+    } else if n >= MIB {
+        format!("{:.2} MiB", n as f64 / MIB as f64)
+    } else if n >= KIB {
+        format!("{:.2} KiB", n as f64 / KIB as f64)
+    } else {
+        format!("{n} B")
     }
 }
 

--- a/crates/rts-bench/src/mcp_runner.rs
+++ b/crates/rts-bench/src/mcp_runner.rs
@@ -33,6 +33,11 @@ pub struct McpCall {
     pub elapsed_ms: u128,
     /// `result.isError` from the response, if present.
     pub is_error: bool,
+    /// Parsed JSON body of the first `Content::text` item, when it
+    /// decoded as a JSON object. Consumers (e.g. the footprint bench
+    /// polling `outline_workspace.files_considered`) reach into this
+    /// directly. `None` for non-JSON bodies or empty responses.
+    pub result_body: Option<Value>,
 }
 
 /// Result of an MCP retrieval session — n tool calls plus the workspace
@@ -188,6 +193,7 @@ impl McpSession {
             response_text_len: 0,
             elapsed_ms: start.elapsed().as_millis(),
             is_error: true,
+            result_body: None,
         }))
     }
 
@@ -196,6 +202,13 @@ impl McpSession {
         drop(self.stdin);
         let _ = tokio::time::timeout(Duration::from_secs(5), self.child.wait()).await;
         Ok(())
+    }
+
+    /// PID of the spawned `rts-mcp` child. Returns `None` if the child
+    /// already exited. The footprint bench uses this to walk down to
+    /// the `rts-daemon` grandchild via `pgrep -P`.
+    pub fn child_pid(&self) -> Option<u32> {
+        self.child.id()
     }
 }
 
@@ -218,11 +231,15 @@ fn parse_tools_call_response(resp: &Value, elapsed_ms: u128) -> McpCall {
         .unwrap_or_default();
     let mut tokens: u64 = 0;
     let mut response_text_len: usize = 0;
-    for item in &content {
+    let mut result_body: Option<Value> = None;
+    for (i, item) in content.iter().enumerate() {
         if let Some(text) = item["text"].as_str() {
             response_text_len += text.len();
             // Prefer the daemon's reported `tokens_returned` when present.
             if let Ok(parsed) = serde_json::from_str::<Value>(text) {
+                if i == 0 && parsed.is_object() {
+                    result_body = Some(parsed.clone());
+                }
                 if let Some(t) = parsed["tokens_returned"].as_u64() {
                     tokens += t;
                     continue;
@@ -237,6 +254,7 @@ fn parse_tools_call_response(resp: &Value, elapsed_ms: u128) -> McpCall {
         response_text_len,
         elapsed_ms,
         is_error,
+        result_body,
     }
 }
 

--- a/crates/rts-bench/tests/footprint_smoke.rs
+++ b/crates/rts-bench/tests/footprint_smoke.rs
@@ -1,0 +1,138 @@
+//! Smoke test for `rts-bench footprint`. Runs the harness end-to-end
+//! on a tiny synth fixture and verifies the report shape. Not a
+//! footprint test — actual RSS/index-size numbers are
+//! workload-dependent and not asserted beyond "nonzero where the
+//! sampler had a chance to fire".
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use tokio::process::Command;
+
+fn rts_bench_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-bench"))
+}
+
+fn sibling(name: &str) -> PathBuf {
+    let me = rts_bench_bin();
+    me.parent().expect("CARGO_BIN_EXE has parent").join(name)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn footprint_report_has_expected_shape() -> Result<()> {
+    let out_dir = tempfile::tempdir()?;
+    let report_path = out_dir.path().join("bench-footprint-test.json");
+
+    let rts_mcp_bin = sibling("rts-mcp");
+    let rts_daemon_bin = sibling("rts-daemon");
+    assert!(rts_mcp_bin.is_file(), "missing {}", rts_mcp_bin.display());
+    assert!(
+        rts_daemon_bin.is_file(),
+        "missing {}",
+        rts_daemon_bin.display()
+    );
+
+    let status = Command::new(rts_bench_bin())
+        .arg("footprint")
+        .arg("--synth-loc")
+        .arg("1000")
+        .arg("--out")
+        .arg(&report_path)
+        .env("RTS_MCP_BIN", &rts_mcp_bin)
+        .env("RTS_DAEMON_BIN", &rts_daemon_bin)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .context("spawn rts-bench footprint")?;
+    let stdout = String::from_utf8_lossy(&status.stdout);
+    let stderr = String::from_utf8_lossy(&status.stderr);
+    assert!(
+        status.status.success(),
+        "rts-bench footprint failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let bytes = tokio::time::timeout(Duration::from_secs(2), tokio::fs::read(&report_path))
+        .await
+        .context("timeout waiting for report")??;
+    let report: Value = serde_json::from_slice(&bytes)?;
+
+    // Wire-stable scalar fields.
+    assert_eq!(report["version"], 1, "report version");
+    assert_eq!(report["synth_loc"], 1000);
+    assert!(report["workspace_path"].is_string());
+    assert!(report["rts_bench_version"].is_string());
+
+    // File / symbol counts must be positive — the synth fixture
+    // generates at least one file with at least one symbol.
+    let files = report["files"].as_u64().expect("files should be a u64");
+    let symbols = report["symbols"].as_u64().expect("symbols should be a u64");
+    assert!(files >= 2, "expected at least 2 synth files; got {files}");
+    assert!(symbols >= 10, "expected many synth symbols; got {symbols}");
+
+    // build_time_ms is set on every run (the probe call is the
+    // gating signal).
+    let build = report["build_time_ms"]
+        .as_u64()
+        .expect("build_time_ms should be a u64");
+    // No upper bound — slow CI runners are real — but it should be
+    // observable.
+    assert!(build < 60_000, "build_time_ms = {build} suggests a hang");
+
+    // full_index_time_ms should be >= build_time_ms; the writer keeps
+    // ingesting files after the first symbol becomes queryable.
+    let full = report["full_index_time_ms"]
+        .as_u64()
+        .expect("full_index_time_ms should be a u64");
+    assert!(
+        full >= build,
+        "full_index_time_ms ({full}) should be >= build_time_ms ({build})"
+    );
+    assert!(
+        full < 120_000,
+        "full_index_time_ms = {full} suggests a hang"
+    );
+
+    // index_size_bytes should be nonzero once the writer commits the
+    // initial walk. The probe call only returns OK after that commit.
+    let idx = report["index_size_bytes"]
+        .as_u64()
+        .expect("index_size_bytes should be a u64");
+    assert!(
+        idx > 0,
+        "index_size_bytes should be nonzero after writer commits; got {idx}"
+    );
+
+    // peak_rss_bytes is best-effort. On CI the pgrep-driven walk can
+    // miss the daemon PID if process trees flap; treat zero as
+    // acceptable, but if it *did* sample, it must look plausible
+    // (≥ 1 MiB, < 4 GiB).
+    let rss = report["peak_rss_bytes"]
+        .as_u64()
+        .expect("peak_rss_bytes should be a u64");
+    if rss > 0 {
+        assert!(
+            (1 << 20..4u64 << 30).contains(&rss),
+            "peak_rss_bytes = {rss} looks implausible"
+        );
+    }
+
+    // Derived ratio matches the raw numbers (off-by-one OK because of
+    // integer division).
+    let bps = report["bytes_per_symbol"]
+        .as_u64()
+        .expect("bytes_per_symbol should be a u64");
+    if symbols > 0 {
+        let expected = idx / symbols;
+        assert_eq!(
+            bps, expected,
+            "bytes_per_symbol = {bps}, expected {expected} ({idx} / {symbols})"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds the **footprint** subcommand to \`rts-bench\` — companion to alpha.19's latency bench. Together they answer "is this daemon production-ready for my repo size?".

Measures four numbers an operator cares about:

| metric              | meaning                                                                                | target (100k LOC) | measured (M-series macOS) |
|---------------------|----------------------------------------------------------------------------------------|------------------:|--------------------------:|
| \`build_time_ms\`     | mount → first \`find_symbol\` returns OK (time agent waits before queries work)          |          < 30 000 |                       196 |
| \`full_index_time_ms\`| mount → writer quiet (\`outline.files_considered\` stops growing)                       |        (new field)|                       610 |
| \`peak_rss_bytes\`    | high-water-mark RSS of \`rts-daemon\` across the full window                            |             < 1GB |                   19.2 MiB |
| \`index_size_bytes\`  | \`db.redb\` size after the writer settles                                               |           < 200MB |                    1.5 MiB |

All four numbers crush the plan's targets by orders of magnitude.

## Why two time fields

Initial implementation only had \`build_time_ms\` (mount → first-query-ok). I caught a measurement bug during dev: at 100k LOC peak RSS was *lower* than at 10k LOC (16.9 MiB vs 18.8 MiB), because the harness stopped sampling sooner on the bigger fixture even though the daemon kept indexing in the background.

Fix: \`wait_for_index_settled()\` polls \`outline_workspace.files_considered\` until two consecutive 200ms checks return the same number. The sampler now runs across the full mount → settled window, and peak RSS at 100k LOC jumped from 16.9 → 19.2 MiB — correctly reflecting the true high-water mark.

\`build_time_ms\` and \`full_index_time_ms\` measure different things and both belong in the report:
- \`build_time_ms\` is what an agent waits before queries work (startup latency)
- \`full_index_time_ms\` is when the writer is done with the initial walk (operator metric for capacity planning)

## RSS measurement portability

- **All Unix:** \`ps -o rss= -p <pid>\` (kilobytes; converted to bytes)
- **Linux only:** \`/proc/<pid>/status:VmHWM\` (kernel-tracked peak; takes the max of sampler + HWM)

\`pgrep -P <mcp_pid>\` walks down from the \`rts-mcp\` child to find the \`rts-daemon\` grandchild. Best-effort with a 500ms retry window — if pgrep is unavailable or no daemon match is found, peak RSS reports 0 and the rest of the metrics still ship.

## Changes

- **\`crates/rts-bench/src/footprint.rs\`** (new): \`FootprintReport\` wire shape, \`run()\` orchestrator, peak-RSS sampler loop, \`pgrep\` daemon PID discovery, \`/proc\` VmHWM fallback, \`db.redb\` locator, \`wait_for_index_settled\` poll loop, 7 unit tests
- **\`crates/rts-bench/src/main.rs\`**: \`Cmd::Footprint\` variant + \`run_footprint\` + \`human_bytes\` summary helper
- **\`crates/rts-bench/src/mcp_runner.rs\`**: \`McpCall.result_body: Option<Value>\` (parsed JSON of first content item) for callers that need response fields beyond \`tokens_returned\`; \`McpSession::child_pid()\` for process-tree walking
- **\`crates/rts-bench/tests/footprint_smoke.rs\`** (new): end-to-end smoke that exercises the harness on a 1000-LOC fixture and verifies the wire-stable shape, including the \`full_index_time_ms >= build_time_ms\` invariant

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\`: **486 passed, 0 failed, 3 ignored** (was 478 in alpha.20; +7 footprint unit tests + 1 smoke test)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets\`: no new warnings on changed files
- [x] Manual: \`rts-bench footprint --synth-loc 100000\` produces the numbers in the table above
- [x] Manual: \`rts-bench footprint --synth-loc 10000\` produces a smaller-scale check (build_time=~1s, peak_rss=~19 MiB)

## Post-Deploy Monitoring & Validation

- **What to monitor:**
  - Bench CI runs of \`rts-bench footprint\` against pinned fixtures (once corpus.lock download pipeline lands)
  - The four wire-stable fields in \`bench-footprint-<sha>.json\` reports
- **Expected healthy behavior on real repos:**
  - \`build_time_ms\` scales linearly with file count, well under 30s for repos up to 1M LOC
  - \`peak_rss_bytes\` grows sub-linearly with symbol count; should stay under 1 GiB for 1M-symbol repos
  - \`full_index_time_ms\` is 2–10× \`build_time_ms\` (writer keeps working after first query OK)
- **Failure signals:**
  - \`full_index_time_ms == 60000\` ceiling hit → writer hang or memory exhaustion; investigate via \`ps\` and the daemon's tracing log
  - \`peak_rss_bytes\` > 1 GiB on < 100k LOC fixture → regression in the writer's batch sizing
  - \`peak_rss_bytes == 0\` consistently → \`pgrep\` not available on the runner; falls through gracefully but the metric is gone
- **Rollback:** revert this commit; no schema or wire-format changes outside the bench tool itself
- **Validation window:** first 24h after merge, then on every \`rts-bench\` invocation
- **Owner:** me@njf.io

🤖 Generated with Claude Opus 4.6 (1M context) via Claude Code + Compound Engineering v2.49.0