### PR TITLE
feat(rts-daemon): 0.2.0-alpha.33 — closure walker reads indexed edges (v0.3 U3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,132 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.33] - 2026-05-14
+
+**Closure walker reads indexed edges (v0.3 U3).** The alpha.22 closure
+walker re-parsed the anchor body on every call to extract identifier
+references. With the persistent ref graph from U1 (`SID_REFS_OUT`),
+outgoing edges are already indexed at write time — closure::compute
+now just reads `store.refs_from_symbol(anchor_sid)`. Same external
+behavior; one redb lookup replaces a tree-sitter parse + filter.
+
+### Bug fix: local-var defs no longer steal `caller_sid`
+
+While swapping the closure walker to the indexed path, the
+`closure_round_trip` integration test caught a latent bug introduced
+in U1's commit_batch: the rts-core analyzer emits local-variable defs
+(e.g. `let w = make_widget(...)`) as Symbols whose byte range covers
+their RHS. When the writer computed `caller_sid` for refs at commit
+time, `enclosing_caller_sid` picked the tiny let-binding range as the
+innermost-enclosing def — so refs inside that range got `caller_sid =
+let_w_sid` instead of `caller_sid = enclosing_fn_sid`.
+
+The bug was invisible in alpha.31 + alpha.32 because outline +
+FindCallers don't use SID_REFS_OUT (outline uses FID_REFS;
+FindCallers uses REFS keyed by callee). The closure walker is the
+first consumer of SID_REFS_OUT, and the broken edges manifested as
+missing entries in `ReadSymbol(include_dependencies=true)` responses.
+
+The fix filters `enclosing_caller_sid` candidates to "call-bearing"
+kinds: `Function`, `Method`, `Module`. Local-variable / type / const
+/ struct defs no longer compete for the innermost-enclosing lookup.
+
+### Added
+
+- **`Store::name_for_sid(sid)`** — inverse of `sid_for_name`. Resolves
+  `SID_TO_NAME[sid]` for closure walker's callee → name lookup.
+- **`store::tests::enclosing_caller_sid_skips_non_call_bearing_kinds`**
+  — regression test pinning the kind filter. Asserts (a) Function
+  beats Other-kind let-binding even when the let's range is smaller;
+  (b) refs outside any def return `None`; (c) Method beats Module
+  when both contain the ref.
+
+### Changed
+
+- **`crates/rts-daemon/src/closure.rs::compute`** — signature drops
+  the `anchor_body: &str` parameter (no longer needed; refs come
+  from the index). Reads `store.refs_from_symbol(anchor_sid)` and
+  resolves callee sids back to names via `store.name_for_sid`.
+  Behavior preserves the v0.2 wire shape; existing
+  `closure_round_trip` + `closure_precision` tests pass unchanged.
+- **`crates/rts-daemon/src/methods/index.rs::read_symbol_body`** —
+  call to `closure::compute` no longer passes `&body_owned`; one
+  fewer move + one less String allocation per closure walk.
+- **`crates/rts-daemon/src/store/mod.rs::enclosing_caller_sid`** —
+  signature changes from `(file_defs: &[(u32, u32, u32)], byte)` to
+  `(file_defs: &[(u32, u32, u32, SymbolKind)], byte)` to support the
+  call-bearing-kind filter. Internal helper; not part of the public
+  surface.
+- **`commit_batch`** carries the `(sid, start, end, kind)` quadruple
+  in the Pass 1 `staged` vector instead of the prior triple. No
+  behavioral change for fn/method-only files; **rebuilds the call
+  graph correctly** for files with local-variable defs (which v0.2
+  workspaces did *not* exercise via SID_REFS_OUT — first time U3
+  consumes it).
+
+### Performance
+
+- **`closure::compute` no longer parses the anchor body.** Pre-U3
+  cost per closure walk: `tree-sitter parse + tags.scm captures +
+  filter against all_def_names` (~1-5 ms for typical fn bodies).
+  Post-U3 cost: one multimap read on SID_REFS_OUT + one SID_TO_NAME
+  lookup per callee. Should drop closure-walker latency materially
+  on cold calls (plan G5 target: ≥ 50% faster than alpha.30; bench
+  validation lands with the alpha.34 perf-pass).
+- **No write-amp delta.** SID_REFS_OUT was already populated by U1
+  at commit time. U3 changes how it's *read*.
+
+### Wire-contract notes
+
+**Zero new wire surface.** Same response shape from
+`Index.ReadSymbol(include_dependencies=true)` — same fields, same
+`closure_truncated` flag, same `truncated_symbols` semantics. Agents
+that ignored the implementation detail (which they should) see no
+change. Capability strings unchanged.
+
+The latent local-var bug means some v0.3 alpha.31/32 daemons may
+have shipped incomplete SID_REFS_OUT data (anything indexed *before*
+this fix landed). The fix triggers automatically: any file the
+writer re-commits after upgrade picks up the corrected caller_sid.
+Workspaces that mount fresh after the alpha.33 binary upgrade are
+fully consistent. **Operators upgrading mid-session can force-rebuild
+the index** by deleting `$XDG_STATE_HOME/rts/<workspace_id>/db.redb`
+— the index is a derived cache per protocol-v0 §15.4. The
+SCHEMA_VERSION bump (v0.3 alpha.31 already did this) means no
+agent-visible failure if you don't rebuild; just an underpopulated
+`include_dependencies` response on files indexed pre-fix.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **541 passed, 0 failed, 0 ignored**
+  (was 540 in alpha.32; +1 from the new enclosing_caller_sid
+  regression test).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: no new warnings on
+  changed files.
+- `closure_round_trip` integration test (which broke during the U3
+  swap until the kind filter landed) now passes — both `make_widget`
+  and `format_widget` correctly appear as dependencies of `process`.
+
+### Not in this slice
+
+- **Symbol-level PageRank → `rank_score`** (U4): the `rank_score`
+  field in `find_symbol` and `find_callers` responses remains a
+  `0.0` placeholder. `pagerank_symbolwise` capability still
+  reserved in §4.2.
+- **`Index.ImpactOf` (transitive callers)** (U5): the closure
+  walker is depth-1 by design; transitive callers go through
+  ImpactOf which adds BFS over reverse edges.
+- **Bench-driven perf validation** of the G5 closure-cold-call
+  speedup target: deferred to a follow-up perf-pass alongside U4 /
+  U5 implementations.
+
+### Refs
+
+- v0.3 plan §Phase 4 / Deepening §C1: [docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md](docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md)
+- Prereq: PRs [#29 (U1)](https://github.com/njfio/rs-agent-code-utility/pull/29) + [#30 (U2')](https://github.com/njfio/rs-agent-code-utility/pull/30)
+
 ## [0.2.0-alpha.32] - 2026-05-14
 
 **Direct callers + `Index.FindCallers` (v0.3 U2').** The persistent

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.0-alpha.32"
+version = "0.2.0-alpha.33"
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yourusername/rust_tree_sitter"

--- a/crates/rts-daemon/src/closure.rs
+++ b/crates/rts-daemon/src/closure.rs
@@ -3,20 +3,33 @@
 //!
 //! ### What this does
 //!
-//! Given an anchor symbol the agent asked for, walk its body for
-//! identifier references and surface each referenced symbol as a
-//! lightweight dep entry: `qualified_name`, `kind`, `file`, `range`,
-//! and a rendered `signature`. This lets agents do their work in one
-//! round trip instead of N `Index.FindSymbol` + `Index.ReadSymbol`
-//! follow-ups — a measurable token-reduction win on the §P9 baseline
-//! tasks (`get_body`, `find_callers`, `summarize_module`).
+//! Given an anchor symbol the agent asked for, look up its outgoing
+//! references via the persistent ref graph (alpha.31 U1) and surface
+//! each referenced symbol as a lightweight dep entry:
+//! `qualified_name`, `kind`, `file`, `range`, and a rendered
+//! `signature`. This lets agents do their work in one round trip
+//! instead of N `Index.FindSymbol` + `Index.ReadSymbol` follow-ups —
+//! a measurable token-reduction win on the §P9 baseline tasks
+//! (`get_body`, `summarize_module`, etc.).
+//!
+//! ### v0.3 U3 — indexed-edge swap
+//!
+//! Before alpha.33, this module re-parsed the anchor body on every
+//! call via `crate::refs::references_for_path` and filtered against
+//! the workspace-wide def-name set. The U1 ref graph means we can
+//! now read the outgoing edges from `SID_REFS_OUT` directly — one
+//! redb lookup instead of a tree-sitter parse + filter. Same
+//! external behavior; the `closure_round_trip` + `closure_precision`
+//! integration tests pass unchanged.
 //!
 //! ### Scope (v0)
 //!
-//! - **Depth 1.** We extract identifiers from the anchor body, filter
-//!   to known def names, and return one entry per unique referenced
-//!   symbol. We do not recursively walk the deps' bodies. Agents that
-//!   want depth > 1 can re-call `Index.ReadSymbol` on each entry.
+//! - **Depth 1.** We enumerate the anchor's outgoing edges from the
+//!   indexed graph and return one entry per unique referenced
+//!   symbol. We do not recursively walk the deps' edges. Agents that
+//!   want depth > 1 can re-call `Index.ReadSymbol` on each entry, or
+//!   use `Index.ImpactOf` (v0.3 U5) for the transitive *caller*
+//!   direction.
 //! - **First-match disambiguation.** When a name has multiple defs,
 //!   we pick the first by `(file, start_byte)` — same policy as the
 //!   anchor in `read_symbol`. The caller can re-resolve with a
@@ -28,6 +41,9 @@
 //!   surfaces in `truncated_symbols` and flips `closure_truncated`.
 //!
 //! Push-flow / multi-hop / type-graph walking is deferred to v1.1.
+//! Index.ImpactOf (v0.3 U5) provides multi-hop in the caller
+//! direction; multi-hop in the dependency direction would re-call
+//! `compute` recursively.
 
 use std::collections::BTreeSet;
 use std::path::Path;
@@ -84,43 +100,58 @@ impl ClosureResult {
     }
 }
 
-/// Walk the closure of `anchor` against `anchor_body` and return the
-/// dep entries that fit in `remaining_budget_tokens`.
+/// Walk the closure of `anchor` and return the dep entries that fit
+/// in `remaining_budget_tokens`.
 ///
 /// `workspace_root` is needed to read each dep's file contents for
 /// signature rendering. I/O failures on a single dep don't fail the
 /// whole call — that dep just gets `signature: None` and we move on.
+///
+/// v0.3 U3 (alpha.33): outgoing refs now come from the indexed
+/// `SID_REFS_OUT` table (populated by the writer in U1). No more
+/// re-parsing the anchor body. The candidate set is implicitly
+/// filtered to workspace-defined names because the writer's
+/// commit-time external-symbol filter (§F1) only interns
+/// workspace-defined callees into NAME_TO_SID.
 pub fn compute(
     workspace_root: &Path,
     store: &Store,
     anchor: &FoundSymbol,
-    anchor_body: &str,
     remaining_budget_tokens: u64,
 ) -> ClosureResult {
-    // Build the set of identifiers referenced by the anchor body
-    // that look like *symbols* (filtered against the workspace-wide
-    // def name set). This piggybacks on the same heuristic
-    // `crate::outline` uses for its PageRank graph, so behaviour is
-    // consistent across the two surfaces.
-    let all_def_names = match store.all_defined_names() {
-        Ok(s) => s,
+    // Resolve the anchor's sid so we can look up its outgoing edges.
+    // The anchor came from `Store::find_symbol(name)` or
+    // `Store::defs_in_file(path)`, so by construction the name has a
+    // NAME_TO_SID entry — but bail gracefully on a torn read.
+    let anchor_sid = match store.sid_for_name(&anchor.name) {
+        Ok(Some(s)) => s,
+        _ => return ClosureResult::empty(),
+    };
+    // Pull outgoing edges from the indexed graph. The writer's
+    // smallest-enclosing-def resolution at commit time (U1) means
+    // each edge's caller_sid is the def whose byte range covers the
+    // call site — so `refs_from_symbol(anchor_sid)` returns exactly
+    // the callees of the anchor's body, deduplicated by callee sid.
+    //
+    // File-scope refs (caller_sid == None) within the anchor's file
+    // are correctly excluded — they have no caller to key the
+    // SID_REFS_OUT edge on, so they wouldn't be in the closure even
+    // under the v0.2 behavior (which extracted from the anchor body
+    // alone, not the whole file).
+    let callee_sids = match store.refs_from_symbol(anchor_sid) {
+        Ok(v) => v,
         Err(_) => return ClosureResult::empty(),
     };
-    // Pull references via tags.scm where available (Rust/Python/Go/Ruby
-    // as of alpha.27); fall through to the regex tokenizer for other
-    // languages. Tags.scm precision eliminates false positives from
-    // local-variable shadowing + identifier mentions in comments. The
-    // call-site filter (`@reference.call`) drops trait/type-position
-    // identifiers too, which the regex would have surfaced as deps.
-    let refs = crate::refs::references_for_path(&anchor.file, anchor_body);
     let mut candidates: BTreeSet<String> = BTreeSet::new();
-    for ident in refs {
-        if ident == anchor.name {
-            continue; // skip self-reference
+    for callee_sid in callee_sids {
+        if callee_sid == anchor_sid {
+            continue; // skip self-reference (mutual recursion would land here too)
         }
-        if all_def_names.contains(&ident) {
-            candidates.insert(ident);
-        }
+        let name = match store.name_for_sid(callee_sid) {
+            Ok(Some(n)) => n,
+            _ => continue, // torn read or unknown sid; skip
+        };
+        candidates.insert(name);
     }
     if candidates.is_empty() {
         return ClosureResult::empty();
@@ -352,10 +383,14 @@ mod tests {
 
     #[test]
     fn extracted_identifiers_round_trip() {
-        // The closure walker piggybacks on outline::extract_identifiers
-        // for the regex fallback path; this test pins the tokenizer's
-        // shape against the patterns closure needs (Rust-style paths,
-        // calls, type names).
+        // Sanity test for the regex tokenizer used by
+        // `refs::references_with_ranges` for languages without a
+        // tags.scm query (C, C++, Java, PHP, Swift). v0.3 U3 no
+        // longer routes the closure walker through this path —
+        // the walker now reads `store.refs_from_symbol` directly
+        // (which itself is fed by the same regex fallback at
+        // write time for those languages). The test stays because
+        // `extract_identifiers` is still the underlying tokenizer.
         let ids: std::collections::HashSet<String> =
             crate::outline::extract_identifiers("fn foo(x: u32) -> bar::Baz { call() }")
                 .map(|s| s.to_string())

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -931,15 +931,12 @@ async fn read_symbol_body(
         let root_owned = root.to_path_buf();
         let store_arc = store_arc.clone();
         let chosen_clone = chosen.clone();
-        let body_owned = body_text.to_string();
+        // v0.3 U3 (alpha.33): closure::compute no longer needs the
+        // anchor body — outgoing refs come from the indexed
+        // SID_REFS_OUT table populated at commit time. body_text
+        // stays in scope for the body-text return.
         let walk = tokio::task::spawn_blocking(move || {
-            crate::closure::compute(
-                &root_owned,
-                &store_arc,
-                &chosen_clone,
-                &body_owned,
-                remaining_budget,
-            )
+            crate::closure::compute(&root_owned, &store_arc, &chosen_clone, remaining_budget)
         })
         .await
         .map_err(|e| {

--- a/crates/rts-daemon/src/store/mod.rs
+++ b/crates/rts-daemon/src/store/mod.rs
@@ -283,7 +283,7 @@ impl Store {
             // We carry `(fid, file_defs)` between passes so the caller_sid
             // resolution in Pass 2 still has access to the file's own def
             // ranges.
-            let mut staged: Vec<(u32, Vec<(u32, u32, u32)>, Vec<RefHit>)> =
+            let mut staged: Vec<(u32, Vec<(u32, u32, u32, SymbolKind)>, Vec<RefHit>)> =
                 Vec::with_capacity(upserts.len());
 
             // Pass 1.
@@ -330,10 +330,15 @@ impl Store {
                 let meta_bytes = to_allocvec(&entry.meta).context("encode FileMeta")?;
                 files.insert(&fid, meta_bytes.as_slice())?;
 
-                // Track each def's (sid, range) so we can compute caller_sid
-                // for ref sites in this file. Smallest enclosing range wins
-                // — same policy as `pick_innermost_def` in `methods/index`.
-                let mut file_defs: Vec<(u32, u32, u32)> = Vec::with_capacity(entry.defs.len());
+                // Track each def's (sid, byte_range, kind) so we can
+                // compute caller_sid for ref sites in this file.
+                // `enclosing_caller_sid` filters by kind (only Function/
+                // Method/Module count as callers) so local-variable
+                // defs emitted alongside fn defs don't "steal" the
+                // innermost-enclosing lookup. See is_call_bearing_kind
+                // for the rationale.
+                let mut file_defs: Vec<(u32, u32, u32, SymbolKind)> =
+                    Vec::with_capacity(entry.defs.len());
 
                 for (name, mut def, kind) in entry.defs {
                     let existing_sid = name_to_sid.get(name.as_str())?.map(|v| v.value());
@@ -351,7 +356,7 @@ impl Store {
                     let def_bytes = to_allocvec(&def).context("encode DefSite")?;
                     defs.insert(&sid, def_bytes.as_slice())?;
                     fid_defs.insert(&fid, &sid)?;
-                    file_defs.push((sid, def.start, def.end));
+                    file_defs.push((sid, def.start, def.end, kind));
                 }
 
                 staged.push((fid, file_defs, entry.refs));
@@ -547,6 +552,17 @@ impl Store {
     }
 
     /// All references *into* a symbol — "who calls X, and where?"
+    /// Resolve `sid` → workspace symbol name via `SID_TO_NAME`. The
+    /// inverse of `sid_for_name`. Returns `Ok(None)` for unknown sids
+    /// (shouldn't happen with committed data). Used by `closure::compute`
+    /// (v0.3 U3) to resolve outgoing-edge callee sids back to names for
+    /// the wire shape.
+    pub fn name_for_sid(&self, sid: u32) -> anyhow::Result<Option<String>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let sid_to_name = txn.open_table(SID_TO_NAME)?;
+        Ok(sid_to_name.get(&sid)?.map(|v| v.value().to_string()))
+    }
+
     /// Resolve `name` → `callee_sid` via `NAME_TO_SID`. Returns
     /// `Ok(None)` for unknown names (external symbols / unindexed).
     /// Used by `Index.FindCallers` (U2') to convert the wire-level
@@ -954,14 +970,38 @@ fn drop_file_entries(
     Ok(())
 }
 
-/// Find the smallest enclosing def whose byte range covers `byte`.
-/// Returns the sid of the innermost containing def, or `None` when
-/// the byte is outside every def (file-scope statement). The list
-/// is the file's own defs as `(sid, start, end)` triples; smallest
-/// range (end - start) wins on ties.
-fn enclosing_caller_sid(file_defs: &[(u32, u32, u32)], byte: u32) -> Option<u32> {
+/// Find the smallest enclosing def whose byte range covers `byte`
+/// AND whose kind is "call-bearing" (Function, Method, Module —
+/// kinds that have a body which can contain call expressions).
+///
+/// **v0.3 U3 fix:** the rts-core analyzer emits local-variable
+/// defs (e.g. `let w = make_widget(...)`) as Symbols with byte
+/// ranges covering their RHS. Without a kind filter, those tiny
+/// variable ranges win the innermost-enclosing lookup and "steal"
+/// the caller_sid from the actual containing function. The fix
+/// restricts candidates to kinds that can plausibly contain a
+/// call site:
+///
+/// - `Function` / `Method` — the obvious cases.
+/// - `Module` — top-level statements at module scope. The
+///   analyzer doesn't always emit module-scope kinds in v0, so
+///   most file-scope calls still end up with `caller_sid = None`.
+///
+/// Non-call-bearing kinds explicitly excluded: `Struct`, `Enum`,
+/// `Trait`, `Type`, `Const`, `Static`, `Class`, and `Other` (which
+/// covers `Variable` and anything from the parser the SymbolKind
+/// enum doesn't map cleanly).
+///
+/// Returns `None` when no call-bearing def covers the byte — the
+/// caller stores `caller_sid: None` in the `RefSite`, and the ref
+/// won't appear in `SID_REFS_OUT` (correct: a file-scope ref has
+/// no caller to key on).
+fn enclosing_caller_sid(file_defs: &[(u32, u32, u32, SymbolKind)], byte: u32) -> Option<u32> {
     let mut best: Option<(u32, u32)> = None; // (sid, range_size)
-    for &(sid, start, end) in file_defs {
+    for &(sid, start, end, kind) in file_defs {
+        if !is_call_bearing_kind(kind) {
+            continue;
+        }
         if byte >= start && byte < end {
             let span = end.saturating_sub(start);
             if best.map(|(_, b)| span < b).unwrap_or(true) {
@@ -970,6 +1010,17 @@ fn enclosing_caller_sid(file_defs: &[(u32, u32, u32)], byte: u32) -> Option<u32>
         }
     }
     best.map(|(sid, _)| sid)
+}
+
+/// Whether a `SymbolKind` represents something that can *contain*
+/// call expressions in its body. Used by `enclosing_caller_sid` to
+/// filter out local-variable / type-alias / const defs that the
+/// analyzer happens to emit alongside fn defs.
+fn is_call_bearing_kind(kind: SymbolKind) -> bool {
+    matches!(
+        kind,
+        SymbolKind::Function | SymbolKind::Method | SymbolKind::Module
+    )
 }
 
 fn u32_from_le_slice(slice: &[u8]) -> Option<u32> {
@@ -1173,6 +1224,48 @@ mod tests {
             visibility: Visibility::Public,
             kind: SymbolKind::Function,
         }
+    }
+
+    #[test]
+    fn enclosing_caller_sid_skips_non_call_bearing_kinds() {
+        // Regression test for the v0.3 U3 bug: the rts-core analyzer
+        // emits local-variable defs (e.g. `let w = make_widget(...)`)
+        // as Symbols with byte ranges covering their RHS. Before the
+        // is_call_bearing_kind filter, those tiny variable ranges
+        // would "steal" the innermost-enclosing lookup from the
+        // actual containing function — the ref's caller_sid would
+        // point at the let-binding instead of the enclosing fn, and
+        // SID_REFS_OUT[fn_sid] would silently drop the edge.
+        //
+        // Setup:
+        //   fn_def:  sid=10, bytes [0..100), kind=Function
+        //   var_def: sid=20, bytes [40..60), kind=Other (the let)
+        // A ref at byte 50 should attribute to fn_def (sid=10),
+        // *not* the let-binding (sid=20), even though the let's
+        // range is smaller.
+        let file_defs: Vec<(u32, u32, u32, SymbolKind)> = vec![
+            (10, 0, 100, SymbolKind::Function),
+            (20, 40, 60, SymbolKind::Other), // local let-binding shape
+        ];
+        let caller = enclosing_caller_sid(&file_defs, 50);
+        assert_eq!(
+            caller,
+            Some(10),
+            "non-call-bearing kinds must not steal caller_sid"
+        );
+
+        // A ref outside any def returns None.
+        assert_eq!(enclosing_caller_sid(&file_defs, 200), None);
+
+        // Methods + Modules also count as callers.
+        let nested: Vec<(u32, u32, u32, SymbolKind)> = vec![
+            (1, 0, 100, SymbolKind::Module),
+            (2, 10, 80, SymbolKind::Method),
+        ];
+        // Innermost: Method at [10..80) beats Module at [0..100) for a ref at 50.
+        assert_eq!(enclosing_caller_sid(&nested, 50), Some(2));
+        // For a ref at byte 5 (inside Module only), the Module wins.
+        assert_eq!(enclosing_caller_sid(&nested, 5), Some(1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Swaps the alpha.22 closure walker (`closure::compute`) from at-query-time tree-sitter parsing to a single redb lookup against the `SID_REFS_OUT` table populated by [#29](https://github.com/njfio/rs-agent-code-utility/pull/29) (U1)'s writer. Same external behavior; one tree-sitter parse + identifier filter replaced by one multimap read per call.

First consumer of `SID_REFS_OUT` — which **surfaced and fixed a latent local-variable bug** in the writer's `caller_sid` resolution. See the bug-fix section below.

## The swap

```text
                          BEFORE (alpha.22-32)                 AFTER (alpha.33)
                          ─────────────────────────────       ─────────────────────────────
closure::compute(anchor)  1. store.all_defined_names()        1. store.sid_for_name(anchor.name)
                          2. parse anchor_body via tags.scm   2. store.refs_from_symbol(sid)
                          3. filter idents by def-name set    3. store.name_for_sid(callee) each
                          4. resolve names → defs             4. resolve names → defs
                          5. render signatures + budget        5. render signatures + budget
```

Steps 1-3 (parse + filter) collapse to two redb lookups.

## Bug: local-variable defs were stealing `caller_sid`

The `closure_round_trip` integration test failed when I made the swap. Diagnosis:

The rts-core analyzer emits local-variable defs (e.g. `let w = make_widget(...)`) as `Symbol`s whose byte range covers the entire let-statement. Before this PR, the writer's `enclosing_caller_sid` picked the *smallest* enclosing def — and the let-binding's tiny range (~24 bytes) beat the containing function's range (~100 bytes) for refs inside the let.

So in the fixture:
```rust
pub fn process(id: u32) -> String {       // process: bytes [0..87), kind=Function
    let w = make_widget(id);              // w: bytes [40..64), kind=Other (variable)
    format_widget(&w)                     // format_widget at byte 69
}
```

- `make_widget` at byte 48 → enclosing-by-smallest-range picked **`w`** (40..64) instead of `process` (0..87)
- `format_widget` at byte 69 → outside `w`'s range → correctly picked `process`

Result: `SID_REFS_OUT[process_sid]` contained only `format_widget`, never `make_widget`. The bug was invisible in alpha.31/32 because neither consumer used the outgoing direction (outline reads `FID_REFS`; FindCallers reads `REFS` keyed by callee). U3 is the first consumer of `SID_REFS_OUT`, and the closure test broke immediately.

**Fix:** `enclosing_caller_sid` now filters candidates by `SymbolKind` — only `Function`, `Method`, and `Module` count as "call-bearing" containers. Local-variable / type / const / struct defs no longer compete for the innermost-enclosing lookup.

The `commit_batch` signature changes to carry `(sid, start, end, kind)` quadruples instead of triples — internal helper only.

## Tests

- **New regression test** `store::tests::enclosing_caller_sid_skips_non_call_bearing_kinds`:
  - Function beats Other-kind let-binding even when the let's range is smaller (the bug above)
  - Refs outside any def return `None`
  - Method beats Module when both contain the ref (innermost wins among call-bearing kinds)
- `closure_round_trip` + `closure_precision` pass unchanged after the swap
- Full workspace: **541 passed, 0 failed** (was 540 in alpha.32; +1 from the regression test)
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets`: no new warnings

## Performance

- **`closure::compute` no longer parses the anchor body.** Pre-U3 cost per closure walk: `tree-sitter parse + tags.scm captures + filter against all_def_names` (~1-5 ms for typical fn bodies). Post-U3 cost: one multimap read on `SID_REFS_OUT` + one `SID_TO_NAME` lookup per callee.
- Plan G5 target: closure-walker cold-call p95 ≥ 50% faster than alpha.30. Bench validation deferred to a follow-up perf-pass alongside U4 / U5.
- **No write-amp delta.** `SID_REFS_OUT` was already populated by U1 at commit time; U3 changes how it's *read*, not when it's *written*.

## Wire contract

**Zero new surface.** Same response shape from `Index.ReadSymbol(include_dependencies=true)`. Capability strings unchanged. Agents observe no difference.

## Operational note (operators upgrading mid-session)

Daemons running alpha.31 or alpha.32 may have shipped under-populated `SID_REFS_OUT` data — refs inside let-bindings would have keyed on the let's sid instead of the enclosing fn's. The fix self-heals on file re-commits (any save triggers re-extraction). Operators upgrading mid-session can force-rebuild by deleting `$XDG_STATE_HOME/rts/<workspace_id>/db.redb`; the index is a derived cache per protocol-v0 §15.4.

SCHEMA_VERSION stays at 2 (U1 already bumped). No agent-visible error if you don't rebuild — just a slightly under-populated `include_dependencies` response on files indexed pre-fix.

## Post-Deploy Monitoring & Validation

- **What to monitor**: `Index.ReadSymbol(include_dependencies=true)` response sizes on real workspaces. A drop in `dependencies[].length` between alpha.32 and alpha.33 is unexpected — would suggest the kind filter is over-aggressive.
- **Validation**: `cargo test --workspace` → 541/0 on a fresh checkout. The closure_round_trip integration test specifically pins both `make_widget` and `format_widget` as deps of `process`.
- **Healthy signals**: `Index.ReadSymbol --include-dependencies` returns the same shape as alpha.32 (possibly with *more* deps on workspaces where the alpha.31/32 bug had silently dropped them).
- **Failure / rollback**: any existing integration test failing post-merge → rollback to alpha.32. Empty `dependencies` array where alpha.32 had entries → possible regression from the kind filter being too narrow.
- **Validation window & owner**: per-call; rollback = revert to alpha.32 binary.

## Related

- v0.3 plan §Phase 4 / Deepening §C1: [docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md](docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md)
- [#29](https://github.com/njfio/rs-agent-code-utility/pull/29) — v0.3 U1 (persistent ref graph; prereq)
- [#30](https://github.com/njfio/rs-agent-code-utility/pull/30) — v0.3 U2' (FindCallers + include_callers; prereq)

## Next

After this merges: **U4** — symbol-level PageRank fills the `rank_score` placeholder in `find_symbol` and `find_callers` responses. New `pagerank_symbolwise` capability.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.5 (1M context) via [Claude Code](https://claude.com/claude-code)