### PR TITLE
feat(rts-daemon): 0.2.0-alpha.31 — persistent reference graph (v0.3 U1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,45 +7,168 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Docs
+## [0.2.0-alpha.31] - 2026-05-14
 
-- **`docs/protocol-v0.md` re-spec at alpha.30 baseline** (U0 of the v0.3
-  code-graph KB plan). The doc was last updated pre-alpha.24 and drifted
-  from the shipped wire surface across 8 alphas. This pass:
-  - Updates the Status line from "Draft 1, design-only" → "Draft 2,
-    alpha.30 baseline" and refreshes `Daemon.Ping`'s example version
-    (`0.2.0-alpha.3` → `0.2.0-alpha.30`).
-  - Documents `Index.ReadSymbolAt` (new method, alpha.24) at §7.7b
-    with full param shape + error catalog + §18.4b JSON Schema.
-  - Documents `Index.FindSymbol` `pattern` (glob) param + `name`
-    being optional + mutual-exclusion rule (alpha.24) at §7.6 and
-    §18.3.
-  - Adds the alpha.22 (`closure_walker`), alpha.24
-    (`read_symbol_at`, `fuzzy_match`), alpha.18
-    (`pagerank_filewise`), and alpha.25 (`polling_fallback`)
-    capability strings to the §4.1 canonical advertisement list.
-  - Updates the §7 method catalog (10 → 11 methods + 1 notification)
-    and the architecture diagram (4 tools → 5).
-  - Reserves the four v0.3 capability strings (`find_callers`,
-    `impact_of`, `read_symbol.include_callers`, `pagerank_symbolwise`)
-    in §4.2 so client implementations can branch on them as the v0.3
-    PR series lands.
-  - Adds **Appendix F — Wire-shape evolution by alpha**, a table of
-    every additive change since Draft 1 plus a workflow for the
-    extension protocol the v0.3 PRs (U1-U5) will follow.
-- **Adds CLAUDE.md ↔ AGENTS.md parity hint not required** — no agent
-  guidance changed; the doc-baseline catch-up is purely about the
-  daemon's wire contract.
+**Persistent reference graph + outline switch (v0.3 U1).** The reference
+half of the call graph that v0.2 computed at query time and threw away is
+now persisted in the redb index. Three new tables (REFS, FID_REFS,
+SID_REFS_OUT) populated by the writer on every commit; `outline::compute`
+reads them instead of re-parsing every file. First land in the v0.3 plan
+([docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md](docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md));
+unblocks `Index.FindCallers` (U2'), `Index.ImpactOf` (U5), and
+symbol-level PageRank (U4).
 
-### Why
+### Schema
 
-The alpha.28 entry called this out explicitly ("Wire-protocol re-spec
-… `docs/protocol-v0.md` is still pre-alpha.24. Worth a docs-only PR
-next"); the v0.3 plan's Deepening §C5 reinforced it ("v0.3's additive
-contract holds *only if* protocol-v0.md is current"). Without this PR,
-v0.3 PRs would compound the drift instead of removing it.
+- **`SCHEMA_VERSION` bumped to 2** at `crates/rts-daemon/src/store/mod.rs:36`.
+  First mount of any v0.2 `db.redb` triggers the existing
+  rebuild-on-mismatch path in `Store::open` (mod.rs:124-178) — no
+  migration code needed. The `INDEX_NOT_READY` retry in `rts-mcp`
+  covers the rebuild window. New `v1_to_v2_schema_mismatch_triggers_rebuild`
+  test asserts the round-trip.
+- **`REFS: MultimapTableDefinition<u32 /* callee_sid */, &[u8] /* postcard(RefSite) */>`**.
+  Mirrors the existing `DEFS` shape; one entry per call site so
+  `REFS[X]` answers "who calls X, and where?" in one lookup.
+- **`FID_REFS: MultimapTableDefinition<u32 /* fid */, u32 /* callee_sid */>`**.
+  Symmetric to `FID_DEFS`; enables O(1) per-file ref invalidation in
+  `drop_file_entries`. Deduplicates per (file, callee) — three call
+  sites in the same file produce one `FID_REFS` row but three
+  `REFS` rows.
+- **`SID_REFS_OUT: MultimapTableDefinition<u32 /* caller_sid */, u32 /* callee_sid */>`**.
+  The *outgoing* direction. Per v0.3 deepening §B1, landed in U1
+  (not U4) to avoid a second SCHEMA_VERSION bump when the closure
+  walker switches. Without this table, "what does X reference?"
+  would scan all REFS rows. With it, one multimap lookup.
+- **`RefSite` postcard struct** carries `(fid, byte_range, line_range,
+  caller_sid: Option<u32>)`. `caller_sid` is the smallest enclosing
+  def whose byte range covers the call site; `None` for top-level /
+  file-scope references. Typical postcard size ~12 bytes (varint u32s).
 
-No code changes; no alpha bump.
+### Writer
+
+- **Two-pass `commit_batch`.** Pass 1 processes all defs across all
+  files in the batch (assigning sids + writing DEFS/FID_DEFS). Pass 2
+  processes all refs, now with every same-batch callee resolved.
+  Fixes an intra-batch ordering bug where callers in a file processed
+  earlier than their callee's file would have refs filtered as
+  "external."
+- **`parse_and_extract` extracts refs alongside defs** via the new
+  `refs::references_with_ranges` (range-carrying sibling of the
+  existing `references_for_path`). AST-precise via tags.scm for the 6
+  languages with reference queries (Rust/Python/Go/Ruby/JS/TS);
+  fallback-regex languages get name-only refs with synthetic 0..0
+  byte ranges.
+- **External-symbol filter at commit time.** Names with no
+  `NAME_TO_SID` entry after Pass 1 are skipped per v0.3 plan §F1.
+  Avoids cross-language name-collision risk in NAME_TO_SID (e.g.
+  Rust `Vec` vs hypothetical Python `Vec` would have collided).
+  `Index.FindCallers(Vec)` is therefore "workspace callers only";
+  external-symbol diagnostics can land as a separate purely-additive
+  PR later.
+- **`drop_file_entries` extended** with the filter-by-fid algorithm
+  for REFS + a rebuild-from-surviving-rows pass for SID_REFS_OUT
+  (since SID_REFS_OUT is u32→u32 with no embedded fid, we can't
+  surgically remove rows by file — we re-derive from REFS instead).
+  Critical correctness invariant: when file A and file B both ref C,
+  dropping A leaves B's ref to C intact. Tested by the new
+  `refs_invalidate_when_referring_file_dropped` integration test.
+
+### Outline
+
+- **`outline::compute` reads indexed edges** via
+  `store.refs_for_file_resolved(fid)` instead of calling
+  `crate::refs::references_for_path` per file. The PageRank graph
+  builds from the persistent REFS table; no at-query-time parsing.
+  Same external behavior — `outline_round_trip` integration test
+  (alpha.18) passes unchanged after the swap.
+
+### Store helpers
+
+- **`refs_to_symbol(callee_sid)`** — "who calls X" (returns RefSites
+  with `caller_sid` populated). Consumed by U2' `Index.FindCallers`.
+- **`refs_from_symbol(caller_sid)`** — "what does X reference"
+  (returns the set of callee sids X has outgoing edges to).
+  Consumed by U3 closure walker.
+- **`refs_for_file(fid)`** — raw callee-sid set per file (multimap
+  deduped). Production code uses `refs_for_file_resolved` for the
+  name + per-callsite-count form `outline::compute` needs.
+- **`refs_for_file_resolved(fid)`** — per-file outgoing refs with
+  callee names resolved + per-callsite counts. Used by outline.
+
+### Tests
+
+- 6 new store unit tests in `store::tests`:
+  - `refs_round_trip_writes_all_three_tables` — two-file fixture asserts
+    `REFS`/`FID_REFS`/`SID_REFS_OUT` all populated with correct
+    `caller_sid` resolution.
+  - `refs_external_symbol_filtered_at_commit` — references to
+    non-workspace names get no NAME_TO_SID entry (per §F1).
+  - `refs_invalidate_when_referring_file_dropped` — multi-file
+    invalidation: drop A, B's ref to C survives.
+  - `refs_invalidate_on_re_upsert` — re-save a file with different refs
+    clears prior contributions.
+  - `refs_for_file_resolved_returns_per_file_callsite_count` — three
+    call sites in one file ⇒ `("callee", 3)`.
+  - `v1_to_v2_schema_mismatch_triggers_rebuild` — first exercise of
+    the schema-mismatch rebuild path since v0.2 alpha.1 introduced it.
+- Existing `outline_round_trip` + `closure_round_trip` integration
+  tests pass unchanged after the writer/outline swap.
+
+### Wire surface
+
+- **Zero new wire surface** in U1 per the plan. v0.3 capability
+  strings (`find_callers`, `impact_of`, `read_symbol.include_callers`,
+  `pagerank_symbolwise`) remain reserved in protocol-v0 §4.2 until
+  U2'+ ship.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **539 passed, 0 failed, 0 ignored**
+  (was 533 in alpha.30; +6 = 5 new ref-graph store tests + 1 v1→v2
+  migration test).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: no new warnings on
+  changed files. The three new Store helpers
+  (`refs_to_symbol`/`refs_from_symbol`/`refs_for_file`) are
+  `#[allow(dead_code)]`-annotated until U2'+ consume them.
+
+### Not in this slice
+
+- **`Index.FindCallers` method** (U2'): direct callers + composes
+  with `Index.ReadSymbol.include_callers`. Next PR.
+- **Closure walker switch to `refs_from_symbol`** (U3): the alpha.22
+  closure walker still re-parses; U3 swaps it to read SID_REFS_OUT.
+- **Symbol-level PageRank** (U4): the `rank_score` placeholder
+  becomes real once the graph builder lands.
+- **`Index.ImpactOf` method** (U5): transitive caller closure with
+  depth + token budget.
+- **External-symbol diagnostics**: per §F1, external refs are
+  filtered at commit time. Adding back later is purely additive
+  (extract-time filter relaxes); no schema bump needed.
+
+### Refs
+
+- v0.3 plan: [docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md](docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md)
+- v0.3 brainstorm: [docs/brainstorms/2026-05-13-v0.3-code-graph-kb-requirements.md](docs/brainstorms/2026-05-13-v0.3-code-graph-kb-requirements.md)
+- Stacked on U0 (PR #27) which re-specced `protocol-v0.md` at the
+  alpha.30 wire-shape baseline.
+
+### Docs (carried from U0 PR #27)
+
+- **`docs/protocol-v0.md` re-spec at alpha.30 baseline.** The doc
+  was last updated pre-alpha.24 and drifted from the shipped wire
+  surface across 8 alphas. This pass updates the Status line
+  ("Draft 1, design-only" → "Draft 2, alpha.30 baseline"), refreshes
+  `Daemon.Ping`'s example version (`0.2.0-alpha.3` →
+  `0.2.0-alpha.30`), documents `Index.ReadSymbolAt` (alpha.24) at
+  §7.7b + §18.4b, documents `Index.FindSymbol` `pattern` + name-optional
+  at §7.6 + §18.3, advertises closure_walker / fuzzy_match /
+  read_symbol_at / pagerank_filewise / polling_fallback capability
+  strings in §4.1, reserves the four v0.3 strings in §4.2, updates
+  the §7 method catalog to 11 methods + 1 notification, and adds
+  **Appendix F — Wire-shape evolution by alpha** tracking every
+  additive change since Draft 1 plus an extension workflow for U1-U5.
 
 ## [0.2.0-alpha.30] - 2026-05-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.31"
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yourusername/rust_tree_sitter"

--- a/crates/rts-daemon/src/outline.rs
+++ b/crates/rts-daemon/src/outline.rs
@@ -29,7 +29,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Context;
 use serde_json::{Value, json};
 
-use crate::store::{FileWithDefs, Store};
+use crate::store::{FileId, FileWithDefs, Store};
 use rust_tree_sitter::pagerank::{self, Edge};
 
 /// Outline render targets.
@@ -133,10 +133,16 @@ impl std::fmt::Debug for OutlineCache {
     }
 }
 
-/// Compute the outline. `workspace_root` is needed to read the actual
-/// file contents for reference extraction.
+/// Compute the outline.
+///
+/// `_workspace_root` is retained in the signature for back-compat
+/// with callers; v0.3 (U1) reads pre-extracted reference edges from
+/// the persistent index (`store.refs_for_file_resolved`) instead of
+/// re-parsing files at query time, so the workspace root is no
+/// longer dereferenced by this path. The closure walker still uses
+/// it via its own code path (v0.3 U3 will swap it too).
 pub fn compute(
-    workspace_root: &Path,
+    _workspace_root: &Path,
     store: &Store,
     params: &OutlineParams<'_>,
 ) -> anyhow::Result<OutlineResult> {
@@ -152,7 +158,6 @@ pub fn compute(
         return Ok(empty_result(files_considered));
     }
 
-    let all_def_names = store.all_defined_names().context("all defined names")?;
     let mentioned_idents_set: HashSet<&str> =
         params.mentioned_idents.iter().map(|s| s.as_str()).collect();
     let mentioned_files_set: HashSet<&str> =
@@ -166,35 +171,39 @@ pub fn compute(
         }
     }
 
-    // For each file, parse and pull AST-precise references via
-    // tags.scm (Rust/Python/Go/Ruby) — or the regex tokenizer fallback
-    // for languages without a query. Each (referencer_file →
-    // definer_file) tuple becomes an edge in the PageRank graph.
+    // For each file, read the persistent ref graph (v0.3 U1).
+    // `refs_for_file_resolved` returns `(callee_name, count)` tuples
+    // where the count is the number of individual call sites in this
+    // file — exactly what the Aider edge-weight recipe needs.
     //
-    // The tags.scm path eliminates false-positive edges from local
-    // variables that shadow def names, comment mentions, and
-    // identifier appearances in trait/type bounds. PageRank ranks
-    // files that *call* a symbol over files that *mention* it.
+    // Externals (names not workspace-defined) are filtered at commit
+    // time in `Store::commit_batch`, so we don't need a redundant
+    // `all_def_names` filter here. We still filter via `def_map` to
+    // honour the `glob` param (which may exclude some workspace
+    // files from `files`, and thus their defs from `def_map`).
+    //
+    // Pre-v0.3 this loop re-parsed every file and called
+    // `refs::references_for_path`. The new path is a single redb
+    // read per file instead.
     let mut edges: Vec<Edge> = Vec::new();
     let mut ref_counts: HashMap<(usize, usize, String), u32> = HashMap::new();
     for (src_idx, f) in files.iter().enumerate() {
-        let abs = workspace_root.join(&f.path);
-        let content = match std::fs::read_to_string(&abs) {
-            Ok(s) => s,
-            Err(_) => continue,
+        let fid = match store.get_file_meta(&f.path)? {
+            Some((FileId(v), _)) => v,
+            None => continue, // file isn't indexed yet (mount-time race)
         };
-        for ident in crate::refs::references_for_path(&f.path, &content) {
-            if !all_def_names.contains(&ident) {
-                continue;
-            }
-            if let Some(dst_files) = def_map.get(&ident) {
+        let resolved = store
+            .refs_for_file_resolved(fid)
+            .context("refs_for_file_resolved")?;
+        for (callee_name, count) in resolved {
+            if let Some(dst_files) = def_map.get(&callee_name) {
                 for &dst_idx in dst_files {
                     if dst_idx == src_idx {
                         continue;
                     }
                     *ref_counts
-                        .entry((src_idx, dst_idx, ident.clone()))
-                        .or_insert(0) += 1;
+                        .entry((src_idx, dst_idx, callee_name.clone()))
+                        .or_insert(0) += count;
                 }
             }
         }

--- a/crates/rts-daemon/src/refs.rs
+++ b/crates/rts-daemon/src/refs.rs
@@ -40,6 +40,8 @@
 
 use rust_tree_sitter::{Language, Parser, query::Query};
 
+use crate::store::RefHit;
+
 /// Extract the set of *referenced* symbol names from `content` parsed
 /// as `language`, using the supplied pre-compiled `Query`. The query
 /// is built once per language (cached via `OnceLock` in
@@ -70,6 +72,48 @@ pub(crate) fn extract_references(
     Some(out)
 }
 
+/// Like [`extract_references`] but emits one [`RefHit`] per call site
+/// (carrying the byte range and 1-based inclusive line range of the
+/// `@name` capture). Used by the writer to populate the v0.3
+/// `REFS`/`FID_REFS`/`SID_REFS_OUT` tables; the at-query-time outline
+/// loop and the closure walker both switch to reading those indexed
+/// edges instead of re-extracting per call.
+///
+/// Returns `None` on parser failure — callers should fall back to a
+/// language-agnostic shape (e.g. an empty Vec when the daemon
+/// supports the language but parsing failed).
+pub(crate) fn extract_references_with_ranges(
+    language: Language,
+    query: &Query,
+    content: &str,
+) -> Option<Vec<RefHit>> {
+    let parser = Parser::new(language).ok()?;
+    let tree = parser.parse(content, None).ok()?;
+    let captures = query.captures(&tree).ok()?;
+    let mut out: Vec<RefHit> = Vec::with_capacity(captures.len());
+    for c in captures {
+        if c.name() == Some("name") {
+            let node = c.node();
+            if let Ok(text) = node.text() {
+                let start_byte = node.start_byte() as u32;
+                let end_byte = node.end_byte() as u32;
+                // tree-sitter rows are 0-based; protocol-v0 line
+                // ranges are 1-based inclusive (matching DefSite).
+                let start_row = node.start_position().row as u32 + 1;
+                let end_row = node.end_position().row as u32 + 1;
+                out.push(RefHit {
+                    name: text.to_string(),
+                    start: start_byte,
+                    end: end_byte,
+                    start_line: start_row,
+                    end_line: end_row,
+                });
+            }
+        }
+    }
+    Some(out)
+}
+
 /// Dispatcher used by `outline` + `closure` for each file they walk.
 /// Tries AST-precise extraction first; falls back to the regex
 /// tokenizer for languages without a query.
@@ -92,6 +136,40 @@ pub(crate) fn references_for_path(rel_path: &str, content: &str) -> Vec<String> 
     }
     crate::outline::extract_identifiers(content)
         .map(|s| s.to_string())
+        .collect()
+}
+
+/// Range-carrying variant of [`references_for_path`]. Used by the
+/// writer (v0.3 U1) to populate the persistent ref graph.
+///
+/// For languages with a tags.scm reference query (Rust, Python, Go,
+/// Ruby, JavaScript, TypeScript), each hit carries a precise byte
+/// range from the `@name` capture. For fallback-regex languages
+/// (C, C++, Java, PHP, Swift) we synthesize the byte range as
+/// `start = end = 0` and 1-based `start_line = end_line = 1` —
+/// enough to populate the index for "who calls X?" queries but not
+/// precise enough for "show me the call site." This trade-off
+/// matches v0.2 behavior: those languages already use the regex
+/// path for closure-walker identifier extraction.
+pub(crate) fn references_with_ranges(rel_path: &str, content: &str) -> Vec<RefHit> {
+    if let Some(info) = crate::language::info_for_path(rel_path) {
+        if let Some(query) = crate::language::cached_refs_query(&info) {
+            if let Some(refs) = extract_references_with_ranges(info.language, query, content) {
+                return refs;
+            }
+        }
+    }
+    // Regex fallback: identifier-shaped tokens with no precise range.
+    // The store can still answer "who calls X" but the RefSite range
+    // will be 0..0 / line 1..1.
+    crate::outline::extract_identifiers(content)
+        .map(|s| RefHit {
+            name: s.to_string(),
+            start: 0,
+            end: 0,
+            start_line: 1,
+            end_line: 1,
+        })
         .collect()
 }
 

--- a/crates/rts-daemon/src/store/mod.rs
+++ b/crates/rts-daemon/src/store/mod.rs
@@ -8,7 +8,7 @@
 
 pub mod schema;
 
-pub use schema::{DefSite, FileId, FileMeta, ParseStatus, SymbolKind};
+pub use schema::{DefSite, FileId, FileMeta, ParseStatus, RefSite, SymbolKind};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -18,12 +18,22 @@ use anyhow::{Context, anyhow};
 use postcard::{from_bytes, to_allocvec};
 use redb::{Database, Durability, ReadableMultimapTable, ReadableTable};
 
-use schema::{DEFS, FID_DEFS, FID_TO_PATH, FILES, META, NAME_TO_SID, PATH_TO_FID, SID_TO_NAME};
+use schema::{
+    DEFS, FID_DEFS, FID_REFS, FID_TO_PATH, FILES, META, NAME_TO_SID, PATH_TO_FID, REFS,
+    SID_REFS_OUT, SID_TO_NAME,
+};
 
 /// Current on-disk schema version. Bump when any table layout or value-bytes
 /// shape changes. Mismatch on open → daemon-controlled rebuild (protocol-v0
 /// §15.4); a newer-than-binary schema → refusal with `SCHEMA_VERSION_NEWER`.
-pub const SCHEMA_VERSION: u32 = 1;
+///
+/// History:
+/// * `1` — initial schema (v0.2 alpha.1+): files, names, defs.
+/// * `2` — v0.3 alpha.31 (U1): adds REFS + FID_REFS + SID_REFS_OUT
+///   for the call graph half of the index. Old `db.redb` files are
+///   wiped on first mount; the index is a derived cache per
+///   protocol-v0 §15.4. No migration code needed.
+pub const SCHEMA_VERSION: u32 = 2;
 
 const META_SCHEMA_VERSION: &str = "schema_version";
 const META_NEXT_FID: &str = "next_fid";
@@ -46,6 +56,22 @@ pub struct StoreStats {
     pub parse_failed_files: u64,
 }
 
+/// A single reference hit extracted from a parse pass. The writer
+/// produces these alongside defs; `commit_batch` resolves
+/// `name` → `callee_sid` and computes `caller_sid` via
+/// smallest-enclosing-def lookup against the file's own defs.
+///
+/// `start_line` / `end_line` are 1-based inclusive (matching `DefSite`);
+/// `start` / `end` are 0-based byte offsets, half-open.
+#[derive(Debug, Clone)]
+pub struct RefHit {
+    pub name: String,
+    pub start: u32,
+    pub end: u32,
+    pub start_line: u32,
+    pub end_line: u32,
+}
+
 /// A single file's contribution to the index, batched up by the writer before
 /// commit. The writer task collects one `FileBatchEntry` per touched file,
 /// hands them to `Store::commit_batch`, and the store applies them as one
@@ -56,6 +82,10 @@ pub struct FileBatchEntry {
     pub meta: FileMeta,
     /// Defined symbols + their byte/line ranges.
     pub defs: Vec<(String, DefSite, SymbolKind)>,
+    /// Reference hits within this file. Empty for parse-failed files.
+    /// `commit_batch` filters external references (names with no
+    /// `NAME_TO_SID` entry after batch interning) per v0.3 plan §F1.
+    pub refs: Vec<RefHit>,
 }
 
 /// A removal entry for files that disappeared since last index.
@@ -161,6 +191,10 @@ impl Store {
                 let _ = w.open_table(SID_TO_NAME)?;
                 let _ = w.open_multimap_table(DEFS)?;
                 let _ = w.open_multimap_table(FID_DEFS)?;
+                // v0.3 (SCHEMA_VERSION=2): call-graph tables.
+                let _ = w.open_multimap_table(REFS)?;
+                let _ = w.open_multimap_table(FID_REFS)?;
+                let _ = w.open_multimap_table(SID_REFS_OUT)?;
                 let _ = w.open_table(META)?;
             }
             w.commit().context("commit table init")?;
@@ -210,6 +244,9 @@ impl Store {
             let mut sid_to_name = txn.open_table(SID_TO_NAME)?;
             let mut defs = txn.open_multimap_table(DEFS)?;
             let mut fid_defs = txn.open_multimap_table(FID_DEFS)?;
+            let mut refs_t = txn.open_multimap_table(REFS)?;
+            let mut fid_refs = txn.open_multimap_table(FID_REFS)?;
+            let mut sid_refs_out = txn.open_multimap_table(SID_REFS_OUT)?;
             let mut meta = txn.open_table(META)?;
 
             // Removals first (rare relative to upserts; cheap to scan).
@@ -219,12 +256,37 @@ impl Store {
                     Some(v) => v.value(),
                     None => continue,
                 };
-                drop_file_entries(&mut files, &mut fid_defs, &mut defs, fid)?;
+                drop_file_entries(
+                    &mut files,
+                    &mut fid_defs,
+                    &mut defs,
+                    &mut fid_refs,
+                    &mut refs_t,
+                    &mut sid_refs_out,
+                    fid,
+                )?;
                 path_to_fid.remove(path_str.as_ref())?;
                 fid_to_path.remove(&fid)?;
             }
 
-            // Upserts.
+            // Upserts: **two-pass** to avoid intra-batch ordering bugs.
+            //
+            // Pass 1: assign FIDs, drop prior entries, write FileMeta +
+            // DEFS + FID_DEFS, intern names. After Pass 1 every def name
+            // in the batch is present in NAME_TO_SID.
+            //
+            // Pass 2: write refs. Now every same-batch callee resolves
+            // correctly via NAME_TO_SID. Before this refactor, callers
+            // in a file processed earlier than their callee's file
+            // would have their refs filtered as "external."
+            //
+            // We carry `(fid, file_defs)` between passes so the caller_sid
+            // resolution in Pass 2 still has access to the file's own def
+            // ranges.
+            let mut staged: Vec<(u32, Vec<(u32, u32, u32)>, Vec<RefHit>)> =
+                Vec::with_capacity(upserts.len());
+
+            // Pass 1.
             for entry in upserts {
                 let path_str = entry.path.to_string_lossy().to_string();
 
@@ -252,12 +314,26 @@ impl Store {
                     parse_failed_delta -= 1;
                 }
 
-                // Drop prior defs for this file before re-inserting; this is the
-                // simplest correct policy and avoids stale-symbol leaks.
-                drop_file_entries(&mut files, &mut fid_defs, &mut defs, fid)?;
+                // Drop prior defs *and* refs for this file before re-inserting;
+                // this is the simplest correct policy and avoids stale-symbol
+                // and stale-edge leaks.
+                drop_file_entries(
+                    &mut files,
+                    &mut fid_defs,
+                    &mut defs,
+                    &mut fid_refs,
+                    &mut refs_t,
+                    &mut sid_refs_out,
+                    fid,
+                )?;
 
                 let meta_bytes = to_allocvec(&entry.meta).context("encode FileMeta")?;
                 files.insert(&fid, meta_bytes.as_slice())?;
+
+                // Track each def's (sid, range) so we can compute caller_sid
+                // for ref sites in this file. Smallest enclosing range wins
+                // — same policy as `pick_innermost_def` in `methods/index`.
+                let mut file_defs: Vec<(u32, u32, u32)> = Vec::with_capacity(entry.defs.len());
 
                 for (name, mut def, kind) in entry.defs {
                     let existing_sid = name_to_sid.get(name.as_str())?.map(|v| v.value());
@@ -275,9 +351,39 @@ impl Store {
                     let def_bytes = to_allocvec(&def).context("encode DefSite")?;
                     defs.insert(&sid, def_bytes.as_slice())?;
                     fid_defs.insert(&fid, &sid)?;
+                    file_defs.push((sid, def.start, def.end));
                 }
 
+                staged.push((fid, file_defs, entry.refs));
                 indexed += 1;
+            }
+
+            // Pass 2: refs. Every same-batch callee is now interned.
+            // External names (no NAME_TO_SID entry after Pass 1) are
+            // filtered per v0.3 plan §F1.
+            for (fid, file_defs, refs) in staged {
+                for r in refs {
+                    let callee_sid = match name_to_sid.get(r.name.as_str())? {
+                        Some(v) => v.value(),
+                        None => continue, // external symbol; skip per F1
+                    };
+                    let caller_sid = enclosing_caller_sid(&file_defs, r.start);
+
+                    let site = RefSite {
+                        fid,
+                        start: r.start,
+                        end: r.end,
+                        start_line: r.start_line,
+                        end_line: r.end_line,
+                        caller_sid,
+                    };
+                    let site_bytes = to_allocvec(&site).context("encode RefSite")?;
+                    refs_t.insert(&callee_sid, site_bytes.as_slice())?;
+                    fid_refs.insert(&fid, &callee_sid)?;
+                    if let Some(c) = caller_sid {
+                        sid_refs_out.insert(&c, &callee_sid)?;
+                    }
+                }
             }
 
             // Persist next-id counters and any other metadata for restart.
@@ -440,6 +546,111 @@ impl Store {
         }
     }
 
+    /// All references *into* a symbol — "who calls X, and where?"
+    /// One entry per call site. The caller (FindCallers handler, v0.3
+    /// U2') resolves `caller_sid` → qualified name via SID_TO_NAME +
+    /// DEFS lookup. Returns `Ok(Vec::new())` for symbols with no
+    /// indexed callers (or for unknown sids).
+    ///
+    /// Order: insertion order within each `(callee_sid)` multimap
+    /// key, which is arbitrary. Callers that want stable ordering
+    /// should sort by `(fid, start)`.
+    #[allow(dead_code)] // consumed by v0.3 U2' (Index.FindCallers)
+    pub fn refs_to_symbol(&self, callee_sid: u32) -> anyhow::Result<Vec<RefSite>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let refs_t = txn.open_multimap_table(REFS)?;
+        let mut out: Vec<RefSite> = Vec::new();
+        let it = refs_t.get(&callee_sid)?;
+        for row in it {
+            let bytes = row?.value().to_vec();
+            if let Ok(rs) = from_bytes::<RefSite>(&bytes) {
+                out.push(rs);
+            }
+        }
+        Ok(out)
+    }
+
+    /// All references *from* a symbol — "what does X reference?"
+    /// Returns the set of callee sids X has outgoing edges to. The
+    /// closure walker (v0.3 U3) uses this to enumerate dependencies
+    /// without re-parsing the anchor file.
+    ///
+    /// Note: this returns only edges where the caller_sid is `Some(X)`
+    /// — file-scope refs are excluded (they have no caller to key on).
+    #[allow(dead_code)] // consumed by v0.3 U3 (closure walker)
+    pub fn refs_from_symbol(&self, caller_sid: u32) -> anyhow::Result<Vec<u32>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let sid_refs_out = txn.open_multimap_table(SID_REFS_OUT)?;
+        let mut out: Vec<u32> = Vec::new();
+        let it = sid_refs_out.get(&caller_sid)?;
+        for row in it {
+            out.push(row?.value());
+        }
+        Ok(out)
+    }
+
+    /// All callee sids referenced by `fid`. The set is deduplicated
+    /// (FID_REFS multimap semantics) — if a file references callee C
+    /// three times, this returns C once. Use [`refs_to_symbol`] for
+    /// per-site information.
+    ///
+    /// `outline::compute` uses [`refs_for_file_resolved`] (which
+    /// returns per-callsite counts + resolved names); this lower-level
+    /// helper is retained for callers that want the raw sid set
+    /// without the SID_TO_NAME join.
+    #[allow(dead_code)] // raw-sid variant; production code uses refs_for_file_resolved
+    pub fn refs_for_file(&self, fid: u32) -> anyhow::Result<Vec<u32>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let fid_refs = txn.open_multimap_table(FID_REFS)?;
+        let mut out: Vec<u32> = Vec::new();
+        let it = fid_refs.get(&fid)?;
+        for row in it {
+            out.push(row?.value());
+        }
+        Ok(out)
+    }
+
+    /// Per-file outgoing refs with their callee names resolved. Used
+    /// by `outline::compute` for the file-level PageRank graph
+    /// construction (which keys edges by name to apply the Aider
+    /// edge-weight recipe).
+    ///
+    /// Returns `(callee_name, ref_count)` tuples where `ref_count`
+    /// is the number of *individual call sites* in the file to that
+    /// callee (not the dedup'd FID_REFS multimap count). Names with
+    /// no SID_TO_NAME entry are silently filtered.
+    pub fn refs_for_file_resolved(&self, fid: u32) -> anyhow::Result<Vec<(String, u32)>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let fid_refs = txn.open_multimap_table(FID_REFS)?;
+        let refs_t = txn.open_multimap_table(REFS)?;
+        let sid_to_name = txn.open_table(SID_TO_NAME)?;
+        let mut out: Vec<(String, u32)> = Vec::new();
+        let it = fid_refs.get(&fid)?;
+        for row in it {
+            let callee_sid = row?.value();
+            let name = match sid_to_name.get(&callee_sid)? {
+                Some(v) => v.value().to_string(),
+                None => continue,
+            };
+            // Count per-file call sites by walking REFS[callee_sid]
+            // and filtering to this fid.
+            let mut count: u32 = 0;
+            let site_it = refs_t.get(&callee_sid)?;
+            for site_row in site_it {
+                let bytes = site_row?.value().to_vec();
+                if let Ok(rs) = from_bytes::<RefSite>(&bytes) {
+                    if rs.fid == fid {
+                        count += 1;
+                    }
+                }
+            }
+            if count > 0 {
+                out.push((name, count));
+            }
+        }
+        Ok(out)
+    }
+
     /// Resolve a name to all of its def sites + the file path each lives in.
     ///
     /// Returned in arbitrary order; the caller (`Index.FindSymbol` handler) is
@@ -522,10 +733,19 @@ pub struct FoundSymbol {
     pub visibility: schema::Visibility,
 }
 
+// Long arg list is the cost of operating on six redb tables in one
+// txn. Wrapping in a struct would just relocate the noise. The single
+// caller is `commit_batch` (twice — once for removals, once before
+// upserting a file). Stable across U1; v0.3 U5+ may revisit if more
+// tables join the txn.
+#[allow(clippy::too_many_arguments)]
 fn drop_file_entries(
     files: &mut redb::Table<'_, u32, &[u8]>,
     fid_defs: &mut redb::MultimapTable<'_, u32, u32>,
     defs: &mut redb::MultimapTable<'_, u32, &[u8]>,
+    fid_refs: &mut redb::MultimapTable<'_, u32, u32>,
+    refs_t: &mut redb::MultimapTable<'_, u32, &[u8]>,
+    sid_refs_out: &mut redb::MultimapTable<'_, u32, u32>,
     fid: u32,
 ) -> anyhow::Result<()> {
     // Drop the file row itself.
@@ -538,7 +758,7 @@ fn drop_file_entries(
     // and re-insert what remains. This is O(touched SIDs × avg fan-out) — fine
     // for v0; a later phase may use a tuple-key (FID, SID) table to make this
     // O(1) per drop.
-    let prior_sids: Vec<u32> = {
+    let prior_def_sids: Vec<u32> = {
         let mut v = Vec::new();
         let it = fid_defs.get(&fid)?;
         for row in it {
@@ -548,11 +768,11 @@ fn drop_file_entries(
     };
     fid_defs.remove_all(&fid)?;
 
-    for sid in prior_sids {
+    for sid in &prior_def_sids {
         // Read & filter.
         let kept: Vec<Vec<u8>> = {
             let mut v = Vec::new();
-            let it = defs.get(&sid)?;
+            let it = defs.get(sid)?;
             for row in it {
                 let bytes = row?.value().to_vec();
                 if let Ok(d) = from_bytes::<DefSite>(&bytes) {
@@ -563,12 +783,119 @@ fn drop_file_entries(
             }
             v
         };
-        defs.remove_all(&sid)?;
+        defs.remove_all(sid)?;
         for v in kept {
-            defs.insert(&sid, v.as_slice())?;
+            defs.insert(sid, v.as_slice())?;
+        }
+    }
+
+    // v0.3 (U1): drop refs that originated in this file. REFS is keyed by
+    // *callee_sid* — so to drop "refs that file F made to anything," we
+    // must:
+    //   1. Walk FID_REFS[fid] → set of callee sids C₁..Cₙ that this file
+    //      referenced.
+    //   2. For each Cᵢ, read REFS[Cᵢ], filter out RefSites whose `fid` ==
+    //      the file being dropped, re-insert the remainder. Mirrors the
+    //      defs filter-by-fid above. Crucial that this is by-fid, not
+    //      by-callee-sid: callee Cᵢ may have refs from many files, and
+    //      we only want to drop the ones originating in this file.
+    //   3. For SID_REFS_OUT, we know which caller_sids in this file's
+    //      defs (`prior_def_sids`) contributed outgoing edges; clear all
+    //      of those — they'll be re-inserted by the upsert that
+    //      follows. If a sid still has defs in OTHER files, its outgoing
+    //      edges from those other files should remain.
+    let prior_ref_callees: Vec<u32> = {
+        let mut v = Vec::new();
+        let it = fid_refs.get(&fid)?;
+        for row in it {
+            v.push(row?.value());
+        }
+        v
+    };
+    fid_refs.remove_all(&fid)?;
+
+    for callee_sid in prior_ref_callees {
+        let kept: Vec<Vec<u8>> = {
+            let mut v = Vec::new();
+            let it = refs_t.get(&callee_sid)?;
+            for row in it {
+                let bytes = row?.value().to_vec();
+                if let Ok(rs) = from_bytes::<RefSite>(&bytes) {
+                    if rs.fid != fid {
+                        v.push(bytes);
+                    }
+                }
+            }
+            v
+        };
+        refs_t.remove_all(&callee_sid)?;
+        for v in kept {
+            refs_t.insert(&callee_sid, v.as_slice())?;
+        }
+    }
+
+    // Outgoing edges: for each def sid that was in this file, the
+    // upsert loop will re-insert its outgoing refs (or not, if the
+    // sid is going away). Clearing all outgoing edges for these sids
+    // is correct ONLY when this file owns the def. If a name has
+    // defs in multiple files, the other files' outgoing edges are
+    // *also* keyed by the same sid — and we'd clobber them.
+    //
+    // Solution: filter SID_REFS_OUT by what's still alive. Read each
+    // sid's outgoing edges, but we don't have file-tag inside SID_REFS_OUT
+    // (it's u32→u32). So we must walk REFS for each outgoing callee_sid
+    // and check if any caller-side RefSite with caller_sid==sid still
+    // references it from another file.
+    //
+    // Simpler shape that's still correct: rebuild SID_REFS_OUT from
+    // surviving REFS rows after the per-file rewrite above. We do
+    // that once per drop call by walking the touched callee_sids.
+    for sid in &prior_def_sids {
+        // Capture the existing outgoing-edge set BEFORE we wipe it.
+        let prior_callees: Vec<u32> = {
+            let mut v = Vec::new();
+            let it = sid_refs_out.get(sid)?;
+            for row in it {
+                v.push(row?.value());
+            }
+            v
+        };
+        sid_refs_out.remove_all(sid)?;
+
+        // Re-insert any callees that still have a RefSite with
+        // caller_sid == sid from a file OTHER than `fid`.
+        for callee in prior_callees {
+            let it = refs_t.get(&callee)?;
+            for row in it {
+                let bytes = row?.value().to_vec();
+                if let Ok(rs) = from_bytes::<RefSite>(&bytes) {
+                    if rs.caller_sid == Some(*sid) && rs.fid != fid {
+                        sid_refs_out.insert(sid, &callee)?;
+                        break;
+                    }
+                }
+            }
         }
     }
     Ok(())
+}
+
+/// Find the smallest enclosing def whose byte range covers `byte`.
+/// Returns the sid of the innermost containing def, or `None` when
+/// the byte is outside every def (file-scope statement). The list
+/// is the file's own defs as `(sid, start, end)` triples; smallest
+/// range (end - start) wins on ties.
+fn enclosing_caller_sid(file_defs: &[(u32, u32, u32)], byte: u32) -> Option<u32> {
+    let mut best: Option<(u32, u32)> = None; // (sid, range_size)
+    for &(sid, start, end) in file_defs {
+        if byte >= start && byte < end {
+            let span = end.saturating_sub(start);
+            if best.map(|(_, b)| span < b).unwrap_or(true) {
+                best = Some((sid, span));
+            }
+        }
+    }
+    best.map(|(sid, _)| sid)
 }
 
 fn u32_from_le_slice(slice: &[u8]) -> Option<u32> {
@@ -648,6 +975,7 @@ mod tests {
                     SymbolKind::Struct,
                 ),
             ],
+            refs: Vec::new(),
         };
         let n = store
             .commit_batch(vec![entry], vec![], Durability::Immediate)
@@ -686,6 +1014,7 @@ mod tests {
                 },
                 SymbolKind::Function,
             )],
+            refs: Vec::new(),
         };
         store
             .commit_batch(vec![v1], vec![], Durability::Immediate)
@@ -708,6 +1037,7 @@ mod tests {
                 },
                 SymbolKind::Function,
             )],
+            refs: Vec::new(),
         };
         store
             .commit_batch(vec![v2], vec![], Durability::Immediate)
@@ -738,6 +1068,7 @@ mod tests {
                 },
                 SymbolKind::Function,
             )],
+            refs: Vec::new(),
         };
         store
             .commit_batch(vec![entry], vec![], Durability::Immediate)
@@ -754,6 +1085,426 @@ mod tests {
             )
             .unwrap();
         assert!(store.find_symbol("vanish").unwrap().is_empty());
+    }
+
+    // ---------- v0.3 ref-graph tests (U1) ----------
+
+    fn fn_def(start: u32, end: u32, start_line: u32, end_line: u32) -> DefSite {
+        DefSite {
+            fid: 0,
+            start,
+            end,
+            start_line,
+            end_line,
+            visibility: Visibility::Public,
+            kind: SymbolKind::Function,
+        }
+    }
+
+    #[test]
+    fn refs_round_trip_writes_all_three_tables() {
+        // Two-file fixture:
+        //   def.rs defines `callee` at bytes [0, 50)
+        //   call.rs defines `caller` at bytes [0, 100); inside caller's
+        //   range there's a ref to `callee` at byte 30.
+        // After commit:
+        //   - refs_to_symbol(callee_sid) returns 1 RefSite with caller_sid == sid(caller)
+        //   - refs_from_symbol(caller_sid) returns [callee_sid]
+        //   - refs_for_file(call.rs fid) returns [callee_sid]
+        let (_tmp, store) = temp_store();
+
+        let def_entry = FileBatchEntry {
+            path: std::path::PathBuf::from("def.rs"),
+            meta: rust_meta(blake3::hash(b"def").into()),
+            defs: vec![(
+                "callee".to_string(),
+                fn_def(0, 50, 1, 5),
+                SymbolKind::Function,
+            )],
+            refs: Vec::new(),
+        };
+
+        let call_entry = FileBatchEntry {
+            path: std::path::PathBuf::from("call.rs"),
+            meta: rust_meta(blake3::hash(b"call").into()),
+            defs: vec![(
+                "caller".to_string(),
+                fn_def(0, 100, 1, 10),
+                SymbolKind::Function,
+            )],
+            refs: vec![RefHit {
+                name: "callee".to_string(),
+                start: 30,
+                end: 36,
+                start_line: 3,
+                end_line: 3,
+            }],
+        };
+
+        store
+            .commit_batch(vec![def_entry, call_entry], vec![], Durability::Immediate)
+            .unwrap();
+
+        // Resolve sids via find_symbol so we don't have to peek under the
+        // hood at NAME_TO_SID directly.
+        let callee_hits = store.find_symbol("callee").unwrap();
+        assert_eq!(callee_hits.len(), 1);
+        let caller_hits = store.find_symbol("caller").unwrap();
+        assert_eq!(caller_hits.len(), 1);
+
+        // The sids aren't on FoundSymbol; we'll grab them via a read txn
+        // on NAME_TO_SID. (In production code, U2's FindCallers handler
+        // does this same lookup.)
+        let txn = store.db.begin_read().unwrap();
+        let name_to_sid = txn.open_table(NAME_TO_SID).unwrap();
+        let callee_sid = name_to_sid.get("callee").unwrap().unwrap().value();
+        let caller_sid = name_to_sid.get("caller").unwrap().unwrap().value();
+        drop(name_to_sid);
+        drop(txn);
+
+        // refs_to_symbol: 1 caller of `callee`, sourced from call.rs.
+        let into_callee = store.refs_to_symbol(callee_sid).unwrap();
+        assert_eq!(into_callee.len(), 1, "expected one ref site into callee");
+        let rs = &into_callee[0];
+        assert_eq!(rs.start, 30);
+        assert_eq!(rs.end, 36);
+        assert_eq!(rs.start_line, 3);
+        assert_eq!(
+            rs.caller_sid,
+            Some(caller_sid),
+            "caller_sid should resolve to the enclosing caller def"
+        );
+
+        // refs_from_symbol: caller references [callee_sid].
+        let out_of_caller = store.refs_from_symbol(caller_sid).unwrap();
+        assert_eq!(out_of_caller, vec![callee_sid]);
+
+        // refs_from_symbol for callee (which defines nothing it calls): empty.
+        let out_of_callee = store.refs_from_symbol(callee_sid).unwrap();
+        assert!(out_of_callee.is_empty());
+
+        // refs_for_file(call.rs) returns the set of callees from that file.
+        let txn = store.db.begin_read().unwrap();
+        let path_to_fid = txn.open_table(PATH_TO_FID).unwrap();
+        let call_fid = path_to_fid.get("call.rs").unwrap().unwrap().value();
+        drop(path_to_fid);
+        drop(txn);
+        let file_refs = store.refs_for_file(call_fid).unwrap();
+        assert_eq!(file_refs, vec![callee_sid]);
+    }
+
+    #[test]
+    fn refs_external_symbol_filtered_at_commit() {
+        // A file references `Vec` (not workspace-defined). After commit,
+        // no REFS row should exist for `Vec` — we filter externals per
+        // the v0.3 plan §F1 "drop external-symbol storage."
+        let (_tmp, store) = temp_store();
+
+        let entry = FileBatchEntry {
+            path: std::path::PathBuf::from("uses_vec.rs"),
+            meta: rust_meta(blake3::hash(b"v").into()),
+            defs: vec![(
+                "local_fn".to_string(),
+                fn_def(0, 50, 1, 5),
+                SymbolKind::Function,
+            )],
+            refs: vec![RefHit {
+                name: "Vec".to_string(), // external: never defined locally
+                start: 20,
+                end: 23,
+                start_line: 2,
+                end_line: 2,
+            }],
+        };
+        store
+            .commit_batch(vec![entry], vec![], Durability::Immediate)
+            .unwrap();
+
+        // NAME_TO_SID should not have an entry for "Vec" (we skip it at
+        // commit time before allocating a sid).
+        let txn = store.db.begin_read().unwrap();
+        let name_to_sid = txn.open_table(NAME_TO_SID).unwrap();
+        assert!(
+            name_to_sid.get("Vec").unwrap().is_none(),
+            "external symbols should NOT be interned"
+        );
+    }
+
+    #[test]
+    fn refs_invalidate_when_referring_file_dropped() {
+        // Two files A and B both ref C. Drop A. B's ref to C survives.
+        // This is the multi-file invalidation test from the Deepening C1.
+        let (_tmp, store) = temp_store();
+
+        let def_c = FileBatchEntry {
+            path: std::path::PathBuf::from("c.rs"),
+            meta: rust_meta(blake3::hash(b"c").into()),
+            defs: vec![("C".to_string(), fn_def(0, 10, 1, 2), SymbolKind::Function)],
+            refs: Vec::new(),
+        };
+        let a = FileBatchEntry {
+            path: std::path::PathBuf::from("a.rs"),
+            meta: rust_meta(blake3::hash(b"a").into()),
+            defs: vec![("A".to_string(), fn_def(0, 100, 1, 10), SymbolKind::Function)],
+            refs: vec![RefHit {
+                name: "C".to_string(),
+                start: 50,
+                end: 51,
+                start_line: 5,
+                end_line: 5,
+            }],
+        };
+        let b = FileBatchEntry {
+            path: std::path::PathBuf::from("b.rs"),
+            meta: rust_meta(blake3::hash(b"b").into()),
+            defs: vec![("B".to_string(), fn_def(0, 100, 1, 10), SymbolKind::Function)],
+            refs: vec![RefHit {
+                name: "C".to_string(),
+                start: 60,
+                end: 61,
+                start_line: 6,
+                end_line: 6,
+            }],
+        };
+
+        store
+            .commit_batch(vec![def_c, a, b], vec![], Durability::Immediate)
+            .unwrap();
+
+        let txn = store.db.begin_read().unwrap();
+        let name_to_sid = txn.open_table(NAME_TO_SID).unwrap();
+        let c_sid = name_to_sid.get("C").unwrap().unwrap().value();
+        drop(name_to_sid);
+        drop(txn);
+
+        // Both A and B should ref C → REFS[c_sid] has 2 entries.
+        let before = store.refs_to_symbol(c_sid).unwrap();
+        assert_eq!(before.len(), 2, "expected 2 ref sites into C");
+
+        // Drop A.
+        store
+            .commit_batch(
+                vec![],
+                vec![FileBatchRemoval {
+                    path: std::path::PathBuf::from("a.rs"),
+                }],
+                Durability::Immediate,
+            )
+            .unwrap();
+
+        // B's ref to C survives.
+        let after = store.refs_to_symbol(c_sid).unwrap();
+        assert_eq!(
+            after.len(),
+            1,
+            "B's ref to C must survive A's deletion (filter-by-fid)"
+        );
+        // The surviving site is from b.rs.
+        let txn = store.db.begin_read().unwrap();
+        let path_to_fid = txn.open_table(PATH_TO_FID).unwrap();
+        let b_fid = path_to_fid.get("b.rs").unwrap().unwrap().value();
+        drop(path_to_fid);
+        drop(txn);
+        assert_eq!(after[0].fid, b_fid);
+    }
+
+    #[test]
+    fn refs_invalidate_on_re_upsert() {
+        // A file re-saved with a different set of refs should clear
+        // its prior REFS contributions and write fresh ones.
+        let (_tmp, store) = temp_store();
+
+        let def_c = FileBatchEntry {
+            path: std::path::PathBuf::from("c.rs"),
+            meta: rust_meta(blake3::hash(b"c").into()),
+            defs: vec![("C".to_string(), fn_def(0, 10, 1, 2), SymbolKind::Function)],
+            refs: Vec::new(),
+        };
+        let def_d = FileBatchEntry {
+            path: std::path::PathBuf::from("d.rs"),
+            meta: rust_meta(blake3::hash(b"d").into()),
+            defs: vec![("D".to_string(), fn_def(0, 10, 1, 2), SymbolKind::Function)],
+            refs: Vec::new(),
+        };
+        let a_v1 = FileBatchEntry {
+            path: std::path::PathBuf::from("a.rs"),
+            meta: rust_meta(blake3::hash(b"v1").into()),
+            defs: vec![("A".to_string(), fn_def(0, 100, 1, 10), SymbolKind::Function)],
+            refs: vec![RefHit {
+                name: "C".to_string(),
+                start: 50,
+                end: 51,
+                start_line: 5,
+                end_line: 5,
+            }],
+        };
+        store
+            .commit_batch(vec![def_c, def_d, a_v1], vec![], Durability::Immediate)
+            .unwrap();
+
+        let txn = store.db.begin_read().unwrap();
+        let name_to_sid = txn.open_table(NAME_TO_SID).unwrap();
+        let c_sid = name_to_sid.get("C").unwrap().unwrap().value();
+        let d_sid = name_to_sid.get("D").unwrap().unwrap().value();
+        drop(name_to_sid);
+        drop(txn);
+
+        assert_eq!(store.refs_to_symbol(c_sid).unwrap().len(), 1);
+        assert!(store.refs_to_symbol(d_sid).unwrap().is_empty());
+
+        // Re-save a.rs with a ref to D instead of C.
+        let a_v2 = FileBatchEntry {
+            path: std::path::PathBuf::from("a.rs"),
+            meta: rust_meta(blake3::hash(b"v2").into()),
+            defs: vec![("A".to_string(), fn_def(0, 100, 1, 10), SymbolKind::Function)],
+            refs: vec![RefHit {
+                name: "D".to_string(),
+                start: 70,
+                end: 71,
+                start_line: 7,
+                end_line: 7,
+            }],
+        };
+        store
+            .commit_batch(vec![a_v2], vec![], Durability::Immediate)
+            .unwrap();
+
+        // A's old ref to C is gone; new ref to D is present.
+        assert!(
+            store.refs_to_symbol(c_sid).unwrap().is_empty(),
+            "re-upsert should clear prior refs"
+        );
+        let into_d = store.refs_to_symbol(d_sid).unwrap();
+        assert_eq!(into_d.len(), 1);
+    }
+
+    #[test]
+    fn refs_for_file_resolved_returns_per_file_callsite_count() {
+        // call.rs has 3 refs to callee → refs_for_file_resolved returns
+        // ("callee", 3). The dedup'd FID_REFS multimap would say "1
+        // distinct callee," but per-call-site count is what
+        // outline::compute needs for the Aider edge-weight recipe.
+        let (_tmp, store) = temp_store();
+
+        let def_entry = FileBatchEntry {
+            path: std::path::PathBuf::from("def.rs"),
+            meta: rust_meta(blake3::hash(b"def").into()),
+            defs: vec![(
+                "callee".to_string(),
+                fn_def(0, 10, 1, 2),
+                SymbolKind::Function,
+            )],
+            refs: Vec::new(),
+        };
+        let call_entry = FileBatchEntry {
+            path: std::path::PathBuf::from("call.rs"),
+            meta: rust_meta(blake3::hash(b"call").into()),
+            defs: vec![(
+                "caller".to_string(),
+                fn_def(0, 200, 1, 20),
+                SymbolKind::Function,
+            )],
+            refs: vec![
+                RefHit {
+                    name: "callee".to_string(),
+                    start: 30,
+                    end: 36,
+                    start_line: 3,
+                    end_line: 3,
+                },
+                RefHit {
+                    name: "callee".to_string(),
+                    start: 60,
+                    end: 66,
+                    start_line: 6,
+                    end_line: 6,
+                },
+                RefHit {
+                    name: "callee".to_string(),
+                    start: 90,
+                    end: 96,
+                    start_line: 9,
+                    end_line: 9,
+                },
+            ],
+        };
+        store
+            .commit_batch(vec![def_entry, call_entry], vec![], Durability::Immediate)
+            .unwrap();
+
+        let txn = store.db.begin_read().unwrap();
+        let path_to_fid = txn.open_table(PATH_TO_FID).unwrap();
+        let call_fid = path_to_fid.get("call.rs").unwrap().unwrap().value();
+        drop(path_to_fid);
+        drop(txn);
+
+        let resolved = store.refs_for_file_resolved(call_fid).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].0, "callee");
+        assert_eq!(resolved[0].1, 3, "3 call sites in this file");
+    }
+
+    #[test]
+    fn v1_to_v2_schema_mismatch_triggers_rebuild() {
+        // Simulate a v0.2 redb file by seeding SCHEMA_VERSION=1, then
+        // open it with the v0.3 binary (SCHEMA_VERSION=2). The existing
+        // `Store::open` rebuild path at mod.rs:124-148 wipes and
+        // recreates; the new tables (REFS, FID_REFS, SID_REFS_OUT)
+        // must be open-able after the rebuild, and the workspace
+        // starts fresh (no leaked rows).
+        //
+        // This is v0.3's first real exercise of the schema-mismatch
+        // rebuild path (the policy was introduced in v0.2 alpha.1 but
+        // never tripped because SCHEMA_VERSION stayed at 1 for the
+        // entire alpha line).
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("db.redb");
+
+        // Seed a v1 db with some content + the old SCHEMA_VERSION metadata.
+        {
+            let db = redb::Database::create(&path).unwrap();
+            let w = db.begin_write().unwrap();
+            {
+                let mut meta = w.open_table(META).unwrap();
+                meta.insert(META_SCHEMA_VERSION, &1u32.to_le_bytes()[..])
+                    .unwrap();
+                let mut path_to_fid = w.open_table(PATH_TO_FID).unwrap();
+                path_to_fid.insert("stale.rs", 42u32).unwrap();
+            }
+            w.commit().unwrap();
+        }
+
+        // Open with v0.3 binary. Should silently rebuild.
+        let store = Store::open(&path).unwrap();
+
+        // The v1 data should be gone (rebuild wiped it).
+        let no_match = store.find_symbol("anything").unwrap();
+        assert!(no_match.is_empty(), "rebuild should erase prior content");
+
+        // The new v0.3 tables should be present + usable. We exercise
+        // them via a fresh commit that includes refs — if the tables
+        // weren't initialised, this would fail with TableDoesNotExist.
+        let entry = FileBatchEntry {
+            path: std::path::PathBuf::from("fresh.rs"),
+            meta: rust_meta(blake3::hash(b"fresh").into()),
+            defs: vec![("X".to_string(), fn_def(0, 10, 1, 2), SymbolKind::Function)],
+            refs: Vec::new(),
+        };
+        store
+            .commit_batch(vec![entry], vec![], Durability::Immediate)
+            .unwrap();
+        assert_eq!(store.find_symbol("X").unwrap().len(), 1);
+
+        // SCHEMA_VERSION metadata is now v2.
+        let txn = store.db.begin_read().unwrap();
+        let meta = txn.open_table(META).unwrap();
+        let stored = meta
+            .get(META_SCHEMA_VERSION)
+            .unwrap()
+            .and_then(|v| u32_from_le_slice(v.value()))
+            .unwrap();
+        assert_eq!(stored, SCHEMA_VERSION);
+        assert_eq!(stored, 2);
     }
 
     #[test]

--- a/crates/rts-daemon/src/store/schema.rs
+++ b/crates/rts-daemon/src/store/schema.rs
@@ -25,6 +25,50 @@ pub const DEFS: MultimapTableDefinition<u32, &[u8]> = MultimapTableDefinition::n
 /// Inverse fan-out for cheap per-file invalidation: `file_id` → set of `sid`s
 /// it defines.
 pub const FID_DEFS: MultimapTableDefinition<u32, u32> = MultimapTableDefinition::new("fid_defs");
+
+// ---------- v0.3 reference-graph tables (SCHEMA_VERSION=2; U1 of v0.3 plan) ----------
+//
+// Three tables form the call-graph half of the index. v0.2 computed
+// references at query time and threw them away; v0.3 persists them so
+// `Index.FindCallers`, `Index.ImpactOf`, and symbol-level PageRank
+// (`rank_score`) become O(1) lookups instead of O(workspace) scans.
+//
+// Shape rationale (see v0.3 plan §"Architecture" + deepening §B1):
+//   * Multimap blob-of-postcard for REFS mirrors DEFS. Bytes-equal
+//     entries dedupe; the secondary B-tree handles per-key fan-out
+//     without rewriting the whole vec on each update.
+//   * FID_REFS gives O(1) per-file ref invalidation symmetric to
+//     FID_DEFS — `drop_file_entries` extends naturally.
+//   * SID_REFS_OUT gives the *outgoing* direction ("what does X
+//     reference?") cheaply. Without it, the closure walker would
+//     have to scan all REFS to find rows where caller_sid == X.
+//     Landed in U1 (not U4) to avoid a second SCHEMA_VERSION bump.
+
+/// Multimap `callee_sid (u32)` → postcard(`RefSite`). One entry per
+/// individual call site, so `REFS[X]` answers "who calls X, and
+/// where?" with one lookup. Used by `Index.FindCallers` (v0.3 U2').
+pub const REFS: MultimapTableDefinition<u32, &[u8]> = MultimapTableDefinition::new("refs");
+
+/// Multimap `file_id (u32)` → set of `callee_sid (u32)`s referenced
+/// in that file. Used by `outline::compute` to enumerate outgoing
+/// refs per file (replacing the at-query-time parse loop). Also the
+/// invalidation key for `drop_file_entries`: when a file is removed,
+/// FID_REFS[fid] enumerates which REFS rows need a filter-by-fid
+/// rewrite.
+///
+/// Multimap dedupes — if file F references callee C three times,
+/// only one row `(F → C)` is stored. The three individual call
+/// sites all live in REFS[C].
+pub const FID_REFS: MultimapTableDefinition<u32, u32> = MultimapTableDefinition::new("fid_refs");
+
+/// Multimap `caller_sid (u32)` → set of `callee_sid (u32)`s the
+/// caller references. Used by `closure::compute` (v0.3 U3) to answer
+/// "what does symbol X call?" without re-parsing the anchor file.
+/// File-scope refs (callsites not inside any def) are excluded —
+/// they have no caller_sid to key on.
+pub const SID_REFS_OUT: MultimapTableDefinition<u32, u32> =
+    MultimapTableDefinition::new("sid_refs_out");
+
 /// Small key-value table for daemon-internal metadata (schema_version,
 /// next_fid, next_sid, workspace_fingerprint, …).
 pub const META: TableDefinition<&str, &[u8]> = TableDefinition::new("meta");
@@ -65,6 +109,29 @@ pub struct DefSite {
     pub end_line: u32,
     pub visibility: Visibility,
     pub kind: SymbolKind,
+}
+
+/// A single reference site: where one symbol is called from. Used as
+/// the value type for the `REFS` multimap, keyed by `callee_sid`.
+///
+/// `caller_sid` is the SID of the smallest enclosing def whose range
+/// covers `start`. `None` when the call site is outside any def
+/// (e.g. a top-level expression statement, a static initializer at
+/// module scope, or a JavaScript top-level call).
+///
+/// Postcard varint-encodes u32s, so a typical RefSite serializes to
+/// ~12 bytes (5 u32s in the 1-2 byte range + 1-byte enum tag for
+/// caller_sid `Option`). Worst case is 26 bytes when every field is
+/// > 2^28. The redb B-tree sorts by *key* (callee_sid), not by
+/// blob bytes; insertion order within a multimap key is arbitrary.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct RefSite {
+    pub fid: u32,
+    pub start: u32,
+    pub end: u32,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub caller_sid: Option<u32>,
 }
 
 /// Cross-language symbol kind. Coarse-grained on purpose; per-language

--- a/crates/rts-daemon/src/writer.rs
+++ b/crates/rts-daemon/src/writer.rs
@@ -430,6 +430,7 @@ fn parse_and_extract(
                 oversize: true,
             },
             defs: Vec::new(),
+            refs: Vec::new(),
         });
     }
 
@@ -467,6 +468,7 @@ fn parse_and_extract(
                     oversize: false,
                 },
                 defs: Vec::new(),
+                refs: Vec::new(),
             });
         }
     };
@@ -475,6 +477,17 @@ fn parse_and_extract(
         .into_iter()
         .filter_map(|sym| symbol_to_def(&sym, &content))
         .collect();
+
+    // v0.3 (U1): extract reference sites alongside defs so the
+    // store's REFS/FID_REFS/SID_REFS_OUT tables get populated on
+    // every commit. `references_with_ranges` returns one `RefHit`
+    // per AST-precise call/reference (Rust/Python/Go/Ruby/JS/TS via
+    // tags.scm; regex fallback for the remaining languages with no
+    // byte ranges — we synthesize empty ranges so the schema stays
+    // populated even on fallback paths). Filtering of external
+    // (non-workspace-defined) names happens at commit time inside
+    // `Store::commit_batch` where the def universe is known.
+    let refs = crate::refs::references_with_ranges(rel_path.to_string_lossy().as_ref(), &content);
 
     Ok(FileBatchEntry {
         path: rel_path.to_path_buf(),
@@ -486,6 +499,7 @@ fn parse_and_extract(
             oversize: false,
         },
         defs,
+        refs,
     })
 }
 


### PR DESCRIPTION
> Re-opened on `main` after the original [#28](https://github.com/njfio/rs-agent-code-utility/pull/28) was auto-closed when its base branch (`feat/protocol-v0-respec-alpha-31`, from PR #27) was deleted on merge. Branch rebased cleanly onto current main. Tests still 539/0.

## Summary

Persists the reference half of the call graph in three new redb tables (`REFS`, `FID_REFS`, `SID_REFS_OUT`) so v0.3 U2'-U5 can read indexed edges instead of re-parsing at query time. First substantive PR of the [v0.3 code-graph KB plan](docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md).

## Schema (SCHEMA_VERSION 1 → 2)

Existing `Store::open` rebuild-on-mismatch path triggers automatically — no migration code needed.

```text
REFS:         MultimapTableDefinition<u32 /* callee_sid */, &[u8] /* postcard(RefSite) */>
FID_REFS:     MultimapTableDefinition<u32 /* fid */,         u32  /* callee_sid */>
SID_REFS_OUT: MultimapTableDefinition<u32 /* caller_sid */,  u32  /* callee_sid */>
```

`RefSite { fid, start, end, start_line, end_line, caller_sid: Option<u32> }`. `caller_sid` is the smallest enclosing def whose byte range covers the call site; `None` for top-level / file-scope refs. Typical postcard size ~12 bytes (varint u32s).

**`SID_REFS_OUT` landed in U1, not U4** (per plan Deepening §B1) — avoids a second SCHEMA_VERSION bump when the closure walker switches.

## Writer (two-pass `commit_batch` fixes an intra-batch ordering bug)

I caught a bug during the outline integration test: when files in a single batch reference each other, processing each file in one pass meant the *first* file's refs to the *second* file's defs were filtered as "external" (no NAME_TO_SID entry yet). All ranks came back uniform.

Fix: two-pass commit.
- **Pass 1**: all defs across the batch → NAME_TO_SID + DEFS + FID_DEFS
- **Pass 2**: all refs → REFS + FID_REFS + SID_REFS_OUT with `caller_sid` resolved

Plus:
- `parse_and_extract` extracts refs alongside defs via the new `refs::references_with_ranges` (range-carrying sibling of `references_for_path`)
- External-symbol filter at commit time per plan §F1 — names not workspace-defined after Pass 1 are dropped

## Invalidation (`drop_file_entries` filter-by-fid for REFS + SID_REFS_OUT rebuild)

Critical correctness invariant from Deepening §C1: REFS is keyed by *callee_sid*, not fid, so naively dropping `REFS.remove_all(callee_sid)` when file F is removed would corrupt refs from *other* files to the same callee. Algorithm:

1. Walk `FID_REFS[fid]` → callee sids this file referenced
2. For each callee, read `REFS[callee]`, filter out `RefSites` where `rs.fid == fid`, re-insert remainder
3. For `SID_REFS_OUT` (which has no embedded fid), rebuild from surviving REFS rows

Tested by `refs_invalidate_when_referring_file_dropped`: two files A and B both ref C; drop A; B's ref to C survives.

## Outline (`outline::compute` reads indexed edges)

The 32-line per-file parse loop in `outline.rs:178-201` is replaced with a one-line `store.refs_for_file_resolved(fid)?` call. Same external behavior — `outline_round_trip` (alpha.18) passes unchanged.

## Verification

- `cargo test --workspace`: **539 passed, 0 failed, 0 ignored** (was 533 in alpha.30; +6)
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets`: no new warnings on changed files
- `outline_round_trip` + `closure_round_trip` integration tests pass unchanged
- `v1_to_v2_schema_mismatch_triggers_rebuild` — first real exercise of the schema rebuild path since v0.2 alpha.1

### New tests

| Test | What it covers |
|---|---|
| `refs_round_trip_writes_all_three_tables` | All 3 tables populated; `caller_sid` resolves correctly |
| `refs_external_symbol_filtered_at_commit` | External names get no NAME_TO_SID entry (§F1) |
| `refs_invalidate_when_referring_file_dropped` | Multi-file invalidation; B's ref to C survives A's drop (§C1) |
| `refs_invalidate_on_re_upsert` | Re-save clears prior refs |
| `refs_for_file_resolved_returns_per_file_callsite_count` | Per-callsite count for outline |
| `v1_to_v2_schema_mismatch_triggers_rebuild` | Schema migration path |

## Wire surface

**Zero new wire surface.** v0.3 capability strings remain reserved in protocol-v0 §4.2 (set up in #27 U0). U2' flips them to advertised.

## Post-Deploy Monitoring & Validation

- **Logs**: `tracing` events at `target: rts_daemon::store::open` for the schema-rebuild path. Watch for `recreate redb at <path>` on workspaces with existing v0.2 indices.
- **Validation**: First mount of a v0.2 workspace after binary upgrade should resolve `INDEX_NOT_READY` within the existing 5s retry, then `Index.Outline` returns the same shape as alpha.30.
- **Healthy signals**: All v0.2 wire methods return v0.2-shape responses (additive contract). `Index.Outline` warm latency p95 unchanged from alpha.30. First-mount cold latency on 100k LOC: ≤ 1500ms (plan G3 budget).
- **Failure signal / rollback**: any existing integration test failing post-merge → rollback to alpha.30 binary. `Workspace.Status.state` stuck on `indexing` past 5s on 100k-LOC workspace → suggests RefSite write-amp worse than expected.
- **Validation window & owner**: first-mount window (5-30s) per daemon update; owner = whoever runs the daemon.

## Next

After this merges: **U2'** — merged `Index.FindCallers` + `Index.ReadSymbol.include_callers` (per Deepening §F2).

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.5 (1M context) via [Claude Code](https://claude.com/claude-code)