### PR TITLE
feat(rts-daemon): 0.2.0-alpha.32 — Index.FindCallers + ReadSymbol.include_callers (v0.3 U2')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,131 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.32] - 2026-05-14
+
+**Direct callers + `Index.FindCallers` (v0.3 U2').** The persistent
+reference graph from alpha.31 (U1) now has its first agent-visible
+consumer: `Index.FindCallers` returns the set of direct callers of a
+named symbol in one redb lookup, and `Index.ReadSymbol` gains an
+`include_callers: bool` parameter that composes callers into the
+existing body+deps response.
+
+This merged unit lands U2 + U3 from the original v0.3 plan as a
+single PR per Deepening §F2 — both shapes share the `CallerEntry`
+schema, handler logic, MCP tool descriptor, and CLI scaffolding.
+
+### Added
+
+- **`Index.FindCallers(name, kind?, file?)`** — new daemon method
+  at `methods/index.rs::find_callers`. Returns
+  `{ callers: [...], truncated: bool }` with 256-entry cap; results
+  sorted by `(file, range.start_byte)` for stable wire ordering.
+  Each entry carries `enclosing_qualified_name` + `kind` +
+  call-site `range` + `enclosing_def_range` + a `rank_score: 0.0`
+  placeholder (U4 fills it). File-scope refs (no enclosing def)
+  surface `enclosing_qualified_name: null` and pass through the
+  `kind` / `enclosing_def_range` filters as nulls.
+- **`Index.ReadSymbol.include_callers: bool`** at
+  `methods/index.rs::ReadSymbolParams` — when true, the response
+  gains a `callers: [...]` array (same `CallerEntry` shape as
+  `Index.FindCallers`) plus `callers_truncated: bool`. Token-budget
+  priority: body wins first, then deps, then callers fill what's
+  left. Mirrored on `Index.ReadSymbolAt`.
+- **Three new Store helpers** on `crate::store::Store`:
+  - `sid_for_name(name)` — `NAME_TO_SID` lookup
+  - `path_for_fid(fid)` — `FID_TO_PATH` lookup
+  - `caller_def_info(caller_sid, fid)` — joins `SID_TO_NAME` +
+    `DEFS` to resolve a `(caller_sid, fid)` pair into the caller's
+    own name + kind + def range. Returns `Ok(None)` on torn-read
+    races where the def is being concurrently removed.
+- **`CallerDefInfo`** surface struct alongside `FoundSymbol`.
+- **`rts-mcp` tool**: `find_callers(name, kind?, file?)` with
+  explicit when-to-use disambiguation in the description
+  (callers-only vs `read_symbol --include-callers` vs `impact_of`
+  per agent-native review §G2).
+- **`rts-mcp` arg** on `read_symbol` + `read_symbol_at`:
+  `include_callers: bool`.
+- **`rts-bench query find-callers --name X [--kind K] [--file F]`** —
+  new query subcommand.
+- **`--callers` flag** on `rts-bench query read-symbol` +
+  `read-symbol-at`.
+- **`crates/rts-daemon/tests/find_callers_round_trip.rs`** (new):
+  hub-spoke integration test. Asserts (a)
+  `Index.FindCallers(hub_compute)` returns 2 callers with correct
+  enclosing names; (b) `file=` filter narrows to 1; (c) unknown
+  name returns SYMBOL_NOT_FOUND; (d) `Index.ReadSymbol --include-callers`
+  returns body + same 2 callers; (e) default `Index.ReadSymbol`
+  preserves v0.2 wire shape (`callers: []`, `callers_truncated: false`).
+
+### Changed
+
+- **`Daemon.Ping` advertises** `find_callers` and
+  `read_symbol.include_callers` capability strings (alpha.32+); see
+  protocol-v0 §4.1 and Appendix F. Total capability count:
+  14 → 16.
+- **Method surface**: 11 → 12 methods + 1 notification.
+- **`docs/protocol-v0.md` §7.7c `Index.FindCallers`** documents the
+  new method's params, result shape, errors, and "when to use which
+  caller-shaped method" disambiguation. **§18.4c** adds the JSON
+  Schema. §7.7 documents `include_callers` on `Index.ReadSymbol`;
+  §18.4 + §18.4b update the schemas.
+- **`docs/protocol-v0.md` §4.2** marks `find_callers` and
+  `read_symbol.include_callers` as **advertised** (strikethrough on
+  the previously-reserved entries) and adds the alpha.32 row to
+  **Appendix F — Wire-shape evolution by alpha**.
+- **`rts-bench task find_callers`** (legacy stub, never
+  implemented) updated its `NotImplemented` message to point at the
+  new `query find-callers` subcommand. Resolves agent-native review
+  §G5's naming-collision concern between the `task` and `query`
+  namespaces — operators now see clear guidance.
+- **`Cargo.toml`** workspace version bumped 0.2.0-alpha.31 → 0.2.0-alpha.32.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **540 passed, 0 failed, 0 ignored**
+  (was 539 in alpha.31; +1 from `find_callers_round_trip`).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: no new warnings on
+  changed files. The new Store helpers
+  (`sid_for_name`/`path_for_fid`/`caller_def_info`) are consumed
+  by the new handler so no `#[allow(dead_code)]` needed — they
+  replace the U1 forward-looking annotations.
+
+### Wire-contract notes
+
+- **Additive only.** Existing v0.2 wire shapes are unchanged.
+  Clients that ignore the new `callers` + `callers_truncated`
+  fields in `Index.ReadSymbol` responses see no observable
+  difference. Clients that branch on
+  `Daemon.Ping.result.capabilities` should now check for
+  `find_callers` and `read_symbol.include_callers` before calling
+  the new surfaces; daemons advertising those strings honor them.
+- **`callers_truncated` is separate from `closure_truncated`** per
+  Deepening §C4 — silent overload of the existing flag was
+  rejected in review.
+
+### Not in this slice
+
+- **`Index.ImpactOf` (transitive callers)** — v0.3 U5.
+- **Closure walker switch to indexed `SID_REFS_OUT`** — v0.3 U3.
+  The alpha.22 closure walker still re-parses; the U3 PR will swap
+  it to read `store.refs_from_symbol`.
+- **Symbol-level PageRank** — v0.3 U4. `rank_score` remains a
+  `0.0` placeholder in `find_callers.callers[*]` / `find_symbol`
+  responses. The `pagerank_symbolwise` capability is still
+  reserved.
+- **External-symbol callers** — per plan §F1, refs to non-workspace
+  names are filtered at commit time. `Index.FindCallers(Vec)`
+  therefore returns "workspace callers only." Adding back later is
+  purely additive (no schema bump).
+
+### Refs
+
+- v0.3 plan §"Phase 2/3" (merged into U2' per Deepening §F2):
+  [docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md](docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md)
+- v0.3 U1 (this PR's prerequisite): [`feat(rts-daemon): 0.2.0-alpha.31`](https://github.com/njfio/rs-agent-code-utility/pull/29)
+
 ## [0.2.0-alpha.31] - 2026-05-14
 
 **Persistent reference graph + outline switch (v0.3 U1).** The reference

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.0-alpha.31"
+version = "0.2.0-alpha.32"
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yourusername/rust_tree_sitter"

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -122,7 +122,7 @@ enum QueryCmd {
         #[arg(long)]
         file: Option<String>,
     },
-    /// `read_symbol` — read by name, optional shape + closure walk.
+    /// `read_symbol` — read by name, optional shape + closure walk + callers.
     ReadSymbol {
         #[arg(long)]
         workspace: Option<PathBuf>,
@@ -140,6 +140,12 @@ enum QueryCmd {
         /// Walk the symbol's referenced-symbol closure (depth 1).
         #[arg(long)]
         deps: bool,
+        /// Include direct callers (v0.3 U2'). Same shape as
+        /// `query find-callers.callers[]`. Token budget shared with
+        /// body + deps; body wins first, deps fill the remainder,
+        /// callers fill what's left.
+        #[arg(long)]
+        callers: bool,
     },
     /// `read_symbol_at` — read by `(file, line)`; line-anchored lookup.
     /// The compiler-error flow: take `error[E0308] --> src/lib.rs:42:18`
@@ -159,6 +165,26 @@ enum QueryCmd {
         token_budget: Option<u64>,
         #[arg(long)]
         deps: bool,
+        /// Include direct callers (v0.3 U2').
+        #[arg(long)]
+        callers: bool,
+    },
+    /// `find_callers` — direct callers of a symbol (v0.3 U2'). One redb
+    /// lookup; returns the call sites + each caller's enclosing fn name.
+    /// AST-precise; avoids ripgrep false positives. Distinct from the
+    /// legacy `task find_callers` (now removed) — this is a one-shot
+    /// query, not a baseline-bench scenario task.
+    FindCallers {
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+        #[arg(long)]
+        name: String,
+        /// Filter callers by the enclosing def's kind (fn/method/etc).
+        #[arg(long)]
+        kind: Option<String>,
+        /// Filter callers to a single workspace-relative file.
+        #[arg(long)]
+        file: Option<String>,
     },
     /// `outline_workspace` — token-budgeted structural map. Use first
     /// when orienting in an unfamiliar repo.
@@ -417,6 +443,7 @@ fn build_query(cmd: &QueryCmd) -> Result<(PathBuf, &'static str, serde_json::Val
             shape,
             token_budget,
             deps,
+            callers,
         } => {
             let mut a = serde_json::Map::new();
             a.insert("name".into(), serde_json::Value::String(name.clone()));
@@ -426,6 +453,9 @@ fn build_query(cmd: &QueryCmd) -> Result<(PathBuf, &'static str, serde_json::Val
             opt_num(*token_budget, &mut a, "token_budget");
             if *deps {
                 a.insert("include_dependencies".into(), serde_json::Value::Bool(true));
+            }
+            if *callers {
+                a.insert("include_callers".into(), serde_json::Value::Bool(true));
             }
             Ok((
                 default_workspace(workspace)?,
@@ -441,6 +471,7 @@ fn build_query(cmd: &QueryCmd) -> Result<(PathBuf, &'static str, serde_json::Val
             shape,
             token_budget,
             deps,
+            callers,
         } => {
             let mut a = serde_json::Map::new();
             a.insert("file".into(), serde_json::Value::String(file.clone()));
@@ -453,9 +484,28 @@ fn build_query(cmd: &QueryCmd) -> Result<(PathBuf, &'static str, serde_json::Val
             if *deps {
                 a.insert("include_dependencies".into(), serde_json::Value::Bool(true));
             }
+            if *callers {
+                a.insert("include_callers".into(), serde_json::Value::Bool(true));
+            }
             Ok((
                 default_workspace(workspace)?,
                 "read_symbol_at",
+                serde_json::Value::Object(a),
+            ))
+        }
+        QueryCmd::FindCallers {
+            workspace,
+            name,
+            kind,
+            file,
+        } => {
+            let mut a = serde_json::Map::new();
+            a.insert("name".into(), serde_json::Value::String(name.clone()));
+            opt_str(kind, &mut a, "kind");
+            opt_str(file, &mut a, "file");
+            Ok((
+                default_workspace(workspace)?,
+                "find_callers",
                 serde_json::Value::Object(a),
             ))
         }

--- a/crates/rts-bench/src/tasks/mod.rs
+++ b/crates/rts-bench/src/tasks/mod.rs
@@ -57,9 +57,12 @@ pub struct TaskContext<'a> {
 }
 
 /// Run one task by id. v0 implements `locate_def`, `get_body`, and
-/// `summarize_module`. `find_callers` + `fix_imports` need the P8
-/// reference-graph that isn't built yet — they return `NotImplemented`
-/// with a pointer to the later slice.
+/// `summarize_module`. `find_callers` (the legacy stub) was superseded
+/// by `rts-bench query find-callers` once v0.3 U2' shipped the
+/// underlying `Index.FindCallers` daemon method; the baseline-bench
+/// version of the same workflow will reland as `scenario_find_callers`
+/// alongside U5's `scenario_refactor_impact`. `fix_imports` still
+/// needs work the v0.3 plan doesn't cover.
 pub async fn run_task(id: &str, ctx: &TaskContext<'_>) -> Result<TaskOutcome> {
     match id {
         "locate_def" => locate_def::run(ctx).await,
@@ -67,14 +70,16 @@ pub async fn run_task(id: &str, ctx: &TaskContext<'_>) -> Result<TaskOutcome> {
         "summarize_module" => summarize_module::run(ctx).await,
         "scenario_compiler_fix" => scenario_compiler_fix::run(ctx).await,
         "find_callers" => Ok(TaskOutcome::NotImplemented {
-            reason: "task `find_callers` needs an inverted ref-graph (closure walker is \
-                     anchor→deps; this is the inverse). Defer to v1.1 alongside multi-hop \
-                     closure."
+            reason: "the underlying `Index.FindCallers` method ships in v0.3 alpha.31+; \
+                     for one-shot queries use `rts-bench query find-callers --name <X>`. \
+                     The baseline-bench variant of this task will reland as \
+                     `scenario_find_callers` alongside `scenario_refactor_impact` (v0.3 U5)."
                 .into(),
         }),
         "fix_imports" => Ok(TaskOutcome::NotImplemented {
-            reason: "task `fix_imports` needs the same inverted ref-graph; defer with \
-                     find_callers."
+            reason: "task `fix_imports` is out of scope for v0.3; revisit once a real user \
+                     has asked. The closure walker + persisted ref graph are the \
+                     primitives it would build on."
                 .into(),
         }),
         other => anyhow::bail!("unknown task id: {other}; valid ids: {TASK_IDS:?}"),

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -68,10 +68,32 @@ struct ReadSymbolParams {
     token_budget: Option<u64>,
     #[serde(default)]
     include_dependencies: bool,
+    /// v0.3 U2' — when true, the response carries a `callers` array
+    /// of direct callers (one redb lookup per anchor, same shape as
+    /// `Index.FindCallers.callers[]`). Token budget is shared with
+    /// body + deps; callers fill the remainder. Defaults to false to
+    /// preserve v0.2 wire shape.
+    #[serde(default)]
+    include_callers: bool,
     /// v1.1 session-dedup override. Accepted but inert in v0.
     #[serde(default)]
     #[allow(dead_code)]
     force_resend: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct FindCallersParams {
+    /// Name of the symbol whose callers we want. Required.
+    name: String,
+    /// Optional filter: only return callers whose enclosing-def's
+    /// `kind` matches. Accepts the same loose-string form as
+    /// `Index.FindSymbol.kind`.
+    #[serde(default)]
+    kind: Option<String>,
+    /// Optional filter: only return callers from this workspace-relative
+    /// file. Useful for "who calls X in foo.rs?".
+    #[serde(default)]
+    file: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -93,6 +115,9 @@ struct ReadSymbolAtParams {
     token_budget: Option<u64>,
     #[serde(default)]
     include_dependencies: bool,
+    /// v0.3 U2' — direct callers. Mirrors `ReadSymbolParams.include_callers`.
+    #[serde(default)]
+    include_callers: bool,
     #[serde(default)]
     #[allow(dead_code)]
     force_resend: bool,
@@ -418,6 +443,222 @@ pub async fn find_symbol(
     }))
 }
 
+/// `Index.FindCallers(name)` — direct callers of a symbol. v0.3 U2'.
+///
+/// Wire shape:
+/// ```jsonc
+/// {
+///   "callers": [
+///     {
+///       "enclosing_qualified_name": "rts_core::index::build_index", // null when caller_sid is None (file-scope ref)
+///       "kind":  "fn",                                                // null when caller_sid is None
+///       "file":  "src/index/mod.rs",
+///       "range": { "start_line": 142, "end_line": 142,
+///                  "start_byte": 4520, "end_byte": 4540 },           // the call site
+///       "enclosing_def_range": {                                      // the caller's def range (null when caller_sid is None)
+///         "start_line": 138, "end_line": 160,
+///         "start_byte": 4400, "end_byte": 5200
+///       },
+///       "rank_score": 0.0                                             // placeholder until v0.3 U4
+///     }
+///   ],
+///   "truncated": false
+/// }
+/// ```
+///
+/// Errors: `SYMBOL_NOT_FOUND` when no `NAME_TO_SID` entry; mirrors
+/// `Index.FindSymbol`'s shape. Result is sorted by `(file, start_byte)`
+/// for stable output across calls. The 256-entry cap (`MAX_CALLERS`)
+/// matches `MAX_MATCHES` from `find_symbol`.
+///
+/// Capability: `find_callers` (advertised in `Daemon.Ping` from
+/// alpha.32 onward).
+pub async fn find_callers(
+    params: serde_json::Value,
+    state: &Arc<DaemonState>,
+) -> Result<serde_json::Value, ProtocolError> {
+    const MAX_CALLERS: usize = 256;
+
+    let p: FindCallersParams = parse_params(params)?;
+    if p.name.is_empty() || p.name.len() > 256 {
+        return Err(ProtocolError::new(
+            ErrorCode::InvalidParams,
+            "`name` must be 1..=256 characters",
+        ));
+    }
+    let kind_filter = p.kind.as_deref().map(SymbolKind::from_str_loose);
+    let file_filter = p.file.as_deref();
+
+    let (_root, store_arc) = snapshot(state)?;
+
+    let callee_sid = match store_arc.sid_for_name(&p.name).map_err(|e| {
+        ProtocolError::new(
+            ErrorCode::InternalError,
+            format!("sid_for_name storage error: {e:#}"),
+        )
+    })? {
+        Some(s) => s,
+        None => {
+            return Err(ProtocolError::new(
+                ErrorCode::SymbolNotFound,
+                format!("no symbol named `{}` is indexed", p.name),
+            ));
+        }
+    };
+
+    let sites = store_arc.refs_to_symbol(callee_sid).map_err(|e| {
+        ProtocolError::new(
+            ErrorCode::InternalError,
+            format!("refs_to_symbol storage error: {e:#}"),
+        )
+    })?;
+
+    let mut callers: Vec<serde_json::Value> = Vec::with_capacity(sites.len().min(MAX_CALLERS));
+    for site in &sites {
+        let entry = match build_caller_entry(&store_arc, site)? {
+            Some(e) => e,
+            None => continue, // path lookup failed (torn read); skip
+        };
+
+        // Filter by file (workspace-relative match).
+        if let Some(filter) = file_filter {
+            if entry.file != filter {
+                continue;
+            }
+        }
+        // Filter by kind. File-scope refs (caller_sid==None) have no
+        // kind and are excluded when a kind filter is set.
+        if let Some(filter) = kind_filter {
+            if entry.kind != Some(filter) {
+                continue;
+            }
+        }
+        callers.push(entry.to_wire_value());
+    }
+
+    // Stable order: (file, start_byte). Matches the FindSymbol
+    // convention of "predictable wire ordering across calls."
+    callers.sort_by(|a, b| {
+        let (af, ab) = (
+            a["file"].as_str().unwrap_or(""),
+            a["range"]["start_byte"].as_u64().unwrap_or(0),
+        );
+        let (bf, bb) = (
+            b["file"].as_str().unwrap_or(""),
+            b["range"]["start_byte"].as_u64().unwrap_or(0),
+        );
+        (af, ab).cmp(&(bf, bb))
+    });
+
+    let truncated = callers.len() > MAX_CALLERS;
+    callers.truncate(MAX_CALLERS);
+
+    Ok(serde_json::json!({
+        "callers":   callers,
+        "truncated": truncated,
+    }))
+}
+
+/// Internal struct used by `find_callers` (and U2's `read_symbol`
+/// `include_callers` branch) to build the wire-level caller entry.
+/// Filter steps run against the typed form before serialization.
+struct CallerEntry {
+    enclosing_qualified_name: Option<String>,
+    kind: Option<SymbolKind>,
+    file: String,
+    /// Call-site range — the RefSite.
+    call_start_byte: u32,
+    call_end_byte: u32,
+    call_start_line: u32,
+    call_end_line: u32,
+    /// Enclosing def's range — present when caller_sid is Some.
+    def_range: Option<(u32, u32, u32, u32)>, // (start_byte, end_byte, start_line, end_line)
+}
+
+impl CallerEntry {
+    fn to_wire_value(&self) -> serde_json::Value {
+        let enclosing_def_range = match self.def_range {
+            Some((sb, eb, sl, el)) => serde_json::json!({
+                "start_byte": sb,
+                "end_byte":   eb,
+                "start_line": sl,
+                "end_line":   el,
+            }),
+            None => serde_json::Value::Null,
+        };
+        serde_json::json!({
+            "enclosing_qualified_name": match &self.enclosing_qualified_name {
+                Some(n) => serde_json::Value::String(n.clone()),
+                None => serde_json::Value::Null,
+            },
+            "kind": match self.kind {
+                Some(k) => serde_json::Value::String(k.as_wire_str().to_string()),
+                None => serde_json::Value::Null,
+            },
+            "file": self.file,
+            "range": {
+                "start_byte": self.call_start_byte,
+                "end_byte":   self.call_end_byte,
+                "start_line": self.call_start_line,
+                "end_line":   self.call_end_line,
+            },
+            "enclosing_def_range": enclosing_def_range,
+            // Placeholder until v0.3 U4 wires symbol-level PageRank.
+            "rank_score": 0.0,
+        })
+    }
+}
+
+/// Resolve a `RefSite` into a `CallerEntry`. Joins `path_for_fid` and
+/// `caller_def_info`. Returns `Ok(None)` only when the fid path lookup
+/// fails (torn read or stale fid) — file-scope refs (caller_sid==None)
+/// return a `CallerEntry` with the caller fields cleared.
+fn build_caller_entry(
+    store: &Arc<Store>,
+    site: &crate::store::RefSite,
+) -> Result<Option<CallerEntry>, ProtocolError> {
+    let file = match store.path_for_fid(site.fid).map_err(|e| {
+        ProtocolError::new(
+            ErrorCode::InternalError,
+            format!("path_for_fid storage error: {e:#}"),
+        )
+    })? {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+    let (enclosing_qualified_name, kind, def_range) = match site.caller_sid {
+        Some(sid) => match store.caller_def_info(sid, site.fid).map_err(|e| {
+            ProtocolError::new(
+                ErrorCode::InternalError,
+                format!("caller_def_info storage error: {e:#}"),
+            )
+        })? {
+            Some(info) => (
+                Some(info.name),
+                Some(info.kind),
+                Some((
+                    info.def_start_byte,
+                    info.def_end_byte,
+                    info.def_start_line,
+                    info.def_end_line,
+                )),
+            ),
+            None => (None, None, None),
+        },
+        None => (None, None, None),
+    };
+    Ok(Some(CallerEntry {
+        enclosing_qualified_name,
+        kind,
+        file,
+        call_start_byte: site.start,
+        call_end_byte: site.end,
+        call_start_line: site.start_line,
+        call_end_line: site.end_line,
+        def_range,
+    }))
+}
+
 /// Minimal shell-style globber for symbol names.
 ///
 /// Supports `*` (zero or more chars) and `?` (one char). Anything else
@@ -551,6 +792,7 @@ pub async fn read_symbol(
         ));
     }
     let include_deps = p.include_dependencies;
+    let include_callers = p.include_callers;
     let budget = check_budget(p.token_budget)?;
 
     let (root, store_arc) = snapshot(state)?;
@@ -598,6 +840,7 @@ pub async fn read_symbol(
         shape,
         budget,
         include_deps,
+        include_callers,
     )
     .await
 }
@@ -617,6 +860,7 @@ async fn read_symbol_body(
     shape: &str,
     budget: u64,
     include_deps: bool,
+    include_callers: bool,
 ) -> Result<serde_json::Value, ProtocolError> {
     let (abs, _rel) = resolve_workspace_path(root, &chosen.file)?;
     check_body_extension(&abs)?;
@@ -711,12 +955,87 @@ async fn read_symbol_body(
     } else {
         (serde_json::Value::Array(vec![]), false, Vec::new(), 0u64)
     };
-    let tokens_returned = body_tokens.saturating_add(dep_tokens);
+
+    // v0.3 U2': callers branch. Parallel to the dep walk above.
+    // Budget priority: body wins first, deps fill the remainder,
+    // callers fill what's left after deps. Callers use a separate
+    // truncation flag (`callers_truncated`) to keep the v0.2
+    // `closure_truncated` semantics intact (Deepening §C4 — silent
+    // overload of the existing flag was rejected).
+    //
+    // Per-entry budget cost is `bytes_div_3` of the JSON entry size;
+    // we approximate this as a constant 60 tokens per entry (matches
+    // the average CallerEntry serialization with all string fields
+    // populated). Cheaper than serializing each entry to measure
+    // exactly; agents have the `tokens_returned` field for precision.
+    let (callers_value, callers_truncated, caller_tokens) = if include_callers {
+        const APPROX_TOKENS_PER_CALLER: u64 = 60;
+        let remaining_budget = budget
+            .saturating_sub(body_tokens)
+            .saturating_sub(dep_tokens);
+        let max_callers_by_budget = remaining_budget / APPROX_TOKENS_PER_CALLER;
+
+        // Anchor is workspace-defined (we just read its body) so a
+        // sid is virtually guaranteed; if it's missing (torn read on
+        // a just-removed file), surface an empty callers list rather
+        // than failing the whole call.
+        let callee_sid_opt = store_arc.sid_for_name(&chosen.name).map_err(|e| {
+            ProtocolError::new(
+                ErrorCode::InternalError,
+                format!("sid_for_name storage error: {e:#}"),
+            )
+        })?;
+        if let Some(callee_sid) = callee_sid_opt {
+            let sites = store_arc.refs_to_symbol(callee_sid).map_err(|e| {
+                ProtocolError::new(
+                    ErrorCode::InternalError,
+                    format!("refs_to_symbol storage error: {e:#}"),
+                )
+            })?;
+            let total_sites = sites.len() as u64;
+            let kept_sites: Vec<_> = sites
+                .into_iter()
+                .take(max_callers_by_budget as usize)
+                .collect();
+            let truncated = (kept_sites.len() as u64) < total_sites;
+
+            let mut entries: Vec<serde_json::Value> = Vec::with_capacity(kept_sites.len());
+            for site in &kept_sites {
+                if let Some(entry) = build_caller_entry(store_arc, site)? {
+                    entries.push(entry.to_wire_value());
+                }
+            }
+            // Stable order: (file, start_byte). Same as Index.FindCallers.
+            entries.sort_by(|a, b| {
+                let (af, ab) = (
+                    a["file"].as_str().unwrap_or(""),
+                    a["range"]["start_byte"].as_u64().unwrap_or(0),
+                );
+                let (bf, bb) = (
+                    b["file"].as_str().unwrap_or(""),
+                    b["range"]["start_byte"].as_u64().unwrap_or(0),
+                );
+                (af, ab).cmp(&(bf, bb))
+            });
+            let tokens = (entries.len() as u64).saturating_mul(APPROX_TOKENS_PER_CALLER);
+            (serde_json::Value::Array(entries), truncated, tokens)
+        } else {
+            (serde_json::Value::Array(vec![]), false, 0u64)
+        }
+    } else {
+        (serde_json::Value::Array(vec![]), false, 0u64)
+    };
+
+    let tokens_returned = body_tokens
+        .saturating_add(dep_tokens)
+        .saturating_add(caller_tokens);
 
     // `truncated_symbols` blends two sources per §7.7: ambiguous
     // anchor matches (extra files) and closure deps that didn't fit
     // (deps_truncated_names). Both let the agent re-request
-    // individually.
+    // individually. Callers truncation is signalled separately via
+    // `callers_truncated` per Deepening §C4 (separate flag rather
+    // than overloading `closure_truncated`).
     let mut truncated_symbols = extra;
     truncated_symbols.extend(deps_truncated_names);
 
@@ -739,6 +1058,8 @@ async fn read_symbol_body(
         "token_counter":   TOKEN_COUNTER,
         "dependencies":      deps_value,
         "closure_truncated": closure_truncated,
+        "callers":           callers_value,
+        "callers_truncated": callers_truncated,
         // Disambiguation surface per §7.7.
         "truncated":         ambiguous || body_truncated,
         "truncated_symbols": truncated_symbols,
@@ -823,6 +1144,7 @@ pub async fn read_symbol_at(
         shape,
         budget,
         p.include_dependencies,
+        p.include_callers,
     )
     .await
 }

--- a/crates/rts-daemon/src/methods/mod.rs
+++ b/crates/rts-daemon/src/methods/mod.rs
@@ -26,6 +26,7 @@ pub async fn dispatch(
         "Session.Close" => session::close(params, state).await,
 
         "Index.FindSymbol" => index::find_symbol(params, state).await,
+        "Index.FindCallers" => index::find_callers(params, state).await,
         "Index.ReadRange" => index::read_range(params, state).await,
         "Index.ReadSymbol" => index::read_symbol(params, state).await,
         "Index.ReadSymbolAt" => index::read_symbol_at(params, state).await,

--- a/crates/rts-daemon/src/store/mod.rs
+++ b/crates/rts-daemon/src/store/mod.rs
@@ -547,6 +547,66 @@ impl Store {
     }
 
     /// All references *into* a symbol — "who calls X, and where?"
+    /// Resolve `name` → `callee_sid` via `NAME_TO_SID`. Returns
+    /// `Ok(None)` for unknown names (external symbols / unindexed).
+    /// Used by `Index.FindCallers` (U2') to convert the wire-level
+    /// name into the integer key needed for `refs_to_symbol`.
+    pub fn sid_for_name(&self, name: &str) -> anyhow::Result<Option<u32>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let name_to_sid = txn.open_table(NAME_TO_SID)?;
+        Ok(name_to_sid.get(name)?.map(|v| v.value()))
+    }
+
+    /// Resolve `fid` → workspace-relative path. Returns `Ok(None)` for
+    /// unknown fids. Used by `Index.FindCallers` (U2') to convert each
+    /// `RefSite.fid` into the path the caller wants to see.
+    pub fn path_for_fid(&self, fid: u32) -> anyhow::Result<Option<String>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let fid_to_path = txn.open_table(FID_TO_PATH)?;
+        Ok(fid_to_path.get(&fid)?.map(|v| v.value().to_string()))
+    }
+
+    /// Resolve a `(caller_sid, fid)` pair into the caller's own def
+    /// info — the enclosing symbol's name + kind + range. Used by
+    /// `Index.FindCallers` (U2') to surface `enclosing_qualified_name`
+    /// + `kind` alongside the call-site range from the `RefSite`.
+    ///
+    /// Returns `Ok(None)` when SID_TO_NAME has no entry for
+    /// `caller_sid` (shouldn't happen for an indexed sid) or when no
+    /// DEFS row for this sid matches the given fid (which only fires
+    /// during a torn-read race — the writer always pairs `caller_sid`
+    /// with a def in the same file at commit time).
+    pub fn caller_def_info(
+        &self,
+        caller_sid: u32,
+        fid: u32,
+    ) -> anyhow::Result<Option<CallerDefInfo>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let sid_to_name = txn.open_table(SID_TO_NAME)?;
+        let name = match sid_to_name.get(&caller_sid)? {
+            Some(v) => v.value().to_string(),
+            None => return Ok(None),
+        };
+        let defs = txn.open_multimap_table(DEFS)?;
+        for row in defs.get(&caller_sid)? {
+            let bytes = row?.value().to_vec();
+            if let Ok(d) = from_bytes::<DefSite>(&bytes) {
+                if d.fid == fid {
+                    return Ok(Some(CallerDefInfo {
+                        name,
+                        kind: d.kind,
+                        def_start_byte: d.start,
+                        def_end_byte: d.end,
+                        def_start_line: d.start_line,
+                        def_end_line: d.end_line,
+                    }));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// All references *into* a symbol — "who calls X, and where?"
     /// One entry per call site. The caller (FindCallers handler, v0.3
     /// U2') resolves `caller_sid` → qualified name via SID_TO_NAME +
     /// DEFS lookup. Returns `Ok(Vec::new())` for symbols with no
@@ -555,7 +615,6 @@ impl Store {
     /// Order: insertion order within each `(callee_sid)` multimap
     /// key, which is arbitrary. Callers that want stable ordering
     /// should sort by `(fid, start)`.
-    #[allow(dead_code)] // consumed by v0.3 U2' (Index.FindCallers)
     pub fn refs_to_symbol(&self, callee_sid: u32) -> anyhow::Result<Vec<RefSite>> {
         let txn = self.db.begin_read().context("begin_read")?;
         let refs_t = txn.open_multimap_table(REFS)?;
@@ -731,6 +790,21 @@ pub struct FoundSymbol {
     pub start_line: u32,
     pub end_line: u32,
     pub visibility: schema::Visibility,
+}
+
+/// Surface struct for v0.3 U2'+. Resolved info for a caller's *own*
+/// def, returned by [`Store::caller_def_info`]. The wire-shape
+/// `enclosing_qualified_name` + `kind` + `enclosing_def_range` fields
+/// in `Index.FindCallers.callers[]` are built from one of these per
+/// `RefSite`.
+#[derive(Debug, Clone)]
+pub struct CallerDefInfo {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub def_start_byte: u32,
+    pub def_end_byte: u32,
+    pub def_start_line: u32,
+    pub def_end_line: u32,
 }
 
 // Long arg list is the cost of operating on six redb tables in one

--- a/crates/rts-daemon/tests/find_callers_round_trip.rs
+++ b/crates/rts-daemon/tests/find_callers_round_trip.rs
@@ -1,0 +1,304 @@
+//! End-to-end test for v0.3 U2': `Index.FindCallers` + `Index.ReadSymbol.include_callers`.
+//!
+//! Hub-spoke fixture (same shape as `outline_round_trip`'s hub-spoke):
+//!   `hub.rs`      defines `hub_compute`
+//!   `caller_a.rs` defines `caller_a_one` which calls `hub_compute`
+//!   `caller_b.rs` defines `caller_b_one` which calls `hub_compute`
+//!
+//! After indexing:
+//!   * `Index.FindCallers(hub_compute)` should return 2 callers, one
+//!     per file, each with `enclosing_qualified_name` resolving to
+//!     the caller fn name.
+//!   * `Index.ReadSymbol(hub_compute, include_callers=true)` should
+//!     return the hub fn body PLUS the same 2 callers.
+//!   * `Index.FindCallers` for an unknown name returns SYMBOL_NOT_FOUND.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn find_callers_and_include_callers_round_trip() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    std::fs::write(
+        workspace.path().join("hub.rs"),
+        "pub fn hub_compute(x: u32) -> u32 { x + 1 }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("caller_a.rs"),
+        "pub fn caller_a_one() {\n    let _ = hub_compute(1);\n}\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("caller_b.rs"),
+        "pub fn caller_b_one() {\n    let _ = hub_compute(2);\n}\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+
+    // Wait for all three defs to land in the index.
+    wait_for_symbol(&mut stream, "hub_compute", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "caller_a_one", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "caller_b_one", Duration::from_secs(5)).await?;
+
+    // 1. Index.FindCallers(hub_compute) → 2 callers.
+    let resp = round_trip(
+        &mut stream,
+        "10",
+        "Index.FindCallers",
+        json!({ "name": "hub_compute" }),
+    )
+    .await?;
+    assert!(resp["error"].is_null(), "find_callers failed: {resp:?}");
+    let callers = resp["result"]["callers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(
+        callers.len(),
+        2,
+        "expected 2 callers of hub_compute; got {callers:?}"
+    );
+    assert_eq!(resp["result"]["truncated"], false);
+
+    // Each caller's enclosing_qualified_name should resolve to the
+    // calling fn. Order is (file, start_byte) — alphabetical by file
+    // here: caller_a.rs then caller_b.rs.
+    let enclosing_names: Vec<&str> = callers
+        .iter()
+        .map(|c| c["enclosing_qualified_name"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        enclosing_names.contains(&"caller_a_one"),
+        "expected caller_a_one in {enclosing_names:?}"
+    );
+    assert!(
+        enclosing_names.contains(&"caller_b_one"),
+        "expected caller_b_one in {enclosing_names:?}"
+    );
+
+    // Each caller carries kind=fn + an enclosing_def_range.
+    for c in &callers {
+        assert_eq!(c["kind"], "fn");
+        assert!(
+            c["enclosing_def_range"].is_object(),
+            "expected enclosing_def_range to be populated; got {c:?}"
+        );
+        assert!(
+            c["range"]["start_byte"].as_u64().unwrap_or(0) > 0,
+            "call site byte range should be populated; got {c:?}"
+        );
+    }
+
+    // 2. file= filter should narrow to one caller.
+    let filtered = round_trip(
+        &mut stream,
+        "11",
+        "Index.FindCallers",
+        json!({ "name": "hub_compute", "file": "caller_a.rs" }),
+    )
+    .await?;
+    let f_callers = filtered["result"]["callers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(f_callers.len(), 1, "file filter should narrow to 1 caller");
+    assert_eq!(f_callers[0]["enclosing_qualified_name"], "caller_a_one");
+
+    // 3. Unknown name returns SYMBOL_NOT_FOUND.
+    let missing = round_trip(
+        &mut stream,
+        "12",
+        "Index.FindCallers",
+        json!({ "name": "no_such_thing_ever" }),
+    )
+    .await?;
+    assert!(
+        missing["error"].is_object(),
+        "expected error envelope; got {missing:?}"
+    );
+    assert_eq!(missing["error"]["code"], "SYMBOL_NOT_FOUND");
+
+    // 4. Index.ReadSymbol(hub_compute, include_callers=true) returns
+    //    the body PLUS the same 2 callers.
+    let combined = round_trip(
+        &mut stream,
+        "20",
+        "Index.ReadSymbol",
+        json!({
+            "name": "hub_compute",
+            "include_callers": true,
+            "token_budget": 4096,
+        }),
+    )
+    .await?;
+    assert!(
+        combined["error"].is_null(),
+        "read_symbol --include-callers failed: {combined:?}"
+    );
+    // Body present.
+    let text = combined["result"]["text"].as_str().unwrap_or("");
+    assert!(
+        text.contains("hub_compute"),
+        "body should contain the symbol name; got `{text}`"
+    );
+    // Callers present and equal length.
+    let rs_callers = combined["result"]["callers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(
+        rs_callers.len(),
+        2,
+        "expected 2 callers in include_callers response; got {rs_callers:?}"
+    );
+    // Same wire shape as find_callers entries — spot-check one.
+    assert!(rs_callers[0]["enclosing_qualified_name"].is_string());
+    assert_eq!(rs_callers[0]["kind"], "fn");
+    assert!(rs_callers[0]["enclosing_def_range"].is_object());
+
+    // 5. Without include_callers, callers[] is an empty array and
+    //    callers_truncated is false. (v0.2 back-compat path.)
+    let no_callers = round_trip(
+        &mut stream,
+        "21",
+        "Index.ReadSymbol",
+        json!({ "name": "hub_compute" }),
+    )
+    .await?;
+    let nc = no_callers["result"]["callers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        nc.is_empty(),
+        "default ReadSymbol should not carry callers; got {nc:?}"
+    );
+    assert_eq!(no_callers["result"]["callers_truncated"], false);
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}

--- a/crates/rts-mcp/src/server.rs
+++ b/crates/rts-mcp/src/server.rs
@@ -79,9 +79,31 @@ pub struct ReadSymbolArgs {
     /// symbol references (tree-shaken closure).
     #[serde(default)]
     pub include_dependencies: bool,
+    /// When `true`, also include `callers[]`: the direct callers of this
+    /// symbol (same shape as `find_callers.callers[]`). Composes with
+    /// `include_dependencies` — body wins token budget first, then deps,
+    /// then callers. Use this when you want the symbol *and* its
+    /// neighborhood in one round trip.
+    #[serde(default)]
+    pub include_callers: bool,
     /// v1.1 session-dedup override. Accepted but inert in v0.
     #[serde(default)]
     pub force_resend: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FindCallersArgs {
+    /// Exact name of the symbol whose callers to find.
+    pub name: String,
+    /// Optional `kind` filter on the *enclosing* def — restrict callers
+    /// to functions / methods / etc. Accepts the same loose-string
+    /// form as `find_symbol.kind`.
+    #[serde(default)]
+    pub kind: Option<String>,
+    /// Optional `file` filter (workspace-relative path) — restrict
+    /// callers to those originating from one file.
+    #[serde(default)]
+    pub file: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -105,6 +127,10 @@ pub struct ReadSymbolAtArgs {
     /// the symbol references (tree-shaken closure).
     #[serde(default)]
     pub include_dependencies: bool,
+    /// When `true`, also include `callers[]`: the direct callers of
+    /// the resolved symbol. Same shape as `find_callers.callers[]`.
+    #[serde(default)]
+    pub include_callers: bool,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -198,6 +224,30 @@ impl RtsServer {
     }
 
     #[tool(
+        description = "Find direct callers of a symbol — where else in the workspace does code call into this function/method? Cheap (one redb lookup; no parsing). Use for: refactor impact preview at depth-1, 'is this function dead?', 'who depends on this API?'. Returns `callers[]` with each call site's file/range plus the enclosing function's `qualified_name` and `kind`. \n\nWhen to use which: this tool returns callers ONLY (no body). Use `read_symbol --include-callers` when you also need the symbol's own body. Use `impact_of` (when v0.3 U5 ships) for *transitive* callers (whole blast radius). Avoid shell `rg` for caller queries — it has high false-positive noise from local variables, comments, and string mentions; this is AST-precise via the indexed reference graph."
+    )]
+    async fn find_callers(
+        &self,
+        Parameters(args): Parameters<FindCallersArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut params = serde_json::Map::new();
+        params.insert("name".into(), Value::String(args.name));
+        if let Some(k) = args.kind {
+            params.insert("kind".into(), Value::String(k));
+        }
+        if let Some(f) = args.file {
+            params.insert("file".into(), Value::String(f));
+        }
+        match self
+            .call_daemon("Index.FindCallers", Value::Object(params))
+            .await
+        {
+            Ok(v) => Ok(success_json(&v)),
+            Err(e) => Ok(daemon_error_to_call_result(&e)),
+        }
+    }
+
+    #[tool(
         description = "Read the source of the symbol containing a given line in a file. Use this when you have a location (file + line) but not the name — e.g. from a compiler error like `error[E0308] --> src/lib.rs:42:18`. Returns the innermost enclosing definition with the same wire shape as `read_symbol`, including optional `include_dependencies` closure walking. Faster than: read the file, scroll to the line, identify the enclosing function, then `read_symbol`."
     )]
     async fn read_symbol_at(
@@ -219,6 +269,9 @@ impl RtsServer {
         if args.include_dependencies {
             params.insert("include_dependencies".into(), Value::Bool(true));
         }
+        if args.include_callers {
+            params.insert("include_callers".into(), Value::Bool(true));
+        }
         match self
             .call_daemon("Index.ReadSymbolAt", Value::Object(params))
             .await
@@ -229,7 +282,7 @@ impl RtsServer {
     }
 
     #[tool(
-        description = "Read the source of a named symbol. `shape=signature` returns just the declaration (cheap). `shape=body` returns the full implementation. `include_dependencies=true` adds the minimum surrounding types/imports the symbol references — use when you'll want to call/modify it without reading more. Prefer this over reading whole files."
+        description = "Read the source of a named symbol. `shape=signature` returns just the declaration (cheap). `shape=body` returns the full implementation. `include_dependencies=true` adds the minimum surrounding types/imports the symbol references — use when you'll want to call/modify it without reading more. `include_callers=true` adds the direct callers in one round trip — use when you want symbol-plus-neighborhood (alternative to a second `find_callers` call). Prefer this over reading whole files."
     )]
     async fn read_symbol(
         &self,
@@ -251,6 +304,9 @@ impl RtsServer {
         }
         if args.include_dependencies {
             params.insert("include_dependencies".into(), Value::Bool(true));
+        }
+        if args.include_callers {
+            params.insert("include_callers".into(), Value::Bool(true));
         }
         if args.force_resend {
             params.insert("force_resend".into(), Value::Bool(true));

--- a/docs/protocol-v0.md
+++ b/docs/protocol-v0.md
@@ -32,8 +32,8 @@ Coding agent (Claude Code, Cursor, Cline, Aider, Continue, ...)
       ▼
 ┌──────────────────┐
 │ rts-mcp          │  per-agent process, rmcp 1.6
-│ (stdio binary)   │  exposes 5 tools: outline_workspace, find_symbol,
-└─────────┬────────┘  read_symbol, read_symbol_at, read_range
+│ (stdio binary)   │  exposes 6 tools: outline_workspace, find_symbol,
+└─────────┬────────┘  find_callers, read_symbol, read_symbol_at, read_range
                      + rts://capabilities resource
           │
           │   protocol-v0  (this document)
@@ -166,12 +166,13 @@ This is the **v2 safe-edit hook** (architecture-review high-leverage edit). When
   "id": "1",
   "result": {
     "protocol":     "0",                          // semver-style major; v1 is the breaking re-cut
-    "daemon":       { "name": "rts-daemon", "version": "0.2.0-alpha.30", "git_sha": "756f5cc..." },
-    "capabilities": ["outline", "find_symbol", "read_symbol", "read_symbol_at", "read_range",
+    "daemon":       { "name": "rts-daemon", "version": "0.2.0-alpha.32", "git_sha": "dd290c7..." },
+    "capabilities": ["outline", "find_symbol", "find_callers", "read_symbol", "read_symbol_at", "read_range",
                      "rank_score", "tree_shake", "partial_responses",
                      "content_version", "secrets_blocklist",
                      "closure_walker", "fuzzy_match", "pagerank_filewise",
-                     "polling_fallback"],
+                     "polling_fallback",
+                     "read_symbol.include_callers"],
     "uptime_ms":    123456
   }
 }
@@ -190,9 +191,9 @@ These strings are reserved and MUST NOT be advertised by `protocol-v0` daemons u
 
 Reserved for the **v0.3 code-graph KB** extension (see [v0.3 plan](plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md)). Each is advertised independently when its implementing PR lands:
 
-- `find_callers` — direct-callers lookup (v0.3 U2').
+- ~~`find_callers`~~ — **advertised** as of `v0.2.0-alpha.32` (U2'). `Index.FindCallers` returns direct callers of a named symbol; see §7.7c.
 - `impact_of` — transitive caller closure (v0.3 U5).
-- `read_symbol.include_callers` — extends `Index.ReadSymbol` to compose with `include_dependencies` (v0.3 U2').
+- ~~`read_symbol.include_callers`~~ — **advertised** as of `v0.2.0-alpha.32` (U2'). `Index.ReadSymbol.params.include_callers: bool` composes with `include_dependencies`; see §7.7.
 - `pagerank_symbolwise` — symbol-level PageRank fills `rank_score`; `find_symbol` results sort by descending rank when advertised. Clients without this capability MAY request `sort: "lexical"` to retain pre-v0.3 ordering.
 - `call_graph` (umbrella; reserved but **not advertised by itself** — agents should branch on the four fine-grained strings above).
 
@@ -302,10 +303,10 @@ The v0 method namespace is `^[A-Z][a-z]+\.[A-Z][A-Za-z]+$`. Methods are grouped 
 |---|---|---|
 | `Daemon.*`   | `Ping`, `Telemetry` (notification) | always |
 | `Workspace.*` | `Mount`, `Unmount`, `Status` | always |
-| `Index.*`    | `Outline`, `FindSymbol`, `ReadSymbol`, `ReadSymbolAt`, `ReadRange` | `outline`, `find_symbol` (+ `fuzzy_match` for `pattern`), `read_symbol` (+ `closure_walker` for `include_dependencies`), `read_symbol_at`, `read_range` |
+| `Index.*`    | `Outline`, `FindSymbol`, `FindCallers`, `ReadSymbol`, `ReadSymbolAt`, `ReadRange` | `outline`, `find_symbol` (+ `fuzzy_match` for `pattern`), `find_callers`, `read_symbol` (+ `closure_walker` for `include_dependencies`, + `read_symbol.include_callers` for `include_callers`), `read_symbol_at`, `read_range` |
 | `Session.*`  | `Open`, `Close` | always; **v1.1**: `MarkDeduped` under `session_dedup` |
 
-Total v0 surface as of alpha.30: **11 methods + 1 notification**. (`Workspace.Mount`, `Workspace.Unmount`, `Workspace.Status`, `Daemon.Ping`, `Session.Open`, `Session.Close`, `Index.Outline`, `Index.FindSymbol`, `Index.ReadSymbol`, `Index.ReadSymbolAt`, `Index.ReadRange`, plus `Daemon.Telemetry` notification.) `Index.ReadSymbolAt` shipped in alpha.24; see [Appendix F](#appendix-f--wire-shape-evolution-by-alpha).
+Total v0 surface as of alpha.32: **12 methods + 1 notification**. (`Workspace.Mount`, `Workspace.Unmount`, `Workspace.Status`, `Daemon.Ping`, `Session.Open`, `Session.Close`, `Index.Outline`, `Index.FindSymbol`, `Index.FindCallers`, `Index.ReadSymbol`, `Index.ReadSymbolAt`, `Index.ReadRange`, plus `Daemon.Telemetry` notification.) `Index.ReadSymbolAt` shipped in alpha.24; `Index.FindCallers` and `Index.ReadSymbol.include_callers` ship in alpha.32. See [Appendix F](#appendix-f--wire-shape-evolution-by-alpha).
 
 `Daemon.Cancel` is **not** part of v0. Per-request cancellation is handled by the daemon noticing the connection closed (drop) or by Tokio `select!` against a soft deadline on the request future; both don't need a wire-level verb. v2 may introduce `Daemon.Cancel(request_id)` if mid-closure cancellation becomes worthwhile.
 
@@ -461,9 +462,12 @@ Read source for a named symbol. Optionally walks the tree-shaken closure of type
   "shape":                "body",                   // "signature" | "body" | "both"  (default "body")
   "token_budget":         4096,                     // optional; default 4096
   "include_dependencies": false,                    // tree-shake closure walk?
+  "include_callers":      false,                    // v0.3 (alpha.32+, cap: read_symbol.include_callers)
   "force_resend":         false                     // v1.1: override the session-dedup `body_omitted` short-circuit
 }
 ```
+
+When `include_callers: true`, the response carries a `callers: [...]` array with the same entry shape as §7.7c `Index.FindCallers.callers[]`, plus a `callers_truncated: bool` flag (separate from `closure_truncated` to preserve v0.2 wire semantics). Token-budget priority: body fills first, then `dependencies` (when requested), then `callers`. Capability: `read_symbol.include_callers`.
 
 **`result`** (full body):
 ```jsonc
@@ -524,6 +528,51 @@ Read source for the symbol whose def-range covers `(file, line)`. The **compiler
 **`result`**: same wire shape as §7.7 `Index.ReadSymbol` (body or session-deduped variant). `qualified_name` is the innermost enclosing def whose def-range covers the line; range tie-breakers prefer smaller ranges (innermost wins). When no def covers the line — e.g. a blank gap, a comment-only region, a top-level statement outside any function — returns `SYMBOL_NOT_FOUND` with `data: { "file", "line" }`.
 
 Errors: `INDEX_NOT_READY`, `SYMBOL_NOT_FOUND` (no def covers the line), `OUT_OF_ROOT`, `FILE_NOT_INDEXED`, `RANGE_OUT_OF_BOUNDS` (line > file LOC), `INVALID_PARAMS` (line < 1).
+
+### 7.7c `Index.FindCallers`
+
+Return the direct callers of a named symbol. One redb lookup over the persistent ref graph (v0.3 U1) — no per-file re-parsing. Backs the `find_callers` MCP tool. Capability: `find_callers` (alpha.32+).
+
+**`params`**:
+```jsonc
+{
+  "name":   "build_index",          // required, exact match
+  "kind":   "fn",                   // optional; filter on the *enclosing* def's kind (fn / method / etc.)
+  "file":   "src/index/mod.rs"      // optional; filter to callers originating from one file
+}
+```
+
+**`result`**:
+```jsonc
+{
+  "callers": [
+    {
+      "enclosing_qualified_name": "rts_core::cli::main",      // null when caller_sid is None (file-scope call)
+      "kind":                     "fn",                       // null when caller_sid is None
+      "file":                     "src/cli.rs",
+      "range": {                                              // the call site
+        "start_byte": 4520, "end_byte": 4531,
+        "start_line": 142,  "end_line":  142
+      },
+      "enclosing_def_range": {                                // the caller's own def range (null when caller_sid is None)
+        "start_byte": 4400, "end_byte": 5200,
+        "start_line": 138,  "end_line":  160
+      },
+      "rank_score": 0.0                                       // placeholder until v0.3 U4 (cap: `pagerank_symbolwise`)
+    }
+  ],
+  "truncated": false                                          // true when more than 256 callers existed
+}
+```
+
+Result is sorted by `(file, range.start_byte)` for stable output across calls; capped at 256 entries (mirrors `Index.FindSymbol`'s `MAX_MATCHES`).
+
+Errors: `INDEX_NOT_READY`, `SYMBOL_NOT_FOUND` (no `NAME_TO_SID` entry — symbol is not workspace-defined or never indexed; mirrors `Index.FindSymbol` error path), `INVALID_PARAMS` (`name` empty or >256 chars; unknown `kind` value).
+
+**When to use vs related methods:**
+- Use `find_callers` for callers-only (cheap; no body read).
+- Use `read_symbol --include-callers` when you also want the symbol's body in the same round trip.
+- Use `impact_of` (v0.3 U5) for *transitive* callers (refactor blast radius).
 
 ### 7.8 `Index.ReadRange`
 
@@ -940,7 +989,26 @@ These are normative for `params` validation. The daemon SHOULD reject schema-non
                               "default": "body" },
     "token_budget":         { "type": "integer", "minimum": 50, "maximum": 200000 },
     "include_dependencies": { "type": "boolean", "default": false },
+    "include_callers":      { "type": "boolean", "default": false },
     "force_resend":         { "type": "boolean", "default": false }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}
+```
+
+### 18.4c `Index.FindCallers.params`
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "kind": { "type": "string", "enum": ["fn", "struct", "enum", "type", "trait",
+                                          "const", "static", "impl", "method",
+                                          "class", "interface", "module"] },
+    "file": { "type": "string" }
   },
   "required": ["name"],
   "additionalProperties": false
@@ -960,7 +1028,8 @@ These are normative for `params` validation. The daemon SHOULD reject schema-non
     "shape":                { "type": "string", "enum": ["signature","body","both"],
                               "default": "body" },
     "token_budget":         { "type": "integer", "minimum": 50, "maximum": 200000 },
-    "include_dependencies": { "type": "boolean", "default": false }
+    "include_dependencies": { "type": "boolean", "default": false },
+    "include_callers":      { "type": "boolean", "default": false }
   },
   "required": ["file", "line"],
   "additionalProperties": false
@@ -968,6 +1037,7 @@ These are normative for `params` validation. The daemon SHOULD reject schema-non
 ```
 
 `column` is accepted but inert in v0 (tie-breaker only). Lands with v1.1 incremental parser reuse.
+`include_callers` (alpha.32+) mirrors `Index.ReadSymbol.params.include_callers`.
 
 ### 18.5 `Index.ReadRange.params`
 
@@ -1172,10 +1242,12 @@ This appendix tracks every additive wire-shape change between Draft 1 (P5 delive
 | `alpha.28` | (none — internal) | `crate::language` per-language dispatcher refactor. No wire change. | — |
 | `alpha.29` | (none — internal) | OnceLock query cache + signature renderer perf. No wire change. | — |
 | `alpha.30` | (none — internal) | JS/TS tags.scm reference queries (extends alpha.27 to JS/TS). Same wire shape; better-quality contents on JS/TS workspaces. | — |
+| `alpha.31` | (none — internal) | **v0.3 U1**: persistent reference graph (REFS / FID_REFS / SID_REFS_OUT tables; SCHEMA_VERSION 1→2). `outline::compute` reads indexed edges. Same wire shape; no agent-visible changes. | — |
+| `alpha.32` | `find_callers`, `read_symbol.include_callers` | **v0.3 U2'**: new method `Index.FindCallers(name, kind?, file?)` returns direct callers. `Index.ReadSymbol.params.include_callers: bool` composes callers into the existing response with a separate `callers_truncated` flag. | §7.7, §7.7c, §18.4, §18.4b, §18.4c |
 
-Capability strings present in `Daemon.Ping.result.capabilities` after alpha.30 (canonical list, in advertisement order): `outline`, `find_symbol`, `read_symbol`, `read_symbol_at`, `read_range`, `rank_score`, `tree_shake`, `partial_responses`, `content_version`, `secrets_blocklist`, `closure_walker`, `fuzzy_match`, `pagerank_filewise`, `polling_fallback`.
+Capability strings present in `Daemon.Ping.result.capabilities` after alpha.32 (canonical list, in advertisement order): `outline`, `find_symbol`, `find_callers`, `read_symbol`, `read_symbol_at`, `read_range`, `rank_score`, `tree_shake`, `partial_responses`, `content_version`, `secrets_blocklist`, `closure_walker`, `fuzzy_match`, `pagerank_filewise`, `polling_fallback`, `read_symbol.include_callers`.
 
-**Pending v0.3** (reserved in §4.2, not advertised at alpha.30): `find_callers`, `impact_of`, `read_symbol.include_callers`, `pagerank_symbolwise`.
+**Pending v0.3** (reserved in §4.2, not advertised at alpha.32): `impact_of` (U5), `pagerank_symbolwise` (U4).
 
 ### How to extend protocol-v0 in a future alpha
 
@@ -1190,4 +1262,4 @@ The PR description SHOULD link to the section(s) it changed so reviewers can ver
 
 ---
 
-*This document is the source of truth for the daemon-side wire protocol. The MCP-facing surface (`outline_workspace`, `find_symbol`, `read_symbol`, `read_symbol_at`, `read_range`, `rts://capabilities`) is governed by [docs/plans/2026-05-10-001-feat-pivot-to-agentic-retrieval-mcp-server-plan.md](plans/2026-05-10-001-feat-pivot-to-agentic-retrieval-mcp-server-plan.md) and the MCP 2025-11-25 spec; future MCP-tool changes should land in that plan, not here. The v0.3 code-graph KB extension lives in [docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md](plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md).*
+*This document is the source of truth for the daemon-side wire protocol. The MCP-facing surface (`outline_workspace`, `find_symbol`, `find_callers`, `read_symbol`, `read_symbol_at`, `read_range`, `rts://capabilities`) is governed by [docs/plans/2026-05-10-001-feat-pivot-to-agentic-retrieval-mcp-server-plan.md](plans/2026-05-10-001-feat-pivot-to-agentic-retrieval-mcp-server-plan.md) and the MCP 2025-11-25 spec; future MCP-tool changes should land in that plan, not here. The v0.3 code-graph KB extension lives in [docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md](plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md).*


### PR DESCRIPTION
## Summary

First agent-visible consumer of the persistent reference graph from [#29](https://github.com/njfio/rs-agent-code-utility/pull/29) (U1):

- **`Index.FindCallers(name)`** — direct callers of a named symbol, one redb lookup.
- **`Index.ReadSymbol.include_callers: bool`** — composes callers into the body+deps response.

**Merged unit** per the plan's [Deepening §F2](https://github.com/njfio/rs-agent-code-utility/blob/main/docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md#section-f--simplifications-selective-adoption-from-code-simplicity-reviewer): U2 + U3 from the original sequencing share the `CallerEntry` schema, handler logic, MCP tool descriptor, and CLI scaffolding. Landing them together saves an alpha bump cycle.

## Surface changes

### Daemon

- New handler `methods/index.rs::find_callers` returning `{callers: [...], truncated: bool}` (256-entry cap, sorted by `(file, range.start_byte)` for stable wire order).
- `ReadSymbolParams` + `ReadSymbolAtParams` gain `include_callers: bool`. `read_symbol_body` extended with a parallel callers branch — token-budget priority is `body > deps > callers`.
- **Separate `callers_truncated` flag** (Deepening §C4 — silent overload of `closure_truncated` was rejected in review).
- Three new `Store` helpers: `sid_for_name`, `path_for_fid`, `caller_def_info`. Plus a `CallerDefInfo` surface struct alongside `FoundSymbol`.
- `methods/mod.rs` dispatch wires `Index.FindCallers`.

### MCP

- New `find_callers` tool with **explicit when-to-use guidance** in the description (per agent-native review §G2):
  > "this tool returns callers ONLY (no body). Use `read_symbol --include-callers` when you also need the symbol's own body. Use `impact_of` (v0.3 U5) for transitive callers."
- `include_callers` arg added to `read_symbol` + `read_symbol_at` tools.

### Bench

- `rts-bench query find-callers --name X [--kind K] [--file F]` — new subcommand.
- `--callers` flag on `query read-symbol` + `query read-symbol-at`.
- **Legacy `task find_callers` stub** (`NotImplemented` since v0.2) updated to point users at the new `query find-callers`. Resolves the agent-native review §G5 naming-collision concern between the `task` and `query` namespaces.

### Protocol

- §4.1 advertises `find_callers` + `read_symbol.include_callers` (canonical capability list: 14 → 16).
- §4.2 marks both as **advertised** (strikethrough on the previously-reserved entries; `impact_of` + `pagerank_symbolwise` remain reserved for U5 / U4).
- §7 method catalog: 11 → 12 methods + 1 notification.
- **New §7.7c** documents `Index.FindCallers` (params, result shape, errors, when-to-use). §7.7 documents `include_callers` on `Index.ReadSymbol`.
- **New §18.4c** JSON Schema for `FindCallers.params`. §18.4 + §18.4b updated for `include_callers`.
- **Appendix F** gains an alpha.32 row.
- Architecture diagram: 5 → 6 MCP tools. `Daemon.Ping` example version refreshed.

## Wire shape (`Index.FindCallers`)

```jsonc
{
  "callers": [
    {
      "enclosing_qualified_name": "rts_core::cli::main", // null when caller_sid is None (file-scope call)
      "kind": "fn",                                       // null when caller_sid is None
      "file": "src/cli.rs",
      "range": { "start_byte": 4520, "end_byte": 4531,
                 "start_line": 142, "end_line": 142 },  // the call site
      "enclosing_def_range": {                          // the caller's def range (null when caller_sid is None)
        "start_byte": 4400, "end_byte": 5200,
        "start_line": 138, "end_line": 160
      },
      "rank_score": 0.0                                 // placeholder until U4 (cap: pagerank_symbolwise)
    }
  ],
  "truncated": false
}
```

`Index.ReadSymbol.include_callers=true` response gains the same `callers: [...]` array + `callers_truncated: bool` flag, alongside the v0.2 `dependencies` + `closure_truncated`.

## Verification

- `cargo test --workspace`: **540 passed, 0 failed, 0 ignored** (was 539 in alpha.31; +1 from `find_callers_round_trip`)
- `cargo fmt --all --check`: exit 0
- `cargo clippy --workspace --all-targets`: no new warnings on changed files. The U1 `#[allow(dead_code)]` on three Store helpers is **removed** since U2' consumes them in production paths.
- `outline_round_trip`, `closure_round_trip`, `find_symbol_round_trip`, etc. — all pre-existing integration tests pass unchanged.

### New `find_callers_round_trip` integration test asserts

| | What |
|---|---|
| 1. | Hub-spoke `Index.FindCallers(hub_compute)` returns 2 callers with correct `enclosing_qualified_name` (`caller_a_one`, `caller_b_one`) |
| 2. | `kind=fn` + `enclosing_def_range` populated on each entry; `range.start_byte` > 0 |
| 3. | `file=caller_a.rs` filter narrows to 1 caller |
| 4. | Unknown name → `SYMBOL_NOT_FOUND` error envelope |
| 5. | `Index.ReadSymbol(hub_compute, include_callers=true)` returns body + same 2 callers; wire shape matches `find_callers.callers[]` |
| 6. | Default `Index.ReadSymbol` preserves v0.2 wire shape (`callers: []`, `callers_truncated: false`) |

## Wire-contract notes

**Additive only.** Existing v0.2 clients see no observable change — they ignore the new `callers` + `callers_truncated` fields. Clients that branch on `Daemon.Ping.result.capabilities` should check for `find_callers` and `read_symbol.include_callers` before calling the new surfaces.

The separate `callers_truncated` flag (not overloading `closure_truncated`) was specifically chosen per Deepening §C4 to avoid silent semantic drift.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Logs: `find_callers` handler error paths via `tracing` at `target: rts_daemon::methods::index`. Watch for `refs_to_symbol storage error` (would indicate REFS table corruption from U1).
  - Wire: `Index.FindCallers` warm p95 latency. Plan G1 target: < 5ms. Each call is 1 NAME_TO_SID lookup + 1 REFS multimap read + N caller_def_info lookups (one per RefSite).
- **Validation**
  - `cargo test --workspace` → 540/0 on a fresh checkout
  - `rts-bench query find-callers --name <some_workspace_symbol>` on a real workspace returns a populated callers array
  - `rts-bench query read-symbol --name <X> --callers` returns body + callers in one round trip
- **Healthy signals**
  - `find_callers` latency p95 < 5ms warm on 100k-LOC workspace (G1)
  - `Index.ReadSymbol --include-callers` doesn't double-count tokens vs `body + find_callers` separately
- **Failure / rollback**
  - `cargo test --workspace` ≠ 540 → investigate before merge
  - `find_callers` warm p95 > 50ms → REFS index too large or per-site `caller_def_info` joins are expensive; consider caching def-name within the same txn
- **Validation window & owner**: per-call (microseconds); first-load on agent restart (seconds). Rollback = revert to alpha.31 binary.

## Related

- [#29](https://github.com/njfio/rs-agent-code-utility/pull/29) — v0.3 U1 (persistent ref graph; prereq)
- [#27](https://github.com/njfio/rs-agent-code-utility/pull/27) — v0.3 U0 (protocol-v0 re-spec at alpha.30 baseline)
- [#26](https://github.com/njfio/rs-agent-code-utility/pull/26) — v0.3 planning docs

## Next

After this merges: **U3** — closure walker swap to `store.refs_from_symbol` (currently re-parses; needs to read indexed `SID_REFS_OUT`). Then **U4** — symbol-level PageRank fills `rank_score`. Then **U5** — `Index.ImpactOf` transitive caller closure.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.5 (1M context) via [Claude Code](https://claude.com/claude-code)