### PR TITLE
chore(dev): pre-push fmt + clippy hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,21 @@ sibling binaries to be built first. `cargo test --workspace` handles
 this correctly; per-crate `cargo test -p` may need an explicit
 `cargo build --workspace` first.
 
+### Pre-push hook (optional)
+
+`lefthook.yml` at the repo root runs `cargo fmt --check` and a scoped
+`cargo clippy` on `git push`, matching what CI enforces, so format /
+lint drift is caught locally instead of via a CI round-trip + force-push.
+
+```sh
+# One-time, if you don't already use lefthook globally:
+brew install lefthook    # or: go install github.com/evilmartians/lefthook@latest
+lefthook install         # writes pre-push into .git/hooks
+```
+
+Bypass for a single push with `LEFTHOOK=0 git push`. Contributors who
+don't install lefthook are unaffected; CI is still the source of truth.
+
 ## Coding style
 
 - **Edition**: Rust 2024.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,20 @@
+# Local quality-of-life hook: catch fmt + clippy drift before CI does.
+# Pre-push only — interim commits are fine to ship.
+#
+# Activation:
+#   - If `lefthook` is on PATH and you use a global git hooks path (or
+#     have run `lefthook install`), this fires automatically.
+#   - To bypass for a single push: `LEFTHOOK=0 git push`.
+#   - To skip one command:        `LEFTHOOK_EXCLUDE=clippy git push`.
+#
+# Clippy is scoped to the actively-developed v0.2 crates; the legacy
+# `rts-core` lib has known latent warnings that the CI workflow also
+# runs in advisory mode (see .github/workflows/ci.yml).
+
+pre-push:
+  parallel: false
+  commands:
+    fmt:
+      run: cargo fmt --all -- --check
+    clippy:
+      run: cargo clippy -p rts-daemon -p rts-mcp -p rts-bench --all-targets


### PR DESCRIPTION
## Summary

Local quality-of-life hook so format / lint drift is caught before `git push`, matching what CI runs. Catches the exact failure mode that hit alpha.24 — files edited after the last `cargo fmt`, missed locally, caught by CI, needing a force-push fix. CI itself is unchanged.

- **Tool:** lefthook — already partway wired in this environment (the global `core.hooksPath` shim invokes `lefthook run pre-push` and was warning about the missing config). One file: `lefthook.yml`. No CI changes.
- **Checks:**
  - `cargo fmt --all -- --check` (fast — sub-second).
  - `cargo clippy -p rts-daemon -p rts-mcp -p rts-bench --all-targets` — scoped to the actively-developed v0.2 crates, matching the v0.2-series linting baseline; legacy `rts-core` lints stay advisory same as CI.
- **Pre-push only.** Commits stay uninstrumented — interim work is fine to ship; CI runs on push to `main`/`master`/`feature/**` per the existing workflow.
- **Opt-in.** Contributors without `lefthook` are unaffected; CI is still the source of truth. Bypass: `LEFTHOOK=0 git push`. Skip one command: `LEFTHOOK_EXCLUDE=clippy git push`.
- **Docs:** brief `Pre-push hook (optional)` block under `Build, test, lint` in `AGENTS.md` (the canonical project-conventions doc).

Total: 35 LOC of additions (15 lines `lefthook.yml`, ~16-line AGENTS.md block, 0 LOC anywhere else). Well under the 100-LOC budget.

## Verification

`cargo test --workspace` ✓ — full pass on workspace (rts-core / rts-daemon / rts-mcp / rts-bench unit + integration tests, plus doc-tests).
`cargo fmt --all -- --check` ✓ — clean.
`cargo clippy -p rts-daemon -p rts-mcp -p rts-bench --all-targets` ✓ — exits 0 (advisory mode, same as CI). Latent warnings noted but no `-D warnings`.

### Hook actually catches drift

Deliberately mis-indented `crates/rts-bench/src/token.rs::approx_tokens` (8-space indent vs. the rustfmt-mandated 4), committed it, and attempted `git push --dry-run`:

```
┃  fmt ❯

Diff in .../crates/rts-bench/src/token.rs:12:
 /// `tokens_returned` formula so bench numbers line up with what the agent
 /// would actually see in a `read_symbol` response.
 pub fn approx_tokens(bytes: usize) -> u64 {
-        (bytes as u64).div_ceil(3)
+    (bytes as u64).div_ceil(3)
 }

exit status 1
  ────────────────────────────────────
summary: (done in 3.97 seconds)
✔️ clippy (1.88 seconds)
🥊 fmt (0.49 seconds)
error: failed to push some refs to 'https://github.com/njfio/rs-agent-code-utility.git'
```

Drift commit then `git reset --hard HEAD~1` to back out; only the legitimate commit was pushed (which itself triggered the hook — both `fmt` and `clippy` reported `✓` on the real push).

## Test plan

- [ ] `cargo fmt --all -- --check` — clean
- [ ] `cargo clippy -p rts-daemon -p rts-mcp -p rts-bench --all-targets` — exits 0
- [ ] `cargo test --workspace` — passes
- [ ] `lefthook run pre-push --force` — runs both commands locally
- [ ] Drift test: mis-indent any tracked `.rs` file, commit, `git push --dry-run` → push rejected with rustfmt diff

## Rollback

Single-file revert of `lefthook.yml` is sufficient; `AGENTS.md` change is text-only. No protocol-wire-shape impact, no CI workflow impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)