### PR TITLE
feat(rts-daemon): 0.2.0-alpha.30 — JS/TS tags.scm reference queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,96 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.30] - 2026-05-13
+
+**JS/TS reference queries.** Closes the alpha.27 language-coverage
+gap — outline + closure walker now use AST-precise reference extraction
+for JavaScript and TypeScript on top of Rust/Python/Go/Ruby.
+
+### Honest correction from alpha.27
+
+I scoped alpha.27 saying upstream tags.scm for JS/TS didn't ship
+`@reference.*` captures. **I was wrong about JavaScript** — its
+upstream tags.scm has `@reference.call` for both bare-identifier
+calls and method calls, plus `@reference.class` for `new` expressions.
+I missed them on first read. Alpha.30 wires them up.
+
+For TypeScript, upstream tags.scm really doesn't have
+`@reference.call` (only `@reference.type` + `@reference.class`).
+Authored locally — the TypeScript grammar accepts the same
+`call_expression` + `member_expression` node shapes JS does, so the
+same patterns work and would catch all TS-source call sites since
+TS is a superset of JS.
+
+### Coverage after this slice
+
+| language | refs query |
+|---|---|
+| Rust, Python, Go, Ruby | ✅ tags.scm (alpha.27) |
+| **JavaScript** | ✅ upstream tags.scm (this slice) |
+| **TypeScript / TSX** | ✅ locally authored (this slice) |
+| C, C++, Java, PHP, Swift | regex fallback |
+
+5 of 11 languages now have AST precision. The remaining 5 fall through
+to the regex tokenizer (no regression) — they're the languages where
+upstream tags.scm uses different conventions and a clean
+locally-authored query needs more research per language.
+
+### One intentional divergence from upstream JS
+
+The upstream JS tags.scm filters out `require()` calls via
+`(#not-match? @name "^(require)$")`. We drop that predicate — for the
+closure walker, an explicit `require(...)` call IS a reference (the
+agent's dep is whatever `require` resolves to). The
+build-system-vs-user-symbol distinction the upstream predicate cares
+about isn't ours to make. Documented inline in `JAVASCRIPT_REFS`.
+
+### Added
+
+- **`crate::language::JAVASCRIPT_REFS` + `TYPESCRIPT_REFS`**: tags.scm
+  `@reference.*` query strings. JS sourced from upstream
+  tree-sitter-javascript (minus the require predicate); TS locally
+  authored to mirror.
+- **`crate::language::JAVASCRIPT_QUERY` + `TYPESCRIPT_QUERY`**:
+  `OnceLock<Option<Query>>` statics. Dispatched via
+  `cached_refs_query` per alpha.29's caching contract.
+- **3 new unit tests in `refs::tests`** covering JS calls/methods/new,
+  TS calls/methods/new, and TSX alias routing.
+- **2 new tests in `language::tests`**: `typescript_has_renderer_and_refs_query`
+  (replaces the old "no refs query in v0" assertion),
+  `javascript_has_renderer_and_refs_query`, and a
+  `js_ts_cached_queries_construct_without_panic` guard so grammar
+  bumps surface at test time, not at first `outline_workspace` call
+  in production.
+
+### Changed
+
+- **`language::info_for_path`**: TS/TSX and JS/JSX/MJS/CJS arms now
+  return `Some(refs_query)`. The "deferred to v1.1" comments on those
+  arms are gone.
+
+### Not in this slice
+
+- **C/C++/Java/PHP/Swift refs queries.** Upstream tags.scm for these
+  has different conventions (e.g. C uses `call_expression function:
+  (identifier) @name` which works but covers a smaller fraction of
+  call shapes). Wiring them up requires per-language research; defer
+  until a concrete user.
+- **JSX/TSX element references.** TSX `<Widget />` isn't a
+  `call_expression` — it's a `jsx_element`. The closure walker
+  currently doesn't treat JSX elements as references; that's a v1.1
+  surface (closure-walking a React component's JSX is a bigger
+  design question than just adding one more capture).
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **533 passed, 0 failed, 3 ignored** (was
+  528 in alpha.29; +3 refs JS/TS + 2 language module).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: 94 warnings, unchanged
+  from alpha.29.
+
 ## [0.2.0-alpha.29] - 2026-05-13
 
 **Reviewer follow-up batch.** Four concrete fixes from the alpha.27

--- a/crates/rts-daemon/src/language.rs
+++ b/crates/rts-daemon/src/language.rs
@@ -109,6 +109,50 @@ const RUBY_REFS: &str = r#"
 (call method: (identifier) @name) @reference.call
 "#;
 
+/// JavaScript reference patterns. The upstream tree-sitter-javascript
+/// tags.scm ships `@reference.call` and `@reference.class` captures —
+/// our alpha.27 scoping pass missed this and deferred them. Fixed in
+/// alpha.30.
+///
+/// Note the upstream `(#not-match? @name "^(require)$")` predicate on
+/// bare-identifier call expressions is dropped here: for the closure
+/// walker, an explicit `require(...)` call IS a reference (the agent's
+/// dep is whatever `require` resolves to), and filtering it would just
+/// hide a real edge. The build-system-vs-user-symbol distinction the
+/// upstream predicate cares about isn't ours to make.
+const JAVASCRIPT_REFS: &str = r#"
+(call_expression
+    function: (identifier) @name) @reference.call
+
+(call_expression
+    function: (member_expression
+        property: (property_identifier) @name)
+    arguments: (_)) @reference.call
+
+(new_expression
+    constructor: (identifier) @name) @reference.class
+"#;
+
+/// TypeScript reference patterns. The upstream tree-sitter-typescript
+/// tags.scm only ships `@reference.type` (type annotations) and
+/// `@reference.class` (new expressions) — no `@reference.call`.
+/// Locally authored here to mirror the JavaScript shape; the
+/// tree-sitter-typescript grammar accepts the same `call_expression` +
+/// `member_expression` nodes JS does, so the same patterns work (and
+/// catch all TS-source call sites since TS is a superset of JS).
+const TYPESCRIPT_REFS: &str = r#"
+(call_expression
+    function: (identifier) @name) @reference.call
+
+(call_expression
+    function: (member_expression
+        property: (property_identifier) @name)
+    arguments: (_)) @reference.call
+
+(new_expression
+    constructor: (identifier) @name) @reference.class
+"#;
+
 /// Path → [`LanguageInfo`]. The canonical extension table.
 ///
 /// `.tsx` is intentionally routed to the same TypeScript renderer as
@@ -137,16 +181,12 @@ pub fn info_for_path(rel_path: &str) -> Option<LanguageInfo> {
         "ts" | "tsx" => Some(LanguageInfo {
             language: Language::TypeScript,
             signature_renderer: Some(rust_tree_sitter::signature::render_typescript),
-            // Upstream tree-sitter-typescript tags.scm doesn't ship
-            // `@reference.*` captures; locally-authored override is
-            // v1.1 work.
-            refs_query: None,
+            refs_query: Some(TYPESCRIPT_REFS),
         }),
         "js" | "jsx" | "mjs" | "cjs" => Some(LanguageInfo {
             language: Language::JavaScript,
             signature_renderer: Some(rust_tree_sitter::signature::render_javascript),
-            // Same v1.1 deferral as TypeScript.
-            refs_query: None,
+            refs_query: Some(JAVASCRIPT_REFS),
         }),
         "go" => Some(LanguageInfo {
             language: Language::Go,
@@ -206,6 +246,8 @@ static RUST_QUERY: OnceLock<Option<Query>> = OnceLock::new();
 static PYTHON_QUERY: OnceLock<Option<Query>> = OnceLock::new();
 static GO_QUERY: OnceLock<Option<Query>> = OnceLock::new();
 static RUBY_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static JAVASCRIPT_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static TYPESCRIPT_QUERY: OnceLock<Option<Query>> = OnceLock::new();
 
 /// Cached `Query` for `language`. Returns `Some` if the language has a
 /// tags.scm-derived `@reference.*` query *and* construction succeeded;
@@ -219,6 +261,8 @@ pub fn cached_refs_query(info: &LanguageInfo) -> Option<&'static Query> {
         Language::Python => &PYTHON_QUERY,
         Language::Go => &GO_QUERY,
         Language::Ruby => &RUBY_QUERY,
+        Language::JavaScript => &JAVASCRIPT_QUERY,
+        Language::TypeScript => &TYPESCRIPT_QUERY,
         _ => return None,
     };
     let query_src = info.refs_query?;
@@ -239,9 +283,9 @@ mod tests {
     }
 
     #[test]
-    fn typescript_has_renderer_but_no_refs_query_in_v0() {
-        // .tsx and .ts both route to TypeScript; both have a renderer.
-        // Neither has a refs query in v0 (deferred to v1.1).
+    fn typescript_has_renderer_and_refs_query() {
+        // .tsx and .ts both route to TypeScript with both renderer and
+        // refs query (alpha.30 closed the alpha.27 deferral).
         for ext in ["src/a.ts", "src/a.tsx"] {
             let info = info_for_path(ext).expect("ts/tsx supported");
             assert_eq!(info.language, Language::TypeScript);
@@ -249,8 +293,44 @@ mod tests {
                 info.signature_renderer.is_some(),
                 "{ext} should have renderer"
             );
-            assert!(info.refs_query.is_none(), "{ext} v0 refs query is None");
+            assert!(
+                info.refs_query.is_some(),
+                "{ext} should have refs query after alpha.30"
+            );
         }
+    }
+
+    #[test]
+    fn javascript_has_renderer_and_refs_query() {
+        for ext in ["a.js", "a.jsx", "a.mjs", "a.cjs"] {
+            let info = info_for_path(ext).expect("js supported");
+            assert_eq!(info.language, Language::JavaScript);
+            assert!(info.signature_renderer.is_some());
+            assert!(info.refs_query.is_some());
+        }
+    }
+
+    #[test]
+    fn js_ts_cached_queries_construct_without_panic() {
+        // Constructing a `Query` from a hand-written query string can
+        // fail if it doesn't typecheck against the grammar's node
+        // names. This test forces the OnceLock init on JS + TS so
+        // any breakage from grammar bumps surfaces here at test time
+        // (not at first `outline_workspace` call in production).
+        let js_info = info_for_path("a.js").unwrap();
+        let q = cached_refs_query(&js_info);
+        assert!(
+            q.is_some(),
+            "JavaScript refs query failed to construct — \
+             check JAVASCRIPT_REFS against the current grammar"
+        );
+        let ts_info = info_for_path("a.ts").unwrap();
+        let q = cached_refs_query(&ts_info);
+        assert!(
+            q.is_some(),
+            "TypeScript refs query failed to construct — \
+             check TYPESCRIPT_REFS against the current grammar"
+        );
     }
 
     #[test]

--- a/crates/rts-daemon/src/refs.rs
+++ b/crates/rts-daemon/src/refs.rs
@@ -173,6 +173,78 @@ def caller():
     }
 
     #[test]
+    fn javascript_references_capture_calls_and_new() {
+        let src = "
+function caller(input) {
+    let local = input + 1;
+    targetFn(local);
+    obj.methodName();
+    const x = new Widget(local);
+    return x;
+}
+";
+        let (lang, q) = refs_query_for("a.js").unwrap();
+        let refs = extract_references(lang, q, src).expect("js has a query");
+        assert!(refs.contains(&"targetFn".to_string()), "got {refs:?}");
+        assert!(refs.contains(&"methodName".to_string()), "got {refs:?}");
+        assert!(refs.contains(&"Widget".to_string()), "got {refs:?}");
+        assert!(
+            !refs.contains(&"local".to_string()),
+            "local var should not be a ref; got {refs:?}"
+        );
+        assert!(
+            !refs.contains(&"caller".to_string()),
+            "caller is a def, not a ref; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn typescript_references_capture_calls_and_new() {
+        let src = "
+function caller(input: number): number {
+    const local = input + 1;
+    targetFn(local);
+    obj.methodName();
+    const x = new Widget(local);
+    return x.value;
+}
+";
+        let (lang, q) = refs_query_for("a.ts").unwrap();
+        let refs = extract_references(lang, q, src).expect("ts has a query");
+        assert!(refs.contains(&"targetFn".to_string()), "got {refs:?}");
+        assert!(refs.contains(&"methodName".to_string()), "got {refs:?}");
+        assert!(refs.contains(&"Widget".to_string()), "got {refs:?}");
+        assert!(
+            !refs.contains(&"local".to_string()),
+            "local var should not be a ref; got {refs:?}"
+        );
+        assert!(
+            !refs.contains(&"caller".to_string()),
+            "caller is a def, not a ref; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn typescript_tsx_alias_uses_same_query() {
+        // .tsx routes to TypeScript; same call_expression shape; same
+        // refs. (TypeScript grammar accepts JSX syntax natively.)
+        let src = "
+function caller(): JSX.Element {
+    targetFn();
+    return <Widget />;
+}
+";
+        let (lang, q) = refs_query_for("a.tsx").unwrap();
+        let refs = extract_references(lang, q, src).expect("tsx has a query");
+        // JSX `<Widget />` isn't a call_expression; only `targetFn()` is.
+        // This pins the boundary: agents using TSX get function call
+        // refs but not JSX element refs (which would be a v1.1 surface
+        // anyway — closure-walking a React component's JSX is a
+        // bigger question).
+        assert!(refs.contains(&"targetFn".to_string()));
+    }
+
+    #[test]
     fn references_for_path_falls_back_to_regex_on_unknown_lang() {
         // .lua is not in our supported set; the fallback regex
         // tokenizer should return identifier-shaped tokens.


### PR DESCRIPTION
## Summary

Closes the alpha.27 language-coverage gap. Outline + closure walker now use AST-precise reference extraction for **JavaScript and TypeScript** on top of Rust/Python/Go/Ruby.

## Honest correction from alpha.27

I scoped alpha.27 saying upstream tags.scm for JS/TS didn't ship \`@reference.*\` captures. **I was wrong about JavaScript** — its upstream tags.scm has \`@reference.call\` for both bare-identifier calls and method calls, plus \`@reference.class\` for \`new\` expressions. Missed on first read. This slice wires them up.

For TypeScript, upstream tags.scm really doesn't have \`@reference.call\` (only \`@reference.type\` + \`@reference.class\`). Authored locally — the TS grammar accepts the same \`call_expression\` + \`member_expression\` nodes as JS, so the same patterns work and catch all TS-source call sites since TS is a superset of JS.

## Coverage after this slice

| language | refs query |
|---|---|
| Rust, Python, Go, Ruby | ✅ tags.scm (alpha.27) |
| **JavaScript** | ✅ upstream tags.scm (this slice) |
| **TypeScript / TSX** | ✅ locally authored (this slice) |
| C, C++, Java, PHP, Swift | regex fallback (no regression) |

5 of 11 languages now have AST precision.

## One intentional divergence from upstream JS

Upstream filters out \`require()\` calls via \`(#not-match? @name \"^(require)$\")\`. We drop that predicate — for the closure walker, an explicit \`require(...)\` call **is** a reference (the agent's dep is whatever \`require\` resolves to). The build-system-vs-user-symbol distinction the upstream predicate cares about isn't ours to make. Documented inline in \`JAVASCRIPT_REFS\`.

## Changes

- **\`JAVASCRIPT_REFS\` + \`TYPESCRIPT_REFS\`** query strings in \`language.rs\`
- **\`JAVASCRIPT_QUERY\` + \`TYPESCRIPT_QUERY\`** OnceLock statics, dispatched via alpha.29's \`cached_refs_query\`
- **\`language::info_for_path\`**: TS/TSX and JS/JSX/MJS/CJS arms now return \`Some(refs_query)\`. The \"deferred to v1.1\" comments are gone
- **3 new unit tests in \`refs::tests\`** covering JS calls/methods/new, TS calls/methods/new, and TSX alias routing
- **2 new tests in \`language::tests\`** + a **\`js_ts_cached_queries_construct_without_panic\`** guard so grammar bumps surface at test time, not at first \`outline_workspace\` call in production

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace\`: **533 passed, 0 failed, 3 ignored** (was 528 in alpha.29; +3 refs JS/TS + 2 language module)
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy --workspace --all-targets\`: 94 warnings, unchanged from alpha.29
- [x] Manual: \`refs::tests::javascript_references_capture_calls_and_new\` confirms local vars are filtered out (the same precision win alpha.27 shipped for Rust)

## Not in this slice

- **C/C++/Java/PHP/Swift refs queries.** Upstream tags.scm conventions vary; per-language research deferred until concrete users ask
- **JSX/TSX element references.** \`<Widget />\` isn't a \`call_expression\`; closure-walking React components is a v1.1 design question

## Post-Deploy Monitoring & Validation

- **What to monitor:**
  - On a real TS/JS workspace, \`Index.ReadSymbol\` with \`include_dependencies: true\` should return fewer false-positive deps (no local-variable bleed-through)
  - \`outline_workspace\` PageRank should rank files that *call* a function over files that just mention it in a comment
- **Validation checks:**
  \`\`\`sh
  rts-bench query read-symbol --workspace /ts-repo --name some_fn --deps \\
    | jq '.dependencies[].qualified_name'
  \`\`\`
- **Expected healthy behavior:**
  - Dep lists shrink on TS/JS workspaces (no \`local_const\` false positives)
  - Latency unchanged (the OnceLock cache from alpha.29 zeros out per-call Query compilation)
- **Failure signals:**
  - \`js_ts_cached_queries_construct_without_panic\` test starts failing → tree-sitter grammar bump invalidated one of the queries; fix the query
  - Dep list grows unexpectedly on TS workspaces → query is catching nodes it shouldn't; tighten the patterns
- **Rollback:** revert this commit. JS/TS fall back to regex extraction (alpha.27 behavior). No wire-format changes
- **Validation window:** first usage cycle on a real TS workspace
- **Owner:** me@njf.io

🤖 Generated with Claude Opus 4.6 (1M context) via Claude Code + Compound Engineering v2.49.0