### PR TITLE
feat(release): 0.2.0-alpha.23 — P9 prebuilt-binaries workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,215 @@
+# Release workflow — publishes prebuilt tarballs for the v0.2 daemon
+# stack so users can install without a Rust toolchain.
+#
+# Triggers:
+#   - push tag `v*`     → real release; uploads tarballs as a draft
+#                          (so the maintainer can spot-check before
+#                          flipping to "published" via the UI).
+#   - workflow_dispatch  → manual run from the Actions tab; useful for
+#                          dry-running the build matrix on a feature
+#                          branch before tagging.
+#
+# Coverage:
+#   - x86_64-unknown-linux-gnu     (ubuntu-latest, native)
+#   - aarch64-unknown-linux-gnu    (ubuntu-24.04-arm, native)
+#   - x86_64-apple-darwin          (macos-13, native Intel)
+#   - aarch64-apple-darwin         (macos-latest, native M-series)
+#
+# Windows is intentionally out — the daemon uses `std::os::unix` (Unix
+# sockets + permissions) and the watcher's fs path is inotify/fsevents.
+# A Windows port is a separate v1.x slice.
+#
+# Each matrix entry produces one tarball:
+#   rts-${VERSION}-${TARGET}.tar.gz
+# containing:
+#   rts-${VERSION}-${TARGET}/
+#     rts-daemon, rts-mcp, rts-bench,
+#     LICENSE-MIT, LICENSE-APACHE, README.md
+#
+# SHA256SUMS file aggregates checksums for all tarballs. The upload step
+# uses softprops/action-gh-release@v2 which creates the release on first
+# matrix entry and appends assets for subsequent entries.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build artifacts but skip the GitHub release upload"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write  # required to create/upload to GitHub Releases
+
+env:
+  CARGO_TERM_COLOR: always
+  # Strip debug symbols from release binaries for ~30% smaller artifacts.
+  # Operators tarball this onto end-user laptops; debug syms are dead
+  # weight unless they're running gdb against the daemon, which is rare.
+  CARGO_PROFILE_RELEASE_STRIP: "symbols"
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false  # one target failing shouldn't kill the others
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive_ext: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            archive_ext: tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            archive_ext: tar.gz
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            archive_ext: tar.gz
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo/target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          # Cache key is per-target so cross-target builds don't poison
+          # each other's `target/` directories.
+          key: ${{ matrix.target }}-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.target }}-release-
+
+      - name: Build release binaries
+        run: |
+          cargo build \
+            --release \
+            --target ${{ matrix.target }} \
+            -p rts-daemon \
+            -p rts-mcp \
+            -p rts-bench
+
+      - name: Smoke test built binaries
+        # Confirm each binary built, is executable, and reports the
+        # expected `<name> <semver>` shape via `--version`. Catches
+        # the "binary built but won't run on this libc" failure mode
+        # before we ship the tarball to a real user.
+        run: |
+          set -euo pipefail
+          BIN_DIR="target/${{ matrix.target }}/release"
+          for b in rts-daemon rts-mcp rts-bench; do
+            test -x "$BIN_DIR/$b" || (echo "missing $b"; exit 1)
+            file "$BIN_DIR/$b"
+            out=$("$BIN_DIR/$b" --version)
+            echo "$out"
+            # Sanity: starts with the binary name. Catches a silent
+            # accidental wire-format change in --version.
+            echo "$out" | grep -q "^$b " || (echo "unexpected version output: $out"; exit 1)
+          done
+
+      - name: Resolve version
+        id: version
+        # On tag push: use the tag (e.g. `v0.2.0-alpha.23` → `0.2.0-alpha.23`).
+        # On workflow_dispatch: use the workspace version + short SHA so
+        # multiple dry-runs don't collide.
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            v="${GITHUB_REF_NAME#v}"
+          else
+            base=$(grep -m1 '^version' Cargo.toml | head -1 | sed -E 's/.*"(.*)".*/\1/')
+            v="${base}-dev.$(git rev-parse --short HEAD)"
+          fi
+          echo "value=$v" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $v"
+
+      - name: Package tarball
+        id: package
+        run: |
+          set -euo pipefail
+          V="${{ steps.version.outputs.value }}"
+          T="${{ matrix.target }}"
+          STAGE="rts-${V}-${T}"
+          BIN_DIR="target/${T}/release"
+          mkdir -p "$STAGE"
+          cp "$BIN_DIR/rts-daemon" "$BIN_DIR/rts-mcp" "$BIN_DIR/rts-bench" "$STAGE/"
+          cp LICENSE-MIT LICENSE-APACHE README.md "$STAGE/"
+          tar -czf "${STAGE}.tar.gz" "$STAGE"
+          # Per-artifact SHA256 to a sidecar file the aggregate step
+          # collects below.
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${STAGE}.tar.gz" > "${STAGE}.tar.gz.sha256"
+          else
+            shasum -a 256 "${STAGE}.tar.gz" > "${STAGE}.tar.gz.sha256"
+          fi
+          echo "tarball=${STAGE}.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "checksum=${STAGE}.tar.gz.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact (always — workflow_dispatch consumes these too)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: |
+            ${{ steps.package.outputs.tarball }}
+            ${{ steps.package.outputs.checksum }}
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload to GitHub release (tag push only)
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          # `draft: true` is deliberate — the maintainer flips to
+          # published after spot-checking each artifact. Prevents an
+          # accidental tag from publishing broken binaries.
+          draft: true
+          files: |
+            ${{ steps.package.outputs.tarball }}
+            ${{ steps.package.outputs.checksum }}
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+
+  aggregate-checksums:
+    name: Aggregate SHA256SUMS
+    needs: build
+    # Run on tag push so the aggregated SHA256SUMS file lands in the
+    # draft release alongside the individual sidecars. workflow_dispatch
+    # skips this — it's only relevant for actual releases.
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all checksums
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Concatenate SHA256SUMS
+        run: |
+          set -euo pipefail
+          find artifacts -name '*.tar.gz.sha256' -print0 \
+            | xargs -0 cat \
+            | sort \
+            > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Upload SHA256SUMS to draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: SHA256SUMS
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,98 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.23] - 2026-05-13
+
+**Prebuilt-binaries release workflow (P9) ships.** Tagging `v*` now
+produces a draft GitHub release with cross-platform tarballs for the
+v0.2 daemon stack. Users no longer need a Rust toolchain to try the
+agentic-retrieval MCP server.
+
+### Build matrix
+
+All native runners (no `cross` / Docker / QEMU gymnastics):
+
+| target                       | runner            |
+|------------------------------|-------------------|
+| `x86_64-unknown-linux-gnu`   | ubuntu-latest     |
+| `aarch64-unknown-linux-gnu`  | ubuntu-24.04-arm  |
+| `x86_64-apple-darwin`        | macos-13          |
+| `aarch64-apple-darwin`       | macos-latest      |
+
+Windows is intentionally out — the daemon uses `std::os::unix` (Unix
+sockets + permissions) and the watcher's fs path is inotify/fsevents.
+A Windows port is a separate v1.x slice.
+
+Each matrix entry produces one tarball:
+```
+rts-${VERSION}-${TARGET}.tar.gz
+└── rts-${VERSION}-${TARGET}/
+    ├── rts-daemon
+    ├── rts-mcp
+    ├── rts-bench
+    ├── LICENSE-MIT
+    ├── LICENSE-APACHE
+    └── README.md
+```
+
+A separate `aggregate-checksums` job concatenates per-artifact
+`.sha256` sidecars into a single `SHA256SUMS` file on the draft
+release so users can verify with `sha256sum -c SHA256SUMS`.
+
+### Why `draft: true` on the release
+
+The release is created in draft state so the maintainer can spot-check
+each artifact before flipping to "published" via the GitHub UI.
+Prevents an accidental tag from publishing broken binaries to users
+who would otherwise pin against the release URL.
+
+### Added
+
+- **`.github/workflows/release.yml`**: 4-way native build matrix,
+  release-profile build with `CARGO_PROFILE_RELEASE_STRIP=symbols`
+  (~30% smaller artifacts), `--version` smoke test on each built
+  binary, tarball packaging with license files + README, SHA256
+  sidecar per artifact, `softprops/action-gh-release@v2` upload as
+  draft, aggregate `SHA256SUMS` job. Also supports
+  `workflow_dispatch` for dry-run testing before tagging.
+- **`--version` / `-V` flag** on all three binaries:
+  - `rts-daemon`: hand-rolled (`std::env::args().nth(1)`), matches
+    the existing `rts-mcp` zero-clap idiom. Also gained `--help`
+    that documents the env-var-only config surface.
+  - `rts-mcp`: hand-rolled, added next to the existing `--help` arm.
+  - `rts-bench`: clap derive, single attribute (`version` reads
+    `CARGO_PKG_VERSION` automatically).
+  - All three emit `<name> <SEMVER>` — stable wire shape for the
+    release smoke test and operator diagnostics.
+- **README install section**: split "Option A: prebuilt tarballs"
+  vs "Option B: build from source", with a `curl | tar` snippet,
+  per-platform target table, `--version` verification, and a
+  `SHA256SUMS` integrity-check example.
+
+### Not in this slice
+
+- musl-libc static builds for distroless/alpine. Easy to add as a
+  fifth matrix entry once we have a user asking — current entries
+  cover glibc-2.31+ which is wide enough for "regular Linux".
+- Windows port — daemon's Unix-only deps need a separate refactor.
+- Auto-publish (vs draft). The maintainer-in-the-loop check is the
+  right default for an alpha line; we can flip to auto-publish at
+  v1.0.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **491 passed, 0 failed, 3 ignored**
+  (unchanged from alpha.22 — pure-tooling slice).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: **91 warnings** (was
+  92 in alpha.22; the `while let` → `if let` fix on the daemon's
+  arg parser closed one).
+- Manual `--version` smoke against all three local release binaries
+  passes; `--help` documents the env-var surface for the daemon.
+- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
+  validates the workflow YAML.
+
 ## [0.2.0-alpha.22] - 2026-05-13
 
 **`Index.ReadSymbol` closure walker ships.** The `include_dependencies: true`

--- a/README.md
+++ b/README.md
@@ -65,8 +65,50 @@ binary release).
 The MCP server auto-spawns the daemon on first connect. There is no
 daemon for the user to start by hand.
 
+### Option A: prebuilt tarballs (no Rust toolchain required)
+
+Released on tag push under [Releases](https://github.com/njfio/rs-agent-code-utility/releases).
+Each tarball contains `rts-daemon`, `rts-mcp`, `rts-bench`, both
+license files, and this README. Available targets:
+
+| target | runner |
+|---|---|
+| `x86_64-unknown-linux-gnu` | most Linux distros (Ubuntu 20.04+, Debian 11+, RHEL 9+) |
+| `aarch64-unknown-linux-gnu` | ARM Linux (Raspberry Pi 64-bit, AWS Graviton) |
+| `x86_64-apple-darwin` | Intel Mac |
+| `aarch64-apple-darwin` | Apple Silicon Mac |
+
+Windows is not yet supported — the daemon uses Unix sockets (a Windows
+port lands in v1.x).
+
 ```sh
-# Build
+# Pick the right target for your platform
+VERSION=0.2.0-alpha.23
+TARGET=aarch64-apple-darwin
+URL="https://github.com/njfio/rs-agent-code-utility/releases/download/v${VERSION}/rts-${VERSION}-${TARGET}.tar.gz"
+
+curl -fsSL "$URL" | tar -xz
+sudo install rts-${VERSION}-${TARGET}/{rts-daemon,rts-mcp,rts-bench} /usr/local/bin/
+
+# Verify (each binary's `--version` should print `<name> ${VERSION}`)
+rts-daemon --version
+rts-mcp    --version
+rts-bench  --version
+
+# Wire into Claude Code
+claude mcp add rts -- rts-mcp --workspace .
+```
+
+Each release ships a `SHA256SUMS` file you can verify against:
+
+```sh
+curl -fsSL "https://github.com/njfio/rs-agent-code-utility/releases/download/v${VERSION}/SHA256SUMS" -o SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+### Option B: build from source
+
+```sh
 cargo build --workspace --release
 
 # Wire into Claude Code (the canonical client)

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -31,7 +31,11 @@ use report::BenchReport;
 use tasks::{TaskContext, TaskOutcome, run_task};
 
 #[derive(Parser, Debug)]
-#[command(name = "rts-bench", about = "Bench harness for the rts-mcp stack")]
+#[command(
+    name = "rts-bench",
+    version, // clap reads CARGO_PKG_VERSION; wires up `--version`/`-V`
+    about = "Bench harness for the rts-mcp stack"
+)]
 struct Cli {
     #[command(subcommand)]
     cmd: Cmd,

--- a/crates/rts-daemon/src/main.rs
+++ b/crates/rts-daemon/src/main.rs
@@ -32,6 +32,47 @@ use tracing::{error, info};
 /// multi-thread.
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
+    // Cheap CLI flags handled before any setup — operators running
+    // `rts-daemon --version` shouldn't pay tracing/preflight cost.
+    // No `clap` dep: two flags, two arms.
+    // The daemon takes no positional args. We accept exactly one
+    // optional flag (--version / --help / -V / -h); anything else is
+    // an error. Looking at only `args.nth(1)` is intentional — there's
+    // no flag that takes a value, so any second arg is ambiguous.
+    if let Some(a) = std::env::args().nth(1) {
+        match a.as_str() {
+            "--version" | "-V" => {
+                // Wire shape: `rts-daemon <SEMVER>`. Stable so the
+                // release-build smoke test + operator diagnostics
+                // (`which rts-daemon; rts-daemon --version`) can parse
+                // it unambiguously.
+                println!("rts-daemon {}", env!("CARGO_PKG_VERSION"));
+                return Ok(());
+            }
+            "--help" | "-h" => {
+                eprintln!(
+                    "rts-daemon — persistent local code-retrieval daemon for AI coding agents."
+                );
+                eprintln!();
+                eprintln!("Usage: rts-daemon");
+                eprintln!();
+                eprintln!(
+                    "The daemon takes no positional arguments. All configuration is via env:"
+                );
+                eprintln!("  RTS_LOG                  tracing filter; defaults to `info`.");
+                eprintln!("  RTS_IDLE_SHUTDOWN_SECS   idle window before self-exit; default 600.");
+                eprintln!(
+                    "  XDG_RUNTIME_DIR / HOME   socket location (per platform XDG fallback)."
+                );
+                eprintln!("  XDG_STATE_HOME           index DB location (defaults under $HOME).");
+                return Ok(());
+            }
+            other => {
+                anyhow::bail!("unknown argument: {other}");
+            }
+        }
+    }
+
     // Stderr-only tracing (stdout is reserved for the MCP server, never the
     // daemon — but it costs nothing to also forbid stdout writes here).
     tracing_subscriber::fmt()

--- a/crates/rts-mcp/src/main.rs
+++ b/crates/rts-mcp/src/main.rs
@@ -52,6 +52,13 @@ fn parse_args() -> Result<Args> {
                 eprintln!("  RTS_LOG         tracing filter; defaults to `rts_mcp=info,warn`.");
                 std::process::exit(0);
             }
+            "--version" | "-V" => {
+                // Stable wire shape for the release-bench smoke test
+                // and `which rts-mcp; rts-mcp --version` diagnostics:
+                // `rts-mcp <SEMVER>`.
+                println!("rts-mcp {}", env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
             other => {
                 anyhow::bail!("unknown argument: {other}");
             }


### PR DESCRIPTION
## Summary

Tagging \`v*\` now produces a draft GitHub release with cross-platform tarballs. Users no longer need a Rust toolchain to try the agentic-retrieval MCP server.

### Build matrix

All native runners — no \`cross\` / Docker / QEMU gymnastics:

| target                       | runner            |
|------------------------------|-------------------|
| \`x86_64-unknown-linux-gnu\`   | ubuntu-latest     |
| \`aarch64-unknown-linux-gnu\`  | ubuntu-24.04-arm  |
| \`x86_64-apple-darwin\`        | macos-13          |
| \`aarch64-apple-darwin\`       | macos-latest      |

Windows is intentionally out — the daemon uses \`std::os::unix\` (Unix sockets + permissions) and the watcher's fs path is inotify/fsevents. A Windows port is a separate v1.x slice.

### Tarball shape

```
rts-\${VERSION}-\${TARGET}.tar.gz
└── rts-\${VERSION}-\${TARGET}/
    ├── rts-daemon
    ├── rts-mcp
    ├── rts-bench
    ├── LICENSE-MIT
    ├── LICENSE-APACHE
    └── README.md
```

Plus a single \`SHA256SUMS\` file aggregating per-artifact checksums (\`sha256sum -c SHA256SUMS\`).

### Why \`draft: true\`

Releases ship as drafts so the maintainer can spot-check each artifact before flipping to "published" via the UI. Prevents an accidental tag from publishing broken binaries to users who would otherwise pin against the release URL. We can flip to auto-publish at v1.0.

## Changes

- **\`.github/workflows/release.yml\`** (new): 4-way native matrix, release-profile build with \`CARGO_PROFILE_RELEASE_STRIP=symbols\` (~30% smaller artifacts), \`--version\` smoke test on each binary, tarball packaging with license files + README, SHA256 sidecars, \`softprops/action-gh-release@v2\` upload as draft, aggregate \`SHA256SUMS\` job. Also supports \`workflow_dispatch\` for dry-run testing before tagging
- **\`--version\` / \`-V\` flag on all three binaries:**
  - \`rts-daemon\`: hand-rolled \`std::env::args().nth(1)\` (matches existing \`rts-mcp\` zero-clap idiom). Also gained a \`--help\` that documents the env-var-only config surface
  - \`rts-mcp\`: hand-rolled, added next to existing \`--help\` arm
  - \`rts-bench\`: clap \`version\` attribute (auto-reads \`CARGO_PKG_VERSION\`)
  - Stable wire shape: \`<name> <SEMVER>\` — the workflow smoke step \`grep -q\`s this to catch silent regressions
- **\`README.md\`**: install section split into "Option A: prebuilt tarballs" (\`curl | tar\` + per-platform table + SHA256SUMS integrity check) vs "Option B: build from source"

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\`: **491 passed, 0 failed, 3 ignored** (unchanged from alpha.22 — pure-tooling slice; no test surface to add)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets\`: **91 warnings** (was 92 in alpha.22; the \`while let\` → \`if let\` fix on the daemon arg parser closed one)
- [x] \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"\` validates the workflow YAML
- [x] Local smoke: \`target/release/rts-daemon --version\`, \`rts-mcp --version\`, \`rts-bench --version\` all emit \`<name> 0.2.0-alpha.3\`
- [x] Local smoke: \`target/release/rts-daemon junk\` exits 1 with \`Error: unknown argument: junk\`
- [ ] **End-to-end validation requires a tag push.** I will not tag in this PR — that's the merge-then-tag follow-up. The \`workflow_dispatch\` path is wired so we can dry-run the matrix after merge before the first real \`v\` tag

## Post-Deploy Monitoring & Validation

- **What to monitor:**
  - GitHub Actions run for the first \`v*\` tag push — all 4 matrix entries should succeed
  - Draft release artifacts: 4 tarballs + 4 \`.sha256\` sidecars + 1 \`SHA256SUMS\`
  - Tarball sizes: expect ~5-10 MiB per (stripped, all three binaries combined)
- **Validation checks:**
  ```sh
  # After downloading + extracting one tarball:
  ./rts-daemon --version    # → rts-daemon <SEMVER>
  ./rts-mcp --version       # → rts-mcp <SEMVER>
  ./rts-bench --version     # → rts-bench <SEMVER>
  # Or end-to-end against a real workspace:
  claude mcp add rts -- ./rts-mcp --workspace /path/to/repo
  ```
- **Expected healthy behavior:**
  - All 4 matrix entries succeed within ~10-15 min total wall clock
  - \`--version\` smoke step prints \`<name> <SEMVER>\` for each binary
  - Aggregate SHA256SUMS job appends to the draft release without duplicating entries
- **Failure signals:**
  - Matrix entry fails on \`--version\` grep → silent CLI flag breakage; investigate that target's binary
  - \`aarch64-unknown-linux-gnu\` job times out / fails to allocate runner → GH ARM runner quota; rerun
  - Draft release missing files → \`softprops/action-gh-release@v2\` token scope; verify \`permissions: contents: write\` is set
- **Rollback:** the workflow is read-only-on-tag; reverting this PR + deleting the draft release is sufficient
- **Validation window:** first \`v*\` tag push, then weekly on each release
- **Owner:** me@njf.io

🤖 Generated with Claude Opus 4.6 (1M context) via Claude Code + Compound Engineering v2.49.0