### PR TITLE
feat(rts-daemon): 0.2.0-alpha.27 — tags.scm ref extraction (precision upgrade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,107 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.27] - 2026-05-13
+
+**Tags.scm precision upgrade.** Outline + closure walker now use
+tree-sitter's `@reference.*` query captures instead of the regex
+identifier tokenizer for Rust/Python/Go/Ruby. Eliminates false-positive
+deps from local variables that shadow def names, identifier mentions in
+comments, and trait/type-position identifiers that aren't call sites.
+
+### Concrete precision win
+
+The new `closure_walker_excludes_local_shadowing_a_def_name` integration
+test seeds:
+
+```rust
+// hub.rs
+pub fn real_callee(id: u32) -> u32 { id + 1 }
+pub fn decoy_target(id: u32) -> u32 { id + 2 }
+
+// caller.rs — `decoy_target` is a LOCAL, not a call site
+pub fn caller(x: u32) -> u32 {
+    let decoy_target = x.saturating_add(10);  // ← regex would surface this
+    real_callee(decoy_target)                  // ← only this is a real call
+}
+```
+
+Pre-alpha.27: `Index.ReadSymbol(caller, include_dependencies=true)` returned
+`[real_callee, decoy_target]` — the local variable bleed-through.
+
+Post-alpha.27: returns `[real_callee]` only — tree-sitter's
+`@reference.call` capture sees only the actual call expression. The
+local binding `let decoy_target = ...` is correctly ignored.
+
+The win compounds across the closure walker (cleaner agent-facing
+`dependencies` lists) and PageRank-driven outline (files that *call*
+a symbol now outrank files that just *mention* it).
+
+### Scope (v0)
+
+AST-precise reference extraction is wired for **Rust, Python, Go, Ruby**
+— the four languages whose upstream `tree-sitter-*/queries/tags.scm`
+ships clean `@reference.call` (and `@reference.implementation` for Rust)
+captures with `@name` sub-captures.
+
+For **C, C++, Java, JavaScript, TypeScript, PHP, Swift**, upstream
+tags.scm either omits `@reference.*` captures or uses different
+conventions. Those fall through to the existing regex tokenizer —
+**no regression** vs alpha.26. A v1.1 slice adds locally-authored
+query overrides for the remaining languages once a concrete user
+asks.
+
+### Added
+
+- **`crates/rts-daemon/src/refs.rs`** (new):
+  `references_for_path(rel_path, content)` → `Vec<String>` dispatcher,
+  `extract_references(language, content)` core that runs a per-language
+  tags.scm-derived query via `rust_tree_sitter::query::Query`. Inlined
+  query strings (Rust/Python/Go/Ruby) sourced verbatim from upstream
+  tags.scm `@reference.*` blocks. 6 unit tests covering Rust call
+  sites + macros + method calls, Python calls, fallback for unknown
+  extensions, fallback for unsupported-but-recognised languages.
+- **`crates/rts-daemon/tests/closure_precision.rs`** (new): end-to-end
+  integration test asserting the local-variable false positive is
+  dropped. Pins the precision contract — if a future regression makes
+  the closure walker re-surface local-name shadows, this test catches
+  it.
+
+### Changed
+
+- **`crates/rts-daemon/src/closure.rs::compute`** now calls
+  `refs::references_for_path(&anchor.file, anchor_body)` instead of
+  `outline::extract_identifiers(anchor_body)`. The path-driven
+  dispatcher picks tags.scm or regex per file extension; the closure
+  walker doesn't need to know which.
+- **`crates/rts-daemon/src/outline.rs::compute`** does the same swap
+  in the file-level reference loop. PageRank edges now weight call
+  sites, not text-occurring identifiers.
+
+### Not in this slice
+
+- **JS/TS reference queries.** Upstream tags.scm for both doesn't
+  ship `@reference.*` captures; we'd need to author them locally.
+  Worth doing when there's a user asking. v1.1.
+- **C/C++/Java/PHP/Swift reference queries.** Same — upstream
+  conventions vary; defer until concrete need.
+- **Closure walker `mentioned_idents` personalization.** The
+  closure walker's input `anchor_body` is parsed in isolation; we
+  don't yet exploit the cross-file PageRank ranks in dep ordering.
+  v1.1.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **517 passed, 0 failed, 3 ignored** (was
+  510 in alpha.26; +6 unit tests + 1 integration).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: no new hits on changed
+  files (after one local fix: `c.name().as_deref()` → `c.name()`).
+- Manual: existing `outline_round_trip` + `closure_round_trip` +
+  `fuzzy_and_at_round_trip` tests all green; new `closure_precision`
+  test passes locally.
+
 ## [0.2.0-alpha.26] - 2026-05-13
 
 **Daemon CLI mode ships.** Closes the dogfooding-gap for callers that

--- a/crates/rts-daemon/src/closure.rs
+++ b/crates/rts-daemon/src/closure.rs
@@ -106,13 +106,20 @@ pub fn compute(
         Ok(s) => s,
         Err(_) => return ClosureResult::empty(),
     };
+    // Pull references via tags.scm where available (Rust/Python/Go/Ruby
+    // as of alpha.27); fall through to the regex tokenizer for other
+    // languages. Tags.scm precision eliminates false positives from
+    // local-variable shadowing + identifier mentions in comments. The
+    // call-site filter (`@reference.call`) drops trait/type-position
+    // identifiers too, which the regex would have surfaced as deps.
+    let refs = crate::refs::references_for_path(&anchor.file, anchor_body);
     let mut candidates: BTreeSet<String> = BTreeSet::new();
-    for ident in crate::outline::extract_identifiers(anchor_body) {
+    for ident in refs {
         if ident == anchor.name {
             continue; // skip self-reference
         }
-        if all_def_names.contains(ident) {
-            candidates.insert(ident.to_string());
+        if all_def_names.contains(&ident) {
+            candidates.insert(ident);
         }
     }
     if candidates.is_empty() {

--- a/crates/rts-daemon/src/main.rs
+++ b/crates/rts-daemon/src/main.rs
@@ -16,6 +16,7 @@ mod lifecycle;
 mod methods;
 mod outline;
 mod protocol;
+mod refs;
 mod socket;
 mod state;
 mod store;

--- a/crates/rts-daemon/src/outline.rs
+++ b/crates/rts-daemon/src/outline.rs
@@ -176,9 +176,15 @@ pub fn compute(
         }
     }
 
-    // For each file, parse-light: walk its source text and collect
-    // identifier-shaped tokens that match a known def name. Each
-    // (referencer_file → definer_file) becomes an edge.
+    // For each file, parse and pull AST-precise references via
+    // tags.scm (Rust/Python/Go/Ruby) — or the regex tokenizer fallback
+    // for languages without a query. Each (referencer_file →
+    // definer_file) tuple becomes an edge in the PageRank graph.
+    //
+    // The tags.scm path eliminates false-positive edges from local
+    // variables that shadow def names, comment mentions, and
+    // identifier appearances in trait/type bounds. PageRank ranks
+    // files that *call* a symbol over files that *mention* it.
     let mut edges: Vec<Edge> = Vec::new();
     let mut ref_counts: HashMap<(usize, usize, String), u32> = HashMap::new();
     for (src_idx, f) in files.iter().enumerate() {
@@ -187,17 +193,17 @@ pub fn compute(
             Ok(s) => s,
             Err(_) => continue,
         };
-        for ident in extract_identifiers(&content) {
-            if !all_def_names.contains(ident) {
+        for ident in crate::refs::references_for_path(&f.path, &content) {
+            if !all_def_names.contains(&ident) {
                 continue;
             }
-            if let Some(dst_files) = def_map.get(ident) {
+            if let Some(dst_files) = def_map.get(&ident) {
                 for &dst_idx in dst_files {
                     if dst_idx == src_idx {
                         continue;
                     }
                     *ref_counts
-                        .entry((src_idx, dst_idx, ident.to_string()))
+                        .entry((src_idx, dst_idx, ident.clone()))
                         .or_insert(0) += 1;
                 }
             }

--- a/crates/rts-daemon/src/refs.rs
+++ b/crates/rts-daemon/src/refs.rs
@@ -1,0 +1,282 @@
+//! AST-precise reference extraction for outline + closure walker.
+//!
+//! ### What this replaces
+//!
+//! Prior to alpha.27, `outline` and `closure` used a regex tokenizer
+//! (`outline::extract_identifiers`) to pull every `[A-Za-z_][A-Za-z0-9_]*`
+//! run out of a file's text and filter against the workspace-wide
+//! def-name set. That's cheap but noisy:
+//!
+//! - Locals that shadow defined fn names get counted as references
+//! - Identifiers in comments and string literals get counted
+//! - Trait names in generic bounds get counted as if they were calls
+//!
+//! For the closure walker the noise translates directly to junk
+//! entries in the agent-visible `dependencies` list. For outline it
+//! biases PageRank toward files that *mention* a symbol over files
+//! that *call* it.
+//!
+//! ### What this ships
+//!
+//! `extract_references(language, content)` parses `content` with
+//! tree-sitter and runs a per-language tags.scm-derived query that
+//! captures `@name` nodes inside `@reference.*` patterns. The result
+//! is the set of names that are actually *referenced* at call sites,
+//! not just text-occurring.
+//!
+//! ### Scope (v0)
+//!
+//! Tags.scm precision is wired for **Rust, Python, Go, Ruby** — the
+//! four languages whose upstream `tree-sitter-*/queries/tags.scm`
+//! ships clean `@reference.call` (and `@reference.implementation`
+//! for Rust) captures with `@name` sub-captures.
+//!
+//! For the other seven languages (C, C++, Java, JavaScript, TypeScript,
+//! PHP, Swift), the upstream tags.scm either omits `@reference.*`
+//! captures or uses different conventions. Those fall through to the
+//! existing regex tokenizer — **no regression** vs alpha.26. A v1.1
+//! slice adds locally-authored query overrides for the remaining
+//! languages once they have a concrete user asking.
+
+use rust_tree_sitter::{Language, Parser, query::Query};
+
+/// Tree-sitter query: capture `@name` nodes that are the *callee*
+/// identifier in a call expression, the method name in a method call,
+/// the macro name in a macro invocation, or the trait/type in an impl
+/// block. Sourced verbatim from `tree-sitter-rust-0.23.3/queries/tags.scm`,
+/// `@reference.*` subset only.
+const RUST_REFS: &str = r#"
+(call_expression
+    function: (identifier) @name) @reference.call
+
+(call_expression
+    function: (field_expression
+        field: (field_identifier) @name)) @reference.call
+
+(macro_invocation
+    macro: (identifier) @name) @reference.call
+
+(impl_item
+    trait: (type_identifier) @name) @reference.implementation
+
+(impl_item
+    type: (type_identifier) @name
+    !trait) @reference.implementation
+"#;
+
+const PYTHON_REFS: &str = r#"
+(call
+  function: [
+      (identifier) @name
+      (attribute
+        attribute: (identifier) @name)
+  ]) @reference.call
+"#;
+
+const GO_REFS: &str = r#"
+(call_expression
+  function: [
+    (identifier) @name
+    (parenthesized_expression (identifier) @name)
+    (selector_expression field: (field_identifier) @name)
+    (parenthesized_expression (selector_expression field: (field_identifier) @name))
+  ]) @reference.call
+"#;
+
+const RUBY_REFS: &str = r#"
+(call method: (identifier) @name) @reference.call
+"#;
+
+/// Extract the set of *referenced* symbol names from `content` parsed
+/// as `language`. Order is the source-order in which tree-sitter
+/// captures them; callers that need deduplication should collect into
+/// a `HashSet`. Returns `None` when the language has no tags.scm
+/// query — callers fall back to [`crate::outline::extract_identifiers`].
+///
+/// Errors during parse or query construction return `None`; this is a
+/// best-effort precision improvement and the regex fallback is always
+/// available.
+pub(crate) fn extract_references(language: Language, content: &str) -> Option<Vec<String>> {
+    let query_src = match language {
+        Language::Rust => RUST_REFS,
+        Language::Python => PYTHON_REFS,
+        Language::Go => GO_REFS,
+        Language::Ruby => RUBY_REFS,
+        _ => return None,
+    };
+    let parser = Parser::new(language).ok()?;
+    let tree = parser.parse(content, None).ok()?;
+    let query = Query::new(language, query_src).ok()?;
+    let captures = query.captures(&tree).ok()?;
+    let mut out: Vec<String> = Vec::with_capacity(captures.len());
+    for c in captures {
+        // Only `@name` captures are the referenced symbol; the wrapping
+        // `@reference.call` etc. captures are spans, not names.
+        if c.name() == Some("name") {
+            if let Ok(text) = c.node().text() {
+                out.push(text.to_string());
+            }
+        }
+    }
+    Some(out)
+}
+
+/// Heuristic dispatcher used by `outline` + `closure` for each file
+/// they walk. Tries AST-precise extraction first; falls back to the
+/// regex tokenizer for languages without a query.
+///
+/// The fallback path is a stable owned-`Vec<String>` shape so callers
+/// don't have to branch on `Option`. We allocate either way; the
+/// AST-precise path is the win, not the allocation profile.
+pub(crate) fn references_for_path(rel_path: &str, content: &str) -> Vec<String> {
+    let lang = language_for_path(rel_path);
+    if let Some(lang) = lang {
+        if let Some(refs) = extract_references(lang, content) {
+            return refs;
+        }
+    }
+    crate::outline::extract_identifiers(content)
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Path-to-Language mapping. Mirrors the dispatch in
+/// `methods::index::render_signature_for_path` but expressed in terms
+/// of `rust_tree_sitter::Language` rather than the per-language
+/// signature renderer.
+fn language_for_path(rel_path: &str) -> Option<Language> {
+    let ext = std::path::Path::new(rel_path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_ascii_lowercase());
+    match ext.as_deref() {
+        Some("rs") => Some(Language::Rust),
+        Some("py") => Some(Language::Python),
+        Some("go") => Some(Language::Go),
+        Some("rb") | Some("rake") => Some(Language::Ruby),
+        // Languages without an @reference.* query in this slice fall
+        // through. Returning None makes `references_for_path` use the
+        // regex fallback.
+        Some("ts") | Some("tsx") | Some("js") | Some("jsx") | Some("mjs") | Some("cjs") => None,
+        Some("c") | Some("h") => None,
+        Some("cpp") | Some("cc") | Some("cxx") | Some("hpp") | Some("hh") | Some("hxx") => None,
+        Some("java") => None,
+        Some("php") | Some("phtml") => None,
+        Some("swift") => None,
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_references_capture_call_sites_only() {
+        // `target_fn` is referenced inside the body (a call). `local_var`
+        // is a local — the regex tokenizer would include it; tags.scm
+        // does not.
+        let src = "\
+fn caller() {
+    let local_var = 0;
+    target_fn(local_var);
+}";
+        let refs = extract_references(Language::Rust, src).expect("rust has a query");
+        assert!(
+            refs.contains(&"target_fn".to_string()),
+            "expected target_fn (call site); got {refs:?}"
+        );
+        assert!(
+            !refs.contains(&"local_var".to_string()),
+            "local_var is not a call site; got {refs:?}"
+        );
+        assert!(
+            !refs.contains(&"caller".to_string()),
+            "caller is a def, not a ref; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn rust_references_pick_up_macros_and_method_calls() {
+        let src = "\
+fn caller() {
+    let s = String::new();
+    println!(\"{}\", s);
+    s.push_str(\"x\");
+}";
+        let refs = extract_references(Language::Rust, src).expect("rust has a query");
+        // String::new is a path-based call — the `function: (identifier)`
+        // capture matches `new` (the call target is a scoped identifier
+        // path, but the field/method ident is `new`).
+        // The macro invocation `println!` gets captured.
+        // The method call `push_str` gets captured.
+        // (Different upstream conventions about what gets captured per
+        // call shape — our test asserts the most common cases.)
+        assert!(
+            refs.iter().any(|n| n == "println"),
+            "println! should be captured; got {refs:?}"
+        );
+        assert!(
+            refs.iter().any(|n| n == "push_str"),
+            "push_str method should be captured; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn python_references_capture_calls_only() {
+        let src = "\
+def caller():
+    local = 0
+    target_fn(local)
+    obj.method_name()
+";
+        let refs = extract_references(Language::Python, src).expect("python has a query");
+        assert!(refs.contains(&"target_fn".to_string()));
+        assert!(refs.contains(&"method_name".to_string()));
+        assert!(
+            !refs.contains(&"local".to_string()),
+            "local var should not be a ref; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn references_for_path_falls_back_to_regex_on_unknown_lang() {
+        // .lua is not in our supported set; the fallback regex
+        // tokenizer should return identifier-shaped tokens.
+        let src = "function caller() local x = target_fn(1) end";
+        let refs = references_for_path("script.lua", src);
+        // Regex tokenizer returns ALL identifier-shaped tokens, so
+        // both `caller` and `target_fn` (plus keywords like `function`)
+        // appear. We just assert the fallback didn't crash and
+        // included something.
+        assert!(!refs.is_empty());
+        assert!(refs.iter().any(|s| s == "target_fn"));
+    }
+
+    #[test]
+    fn references_for_path_uses_tags_for_rust() {
+        // Same content as the unit test above, routed through the
+        // path-driven dispatcher.
+        let src = "fn caller() { let local_var = 0; target_fn(local_var); }";
+        let refs = references_for_path("src/lib.rs", src);
+        assert!(refs.iter().any(|n| n == "target_fn"));
+        assert!(
+            !refs.iter().any(|n| n == "local_var"),
+            "rust path should use tags.scm; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn unsupported_language_returns_none_from_extract() {
+        // Java isn't wired in this slice; should return None and let
+        // the dispatcher fall through.
+        // (We can't pass an unsupported Language variant — the enum is
+        // exhaustive — but we can confirm the path-driven dispatcher
+        // routes via the regex.)
+        let src = "public class C { void f() { other(); } }";
+        let refs = references_for_path("X.java", src);
+        // Regex fallback picks up everything, including class/void/etc.
+        // The point is: it returns something non-empty.
+        assert!(!refs.is_empty());
+    }
+}

--- a/crates/rts-daemon/tests/closure_precision.rs
+++ b/crates/rts-daemon/tests/closure_precision.rs
@@ -1,0 +1,200 @@
+//! Integration test for the alpha.27 tags.scm precision upgrade.
+//!
+//! Seeds a workspace where the regex tokenizer would produce a false
+//! positive in the closure walker's dep list (a local variable shadowing
+//! a def name). With tags.scm precision, the local variable is dropped
+//! because tree-sitter sees only the actual call site.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("socket {} never appeared", path.display());
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn closure_walker_excludes_local_shadowing_a_def_name() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // Two files. `hub.rs` defines two pub fns:
+    //   - real_callee (a function `caller` actually calls)
+    //   - decoy_target (a function whose *name* the caller has as a
+    //     local variable, but never invokes)
+    //
+    // Pre-alpha.27 regex tokenizer would pick up `decoy_target` as a
+    // ref from `caller.rs` because the identifier text appears in the
+    // body. Post-alpha.27 tags.scm sees only the call site
+    // `real_callee(...)` — `decoy_target` is a local binding, not a
+    // call.
+    std::fs::write(
+        workspace.path().join("hub.rs"),
+        "pub fn real_callee(id: u32) -> u32 { id + 1 }\n\
+         pub fn decoy_target(id: u32) -> u32 { id + 2 }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("caller.rs"),
+        // The local `let decoy_target = ...` has the same NAME as the
+        // pub fn in hub.rs but is *not* a call. Tags.scm correctly
+        // ignores this — the regex tokenizer would have surfaced it.
+        "pub fn caller(x: u32) -> u32 {\n    \
+         let decoy_target = x.saturating_add(10);\n    \
+         real_callee(decoy_target)\n\
+         }\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount failed: {mount:?}");
+
+    wait_for_symbol(&mut stream, "caller", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "real_callee", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "decoy_target", Duration::from_secs(5)).await?;
+
+    // ReadSymbol with include_dependencies on `caller`.
+    let resp = round_trip(
+        &mut stream,
+        "10",
+        "Index.ReadSymbol",
+        json!({ "name": "caller", "include_dependencies": true }),
+    )
+    .await?;
+    assert!(resp["error"].is_null(), "ReadSymbol failed: {resp:?}");
+
+    let deps = resp["result"]["dependencies"]
+        .as_array()
+        .expect("dependencies array");
+    let dep_names: Vec<&str> = deps
+        .iter()
+        .filter_map(|d| d["qualified_name"].as_str())
+        .collect();
+
+    // PRECISION ASSERTION: real_callee IS a dep (true call site).
+    assert!(
+        dep_names.contains(&"real_callee"),
+        "real_callee should be in deps (true call site); got {dep_names:?}"
+    );
+
+    // PRECISION ASSERTION: decoy_target is NOT a dep (local var with
+    // same name, no call). Pre-alpha.27 regex tokenizer would have
+    // surfaced this. The tags.scm precision upgrade is what drops it.
+    assert!(
+        !dep_names.contains(&"decoy_target"),
+        "decoy_target is a local variable with no call site; should NOT be in deps. got {dep_names:?}"
+    );
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}


### PR DESCRIPTION
## Summary

Outline + closure walker now use tree-sitter's \`@reference.*\` query captures instead of the regex identifier tokenizer for **Rust, Python, Go, Ruby**. Eliminates false-positive deps from local variables that shadow def names, identifier mentions in comments, and trait/type-position identifiers that aren't call sites.

## Concrete precision win

The new \`closure_walker_excludes_local_shadowing_a_def_name\` integration test seeds:

\`\`\`rust
// hub.rs
pub fn real_callee(id: u32) -> u32 { id + 1 }
pub fn decoy_target(id: u32) -> u32 { id + 2 }

// caller.rs — \`decoy_target\` is a LOCAL, not a call site
pub fn caller(x: u32) -> u32 {
    let decoy_target = x.saturating_add(10);  // ← regex tokenizer surfaced this
    real_callee(decoy_target)                  // ← only this is a real call
}
\`\`\`

| | dependencies |
|---|---|
| Pre-alpha.27 | \`[real_callee, decoy_target]\` ← local bleed-through |
| Post-alpha.27 | \`[real_callee]\` ← tree-sitter sees only the call |

The win compounds: **closure walker** gets cleaner agent-facing \`dependencies\` lists; **PageRank-driven outline** now weights files that *call* a symbol over files that just *mention* it.

## Scope

| language | path |
|---|---|
| Rust, Python, Go, Ruby | tags.scm \`@reference.*\` (precision) |
| C, C++, Java, JavaScript, TypeScript, PHP, Swift | regex fallback (no regression) |

Upstream tags.scm for JS/TS doesn't ship \`@reference.*\` captures (only \`@definition.*\`); the others use varying conventions. Locally-authored override queries for those languages are deferred to v1.1 once a concrete user asks. **No language regresses.**

## Changes

- **\`crates/rts-daemon/src/refs.rs\`** (new): \`references_for_path(rel_path, content)\` dispatcher + \`extract_references(language, content)\` core that runs a per-language tags.scm-derived query via \`rust_tree_sitter::query::Query\`. Inlined query strings (Rust/Python/Go/Ruby) sourced verbatim from upstream tags.scm \`@reference.*\` blocks
- **\`closure::compute\`** now calls \`refs::references_for_path(&anchor.file, anchor_body)\` instead of \`outline::extract_identifiers(anchor_body)\`
- **\`outline::compute\`** does the same swap in the file-level reference loop
- **6 new unit tests** in \`refs::tests\`: Rust call sites + macros + method calls, Python calls, fallback for unknown extensions, fallback for unsupported-but-recognised languages
- **\`crates/rts-daemon/tests/closure_precision.rs\`** (new): integration test pinning the local-shadowing-elimination contract

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\`: **517 passed, 0 failed, 3 ignored** (was 510 in alpha.26; +6 unit + 1 integration)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets\`: clean on changed files (after one local fix — \`c.name().as_deref()\` → \`c.name()\`)
- [x] All existing tests still green: \`outline_round_trip\`, \`closure_round_trip\`, \`fuzzy_and_at_round_trip\` — confirms the regex→tags swap doesn't regress correctness on the four supported languages

## Post-Deploy Monitoring & Validation

- **What to monitor:**
  - \`Index.ReadSymbol(name, include_dependencies=true)\` response sizes should *decrease* on real codebases (fewer false-positive deps)
  - \`Index.Outline\` PageRank ordering on real workspaces — call sites should now outrank text mentions
- **Validation checks:**
  \`\`\`sh
  # Get a closure walk over a fn with known refs; assert no local-vars leak in
  rts-bench query read-symbol --workspace /path/to/repo \\
    --name some_fn --deps --shape signature | jq '.dependencies[].qualified_name'
  \`\`\`
- **Expected healthy behavior:**
  - Same set of \"true\" dep entries as before, minus the false positives
  - Latency unchanged or slightly higher (tree-sitter parse + query is heavier than regex; closure walker is already on a blocking task)
- **Failure signals:**
  - Specific real-callee deps *missing* from response → upstream tags.scm doesn't cover this call shape; investigate the language's query
  - Latency spike on closure walker → tree-sitter Query construction not cached; consider lazy-static for the per-lang Query
- **Rollback:** revert this commit. Languages fall back to regex extraction. No wire-format changes
- **Validation window:** first 24h after merge, then weekly via bench CI
- **Owner:** me@njf.io

🤖 Generated with Claude Opus 4.6 (1M context) via Claude Code + Compound Engineering v2.49.0