### PR TITLE
feat(rts-daemon): 0.2.0-alpha.34 — symbol-level PageRank fills rank_score (v0.3 U4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,140 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.34] - 2026-05-14
+
+**Symbol-level PageRank fills `rank_score` (v0.3 U4).** The
+`rank_score` placeholder field in `Index.FindSymbol` and
+`Index.FindCallers` responses — `0.0` since alpha.18 — now carries
+the real symbol-level PageRank value, computed over the persistent
+call graph from U1. `Index.FindSymbol.matches[]` sorts by descending
+rank by default, making `find_symbol(pattern="*")` the de-facto
+"top symbols in this workspace" query without a new endpoint.
+
+### Added
+
+- **`crates/rts-daemon/src/symbol_pagerank.rs`** (new module): graph
+  builder over workspace-defined sids (nodes) + `SID_REFS_OUT`
+  edges, weighted via Aider's recipe (×10 well-named compound names,
+  ×0.1 leading-underscore privates, ×0.1 ubiquitous symbols defined
+  in >5 files). Reuses `rust_tree_sitter::pagerank::compute` with
+  NetworkX defaults (α=0.85, max_iter=100, tol=1e-6).
+- **`SymbolPagerankCache`** (single-slot mutex, generation-keyed) at
+  `symbol_pagerank::SymbolPagerankCache`. Mirrors alpha.20's
+  `OutlineCache` shape. First `find_symbol` after a generation bump
+  pays the compute cost; subsequent calls within the same generation
+  are O(1).
+- **`Store::iter_workspace_sids()`** — enumerates `(sid, name, def_count)`
+  for every sid with at least one DEFS entry. External-only sids
+  (referenced but not defined) are naturally absent per Deepening §F1.
+- **`Index.FindSymbol.params.sort: Option<String>`** — accepts
+  `"rank"` (default) and `"lexical"`. Lexical opts out for tooling
+  pinned to v0.2's alphabetical-by-`(file, start_byte)` ordering.
+- **`pagerank_symbolwise` capability string** advertised via
+  `Daemon.Ping.result.capabilities` (canonical list grows 16 → 17).
+  Also: full canonical capability list now matches protocol-v0.md §4.1
+  — `DAEMON_CAPABILITIES` had drifted across alpha.18-33 and never
+  advertised `pagerank_filewise`, `closure_walker`, `read_symbol_at`,
+  `fuzzy_match`, `polling_fallback`, `find_callers`, or
+  `read_symbol.include_callers`. All landed in this PR.
+- **`crates/rts-daemon/tests/symbol_pagerank_round_trip.rs`** (new):
+  5-symbol hub-spoke fixture (4 callers around 1 hub). Asserts
+  (a) `pagerank_symbolwise` advertised via `Daemon.Ping`;
+  (b) `find_symbol(pattern="*")` puts `hub_compute` first (top of
+  rank-sorted list);
+  (c) each `rank_score > 0`; hub's rank exceeds the average caller rank;
+  (d) `sort: "lexical"` opt-out restores alphabetical order;
+  (e) `find_callers` fills `rank_score` per CallerEntry.
+- Two new module unit tests: `empty_workspace_returns_empty_ranks`,
+  `cache_stores_and_invalidates_by_generation`.
+
+### Changed
+
+- **`Index.FindSymbol` handler** (`methods/index.rs::find_symbol`):
+  reads `state.index_generation` *before* opening any read txn
+  (Deepening §C cache TOCTOU invariant); looks up ranks via the new
+  `symbol_ranks_lazy` helper; collects matches into typed tuples,
+  sorts (by descending rank or lexical), then truncates at 256.
+  Pre-U4 the code truncated mid-iteration which could drop higher-rank
+  matches in pattern queries.
+- **`CallerEntry`** (`find_callers` + `read_symbol.include_callers`):
+  `rank_score` field now carries the enclosing caller's PageRank
+  (was `0.0` constant in U2'). File-scope refs (no caller_sid)
+  still get `0.0`.
+- **`DaemonState`** gains a `symbol_pagerank_cache: SymbolPagerankCache`
+  field, initialised on construction. Drops automatically when the
+  daemon's `DaemonState` is dropped (idle shutdown).
+- **`Cargo.toml`** workspace version 0.2.0-alpha.33 → 0.2.0-alpha.34.
+
+### Performance
+
+- **First find_symbol after a writer commit pays the PageRank
+  compute cost.** Plan §G3 / Deepening §C3 estimates 150-450ms on a
+  100k-LOC workspace (~20-40k sids × ~100-300k edges). Plan §G1's
+  warm-call target (<5ms) is unaffected once the cache is filled.
+- **No stale-rank-during-recompute path yet** (Deepening §C3
+  optimization). Cold compute is synchronous; the
+  `find_symbol`/`find_callers` call that triggers it blocks. If
+  bench shows this dominates real-agent loops, the stale-serving
+  path lands as a follow-up.
+- **No sorted-edge-vec collapse yet** (also §C3). `pagerank::compute`'s
+  `HashMap<(u32,u32), f64>` shape is shared with the file-level
+  ranker (alpha.18). A follow-up perf-pass alongside benchmarks.
+- **Aider edge multipliers** applied at edge-construction time per
+  Deepening §D. Compound well-named symbols (≥ 8 chars, snake_case
+  or camelCase) get ×10 inbound weight, leading-underscore privates
+  get ×0.1, and ubiquitous symbols (>5 defs across the workspace)
+  get ×0.1 dampening.
+
+### Wire-contract notes
+
+**Additive but with a default-sort behavior change.** Clients that
+ignored `rank_score: 0.0` and didn't rely on the previous insertion
+order see no observable change. Clients that *did* rely on the
+previous ordering should:
+- branch on the `pagerank_symbolwise` capability in `Daemon.Ping`
+  before calling `Index.FindSymbol`, OR
+- pass `sort: "lexical"` explicitly (works on every alpha — older
+  daemons silently ignore unknown params).
+
+Per Deepening §G4, the default-change was deliberate: the plan §R5
+specifies that "results sort by descending rank" once rank is real,
+and gating behind the capability-string AND a sort opt-out covers
+both the ranked-default + lexical-back-compat paths.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **544 passed, 0 failed, 0 ignored**
+  (was 541 in alpha.33; +3 = 2 unit + 1 integration).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: no new warnings on
+  changed files.
+- New integration test `symbol_pagerank_ranks_hub_above_callers`
+  pins the hub-above-callers expectation, capability advertisement,
+  and `sort: "lexical"` opt-out behavior.
+
+### Not in this slice
+
+- **`Index.ImpactOf` (transitive callers)** — v0.3 U5, last unit of
+  the v0.3 plan. New BFS over reverse edges + depth + token budget
+  + `scenario_refactor_impact` bench fixture.
+- **Stale-rank serving during recompute** (Deepening §C3): cold
+  recompute currently blocks. Bench-driven; defer until measured.
+- **Aider edge-weight `mentioned_idents` / `chat_files` multipliers**:
+  the underlying `pagerank::edge_weight` function accepts them, but
+  symbol-level PageRank doesn't surface a way to pass user-provided
+  "interesting symbols" yet. Could land as a `find_symbol.params.bias_idents`
+  follow-up if a real consumer asks.
+
+### Refs
+
+- v0.3 plan §Phase 5 / Deepening §C3, §D, §G4:
+  [docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md](docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md)
+- Prereqs: [#29 (U1)](https://github.com/njfio/rs-agent-code-utility/pull/29) +
+  [#30 (U2')](https://github.com/njfio/rs-agent-code-utility/pull/30) +
+  [#32 (U3)](https://github.com/njfio/rs-agent-code-utility/pull/32)
+
 ## [0.2.0-alpha.33] - 2026-05-14
 
 **Closure walker reads indexed edges (v0.3 U3).** The alpha.22 closure

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.0-alpha.33"
+version = "0.2.0-alpha.34"
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yourusername/rust_tree_sitter"

--- a/crates/rts-daemon/src/main.rs
+++ b/crates/rts-daemon/src/main.rs
@@ -22,6 +22,7 @@ mod refs;
 mod socket;
 mod state;
 mod store;
+mod symbol_pagerank;
 mod watcher;
 mod workspace;
 mod writer;

--- a/crates/rts-daemon/src/methods/daemon.rs
+++ b/crates/rts-daemon/src/methods/daemon.rs
@@ -6,14 +6,43 @@ use std::sync::Arc;
 use crate::error::ProtocolError;
 use crate::state::DaemonState;
 
+/// Canonical advertised capability list. Mirrors protocol-v0.md §4.1
+/// + Appendix F. Order matches the canonical list documented in §4.1
+/// so capability-string ordering across daemons is stable.
+///
+/// Each entry corresponds to a method, param, or behavior whose
+/// presence clients can branch on without re-issuing methods that may
+/// not exist. Reserved-for-future entries live in §4.2 and are NOT in
+/// this list; they're advertised only when the implementing alpha
+/// lands.
 const DAEMON_CAPABILITIES: &[&str] = &[
-    "outline", // present in spec; reads return IndexNotReady until P6 indexing lands
+    // v0 base methods (alpha.1+).
+    "outline",
     "find_symbol",
     "read_symbol",
     "read_range",
+    // Behaviors + content shape.
+    "rank_score",
+    "tree_shake",
     "partial_responses",
     "content_version",
     "secrets_blocklist",
+    // alpha.18 — file-level PageRank ranking inside Index.Outline.
+    "pagerank_filewise",
+    // alpha.22 — Index.ReadSymbol.include_dependencies (closure walker).
+    "closure_walker",
+    // alpha.24 — Index.ReadSymbolAt method + Index.FindSymbol.pattern glob.
+    "read_symbol_at",
+    "fuzzy_match",
+    // alpha.25 — Workspace.Status.watcher_status = "polling_fallback".
+    "polling_fallback",
+    // v0.3 alpha.32 — Index.FindCallers method.
+    "find_callers",
+    // v0.3 alpha.32 — Index.ReadSymbol.include_callers param.
+    "read_symbol.include_callers",
+    // v0.3 alpha.34 — symbol-level PageRank fills rank_score; default
+    // sort is descending rank (lexical opt-out via `sort: "lexical"`).
+    "pagerank_symbolwise",
 ];
 
 /// `Daemon.Ping` — heartbeat + capability advertisement (protocol-v0 §4.1, §7.1).

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -14,6 +14,7 @@ use crate::error::{ErrorCode, ProtocolError};
 use crate::filter::BODY_ALLOWED_EXTENSIONS;
 use crate::state::DaemonState;
 use crate::store::{FoundSymbol, Store, SymbolKind};
+use crate::symbol_pagerank::{SymbolRanks, compute_symbol_ranks};
 
 /// `Index.ReadSymbol`/`Index.ReadRange` clamp at 4 MiB of returned text. The
 /// 16 MiB wire cap (§3.3) is the hard ceiling; the 4 MiB cap leaves room for
@@ -44,6 +45,17 @@ struct FindSymbolParams {
     kind: Option<String>,
     #[serde(default)]
     file: Option<String>,
+    /// v0.3 U4 (alpha.34+, cap: `pagerank_symbolwise`) — sort order
+    /// for the `matches` array. Accepted values:
+    /// - `"rank"` (default when the capability is advertised) —
+    ///   descending `rank_score` (symbol-level PageRank). Use this
+    ///   to get the top-K most central matches first.
+    /// - `"lexical"` — back-compat alphabetical order by `file` then
+    ///   `start_byte`. Opt out for tooling that pinned to v0.2's
+    ///   insertion-shape ordering.
+    /// Unknown values are accepted and treated as `"rank"`.
+    #[serde(default)]
+    sort: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -316,6 +328,69 @@ fn line_range_bytes(
     Ok((s, e))
 }
 
+/// Sort modes for `Index.FindSymbol.matches`. v0.3 U4 (alpha.34+).
+/// `Rank` is the default when the `pagerank_symbolwise` capability
+/// is advertised; `Lexical` is opt-in for tooling pinned to v0.2's
+/// insertion-shape ordering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SortMode {
+    Rank,
+    Lexical,
+}
+
+impl SortMode {
+    fn from_param(s: Option<&str>) -> Self {
+        match s.map(|x| x.trim().to_ascii_lowercase()) {
+            Some(ref v) if v == "lexical" => SortMode::Lexical,
+            Some(ref v) if v == "rank" => SortMode::Rank,
+            _ => SortMode::Rank, // unknown / unset → default
+        }
+    }
+}
+
+/// Fetch the symbol-level PageRank for the current generation. On a
+/// cache hit (warm), returns the cached `Arc<SymbolRanks>` cheaply.
+/// On a miss (cold or post-commit), runs `compute_symbol_ranks` on a
+/// blocking thread (the compute is CPU-bound; spawn_blocking keeps
+/// the tokio runtime responsive for other concurrent requests),
+/// stores the result, and hands it back.
+///
+/// Returns `Ok(None)` only when no workspace symbols exist yet
+/// (cold start). In that case `find_symbol` proceeds with all
+/// `rank_score: 0.0` — the wire shape stays consistent.
+///
+/// **Cache TOCTOU invariant (Deepening §C):** the caller must read
+/// `state.index_generation` *before* opening any read transaction
+/// against the store. Passing `generation` in (rather than reading
+/// it here) makes that ordering explicit.
+fn symbol_ranks_lazy(
+    state: &Arc<DaemonState>,
+    store: &Arc<Store>,
+    generation: u64,
+) -> Result<Option<Arc<SymbolRanks>>, ProtocolError> {
+    if let Some(hit) = state.symbol_pagerank_cache.get(generation) {
+        return Ok(Some(hit));
+    }
+    // Miss: synchronously compute. First cut per the plan; the
+    // stale-rank-during-recompute optimization from Deepening §C3 is
+    // a follow-up if perf bench shows this dominates.
+    let ranks = compute_symbol_ranks(store, generation).map_err(|e| {
+        ProtocolError::new(
+            ErrorCode::InternalError,
+            format!("symbol_pagerank compute error: {e:#}"),
+        )
+    })?;
+    if ranks.sid_to_rank.is_empty() {
+        return Ok(None);
+    }
+    state.symbol_pagerank_cache.put(ranks.clone());
+    // Re-fetch through the cache so callers get an `Arc<SymbolRanks>`
+    // instead of cloning the map. The cache's mutex guarantees the
+    // value we just put is the one we read back (no other writer
+    // could race against this thread between put and get).
+    Ok(state.symbol_pagerank_cache.get(generation))
+}
+
 /// `Index.FindSymbol` — protocol-v0 §7.6.
 ///
 /// v0 contract:
@@ -326,8 +401,11 @@ fn line_range_bytes(
 ///   not both — the pattern path is the alpha.24 dogfooding-gap fix
 ///   that replaces "agent falls back to ripgrep when they don't know the
 ///   exact name". O(N) over all indexed names; with a 256-match cap.
-/// - `rank_score` is a placeholder constant for this slice — the real
-///   PageRank-driven ranking lands in the P8 token-reduction-depth phase.
+/// - **v0.3 U4** (alpha.34+, capability `pagerank_symbolwise`):
+///   `rank_score` is filled with the symbol-level PageRank value
+///   and results sort by descending rank. The `sort: "lexical"`
+///   param opts out for tooling that pinned to v0.2's
+///   insertion-order ordering.
 pub async fn find_symbol(
     params: serde_json::Value,
     state: &Arc<DaemonState>,
@@ -365,8 +443,16 @@ pub async fn find_symbol(
     }
     let kind_filter = p.kind.as_deref().map(SymbolKind::from_str_loose);
     let file_filter = p.file.as_deref();
+    let sort_mode = SortMode::from_param(p.sort.as_deref());
 
     let (_root, store_arc) = snapshot(state)?;
+
+    // Read the index generation BEFORE opening any read transaction
+    // for rank lookup. Deepening §C invariant: the cache key must be
+    // observed *before* the data the cache describes, never after,
+    // to avoid storing pre-commit ranks under a post-commit key.
+    let generation = state.index_generation.load(Ordering::Relaxed);
+    let ranks = symbol_ranks_lazy(state, &store_arc, generation)?;
 
     // Resolve the candidate symbol names.
     let names: Vec<String> = if let Some(n) = &p.name {
@@ -393,14 +479,24 @@ pub async fn find_symbol(
         filtered
     };
 
-    let mut matches = Vec::with_capacity(names.len().min(MAX_MATCHES));
-    'outer: for n in &names {
+    // Collect typed `(FoundSymbol, rank_score)` tuples so we can sort
+    // before building the wire JSON. The 256-entry cap applies after
+    // sorting (per Deepening §G: rank-then-truncate gives the
+    // top-K-by-rank, not the top-K-by-encounter).
+    let mut typed: Vec<(crate::store::FoundSymbol, f64)> =
+        Vec::with_capacity(names.len().min(MAX_MATCHES));
+    for n in &names {
         let hits = store_arc.find_symbol(n).map_err(|e| {
             ProtocolError::new(
                 ErrorCode::InternalError,
                 format!("find_symbol storage error: {e:#}"),
             )
         })?;
+        // Resolve this name's sid once per name (all hits share it).
+        let rank_for_name = match store_arc.sid_for_name(n) {
+            Ok(Some(sid)) => ranks.as_ref().map(|r| r.rank_for(sid)).unwrap_or(0.0),
+            _ => 0.0,
+        };
         for h in hits.into_iter() {
             if let Some(filter) = kind_filter {
                 if h.kind != filter {
@@ -412,7 +508,34 @@ pub async fn find_symbol(
                     continue;
                 }
             }
-            matches.push(serde_json::json!({
+            typed.push((h, rank_for_name));
+        }
+    }
+
+    // Apply sort. Default = descending rank when ranks are available;
+    // explicit "lexical" opts out. Stable secondary sort by
+    // (file, start_byte) keeps the order deterministic across ties.
+    match sort_mode {
+        SortMode::Lexical => typed.sort_by(|a, b| {
+            a.0.file
+                .cmp(&b.0.file)
+                .then(a.0.start_byte.cmp(&b.0.start_byte))
+        }),
+        SortMode::Rank => typed.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(a.0.file.cmp(&b.0.file))
+                .then(a.0.start_byte.cmp(&b.0.start_byte))
+        }),
+    }
+
+    let pre_truncate_len = typed.len();
+    typed.truncate(MAX_MATCHES);
+
+    let matches: Vec<serde_json::Value> = typed
+        .into_iter()
+        .map(|(h, rank)| {
+            serde_json::json!({
                 "qualified_name": h.name,
                 "kind":           h.kind.as_wire_str(),
                 "file":           h.file,
@@ -422,21 +545,19 @@ pub async fn find_symbol(
                     "start_byte": h.start_byte,
                     "end_byte":   h.end_byte,
                 },
-                // v0: signature rendering is part of P8 SignatureRenderer; for now
+                // v0: signature rendering is part of P8 SignatureRenderer;
                 // the writer doesn't store extracted signatures.
                 "signature": serde_json::Value::Null,
                 "doc":       serde_json::Value::Null,
                 "visibility": h.visibility.as_wire_str(),
-                // Placeholder until P8 wires PageRank.
-                "rank_score": 0.0,
-            }));
-            if matches.len() >= MAX_MATCHES {
-                break 'outer;
-            }
-        }
-    }
+                // v0.3 U4: real PageRank score when ranks are loaded;
+                // 0.0 fallback during cold start / torn read.
+                "rank_score": rank,
+            })
+        })
+        .collect();
 
-    let truncated = matches.len() == MAX_MATCHES;
+    let truncated = pre_truncate_len > MAX_MATCHES;
     Ok(serde_json::json!({
         "matches":   matches,
         "truncated": truncated,
@@ -491,6 +612,10 @@ pub async fn find_callers(
 
     let (_root, store_arc) = snapshot(state)?;
 
+    // v0.3 U4: read generation BEFORE any redb txn (Deepening §C).
+    let generation = state.index_generation.load(Ordering::Relaxed);
+    let ranks = symbol_ranks_lazy(state, &store_arc, generation)?;
+
     let callee_sid = match store_arc.sid_for_name(&p.name).map_err(|e| {
         ProtocolError::new(
             ErrorCode::InternalError,
@@ -515,7 +640,7 @@ pub async fn find_callers(
 
     let mut callers: Vec<serde_json::Value> = Vec::with_capacity(sites.len().min(MAX_CALLERS));
     for site in &sites {
-        let entry = match build_caller_entry(&store_arc, site)? {
+        let entry = match build_caller_entry(&store_arc, site, ranks.as_deref())? {
             Some(e) => e,
             None => continue, // path lookup failed (torn read); skip
         };
@@ -573,6 +698,10 @@ struct CallerEntry {
     call_end_line: u32,
     /// Enclosing def's range — present when caller_sid is Some.
     def_range: Option<(u32, u32, u32, u32)>, // (start_byte, end_byte, start_line, end_line)
+    /// v0.3 U4: rank of the enclosing caller fn. `0.0` for
+    /// file-scope refs (no caller_sid) and on cold-start before
+    /// ranks have been computed.
+    rank_score: f64,
 }
 
 impl CallerEntry {
@@ -603,8 +732,8 @@ impl CallerEntry {
                 "end_line":   self.call_end_line,
             },
             "enclosing_def_range": enclosing_def_range,
-            // Placeholder until v0.3 U4 wires symbol-level PageRank.
-            "rank_score": 0.0,
+            // v0.3 U4: PageRank of the enclosing caller fn.
+            "rank_score": self.rank_score,
         })
     }
 }
@@ -613,9 +742,13 @@ impl CallerEntry {
 /// `caller_def_info`. Returns `Ok(None)` only when the fid path lookup
 /// fails (torn read or stale fid) — file-scope refs (caller_sid==None)
 /// return a `CallerEntry` with the caller fields cleared.
+///
+/// `ranks` is `None` during cold-start (no PageRank computed yet) or
+/// for empty workspaces; in that case every entry gets `rank_score = 0.0`.
 fn build_caller_entry(
     store: &Arc<Store>,
     site: &crate::store::RefSite,
+    ranks: Option<&SymbolRanks>,
 ) -> Result<Option<CallerEntry>, ProtocolError> {
     let file = match store.path_for_fid(site.fid).map_err(|e| {
         ProtocolError::new(
@@ -647,6 +780,12 @@ fn build_caller_entry(
         },
         None => (None, None, None),
     };
+    // Caller rank: use the enclosing fn's sid → ranks lookup. File-scope
+    // refs (no caller_sid) get 0.0; cold-start (ranks is None) also gets 0.0.
+    let rank_score = match (site.caller_sid, ranks) {
+        (Some(sid), Some(r)) => r.rank_for(sid),
+        _ => 0.0,
+    };
     Ok(Some(CallerEntry {
         enclosing_qualified_name,
         kind,
@@ -656,6 +795,7 @@ fn build_caller_entry(
         call_start_line: site.start_line,
         call_end_line: site.end_line,
         def_range,
+        rank_score,
     }))
 }
 
@@ -972,6 +1112,11 @@ async fn read_symbol_body(
             .saturating_sub(dep_tokens);
         let max_callers_by_budget = remaining_budget / APPROX_TOKENS_PER_CALLER;
 
+        // v0.3 U4: rank lookup for the caller entries' rank_score
+        // field. Read generation BEFORE the read txn (Deepening §C).
+        let generation = state.index_generation.load(Ordering::Relaxed);
+        let ranks = symbol_ranks_lazy(state, store_arc, generation)?;
+
         // Anchor is workspace-defined (we just read its body) so a
         // sid is virtually guaranteed; if it's missing (torn read on
         // a just-removed file), surface an empty callers list rather
@@ -998,7 +1143,7 @@ async fn read_symbol_body(
 
             let mut entries: Vec<serde_json::Value> = Vec::with_capacity(kept_sites.len());
             for site in &kept_sites {
-                if let Some(entry) = build_caller_entry(store_arc, site)? {
+                if let Some(entry) = build_caller_entry(store_arc, site, ranks.as_deref())? {
                     entries.push(entry.to_wire_value());
                 }
             }

--- a/crates/rts-daemon/src/state.rs
+++ b/crates/rts-daemon/src/state.rs
@@ -10,6 +10,7 @@ use std::time::Instant;
 
 use crate::outline::OutlineCache;
 use crate::store::Store;
+use crate::symbol_pagerank::SymbolPagerankCache;
 use crate::watcher::Watcher;
 use crate::workspace::MountedWorkspace;
 
@@ -96,6 +97,12 @@ pub struct DaemonState {
     /// and invalidate the entry implicitly on the next lookup. See
     /// `outline.rs` module docs for the rationale.
     pub outline_cache: OutlineCache,
+    /// Single-slot cache for symbol-level PageRank (v0.3 U4). Keyed by
+    /// `index_generation` — writer commits bump the generation and the
+    /// next `find_symbol` triggers a recompute. Mirrors `outline_cache`'s
+    /// shape; see `symbol_pagerank.rs` for the algorithm + Deepening §C3
+    /// for the perf budget.
+    pub symbol_pagerank_cache: SymbolPagerankCache,
 }
 
 impl DaemonState {
@@ -112,6 +119,7 @@ impl DaemonState {
             index_generation: AtomicU64::new(0),
             watcher_status: AtomicU8::new(WatcherStatus::NoWatcher as u8),
             outline_cache: OutlineCache::new(),
+            symbol_pagerank_cache: SymbolPagerankCache::new(),
         }
     }
 

--- a/crates/rts-daemon/src/store/mod.rs
+++ b/crates/rts-daemon/src/store/mod.rs
@@ -552,6 +552,47 @@ impl Store {
     }
 
     /// All references *into* a symbol — "who calls X, and where?"
+    /// Enumerate every workspace-defined sid plus its name and the
+    /// number of files that define it. Used by `symbol_pagerank` (v0.3
+    /// U4) to build the rank-graph node set + apply the "ubiquitous"
+    /// edge-weight multiplier (>5 def sites → ×0.1).
+    ///
+    /// A sid is "workspace-defined" iff it has at least one DEFS row.
+    /// External symbols (referenced but not defined in the workspace)
+    /// are filtered at commit time per Deepening §F1, so they have no
+    /// NAME_TO_SID entry and are naturally absent here.
+    ///
+    /// Returns `(sid, name, def_count)` tuples in arbitrary order;
+    /// the caller assigns dense indices for PageRank input.
+    pub fn iter_workspace_sids(&self) -> anyhow::Result<Vec<(u32, String, u32)>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let sid_to_name = txn.open_table(SID_TO_NAME)?;
+        let defs = txn.open_multimap_table(DEFS)?;
+
+        let mut out: Vec<(u32, String, u32)> = Vec::new();
+        let iter = sid_to_name.iter()?;
+        for row in iter {
+            let row = row?;
+            let sid = row.0.value();
+            let name = row.1.value().to_string();
+
+            // Skip sids with no DEFS entry — they're external symbols
+            // that got interned for ref tracking but aren't actually
+            // workspace-defined. (Shouldn't happen given §F1, but
+            // defensive.)
+            let mut def_count: u32 = 0;
+            let it = defs.get(&sid)?;
+            for _ in it {
+                def_count = def_count.saturating_add(1);
+            }
+            if def_count == 0 {
+                continue;
+            }
+            out.push((sid, name, def_count));
+        }
+        Ok(out)
+    }
+
     /// Resolve `sid` → workspace symbol name via `SID_TO_NAME`. The
     /// inverse of `sid_for_name`. Returns `Ok(None)` for unknown sids
     /// (shouldn't happen with committed data). Used by `closure::compute`

--- a/crates/rts-daemon/src/symbol_pagerank.rs
+++ b/crates/rts-daemon/src/symbol_pagerank.rs
@@ -1,0 +1,343 @@
+//! Symbol-level PageRank — v0.3 U4 of the code-graph KB plan.
+//!
+//! ## What this does
+//!
+//! Computes a PageRank score over the workspace-defined symbol set,
+//! using the persistent reference graph (`SID_REFS_OUT` populated by
+//! U1's writer) as the edge structure. The result fills the
+//! `rank_score` field in `Index.FindSymbol` and `Index.FindCallers`
+//! responses — which v0.2 left as a `0.0` placeholder.
+//!
+//! `find_symbol(pattern="*")` becomes the de-facto "top symbols in
+//! this workspace" query: results sort by descending rank, with the
+//! 256-entry cap surfacing the most-central symbols.
+//!
+//! ## Algorithm
+//!
+//! - **Nodes**: workspace-defined `sid`s (have ≥ 1 DEFS entry).
+//!   External symbols (referenced but not workspace-defined) are
+//!   filtered at commit time by U1's writer, so they have no
+//!   NAME_TO_SID entry and are naturally absent here.
+//! - **Edges**: `(caller_sid, callee_sid)` pairs from
+//!   `SID_REFS_OUT`. Multimap dedup means each `(caller, callee)`
+//!   pair contributes once even if there are multiple call sites in
+//!   the same caller's body.
+//! - **Weights**: Aider's recipe via
+//!   [`rust_tree_sitter::pagerank::edge_weight`] — ×10 for compound
+//!   well-named symbols (≥ 8 chars), ×0.1 for leading-underscore
+//!   privates, ×0.1 for ubiquitous symbols (>5 defs across the
+//!   workspace). `num_refs` is the call-site count (i.e. how often
+//!   the caller references the callee), summed across all edges.
+//! - **PageRank**: [`rust_tree_sitter::pagerank::compute`] with
+//!   NetworkX defaults (α=0.85, max_iter=100, tol=1e-6). Returns
+//!   ranks summing to 1.
+//!
+//! ## Caching
+//!
+//! Single-slot mutex cache keyed on `index_generation`, mirroring
+//! alpha.20's [`crate::outline::OutlineCache`]. The first
+//! `find_symbol` call after a generation bump pays the compute cost
+//! (estimated 150–450ms on 100k LOC per plan §G3 / Deepening §C3);
+//! subsequent calls at the same generation are O(1).
+//!
+//! ## Deferred (planned for follow-up)
+//!
+//! - **Stale-rank serving during recompute** (Deepening §C3): on
+//!   cold compute, return v0.2 insertion-order results immediately
+//!   while the recompute runs in the background. Subsequent calls
+//!   pick up the new ranks. Not landed in U4 — first cut is
+//!   synchronous compute (matches alpha.20's outline cache pattern).
+//! - **Sorted-edge-vec collapse** instead of `HashMap<(u32,u32),f64>`
+//!   in `pagerank::compute` (Deepening §C3): defer until perf bench
+//!   confirms the cold-call latency target needs it. The existing
+//!   compute path is shared with file-level PageRank.
+//! - **Loosened TOL / capped iters** for symbol-level: ditto; defer
+//!   until measured.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use anyhow::Context;
+use rust_tree_sitter::pagerank::{Edge, compute as pagerank_compute, edge_weight};
+
+use crate::store::Store;
+
+/// Cached PageRank scores for a single `index_generation`.
+#[derive(Debug, Clone)]
+pub struct SymbolRanks {
+    /// `index_generation` at the time the ranks were computed. The
+    /// cache only hands these out when the daemon's current generation
+    /// matches; stale entries are recomputed on the next lookup.
+    pub generation: u64,
+    /// `sid` → rank score. `0.0..=1.0`; the full sid set sums to 1.
+    /// Lookups via the wire-level name go through `Store::sid_for_name`.
+    pub sid_to_rank: HashMap<u32, f64>,
+}
+
+impl SymbolRanks {
+    /// Returns the rank for a given `sid`, or `0.0` when the sid is
+    /// not in the workspace-defined set (e.g. an external symbol
+    /// that snuck through, or a torn read).
+    pub fn rank_for(&self, sid: u32) -> f64 {
+        self.sid_to_rank.get(&sid).copied().unwrap_or(0.0)
+    }
+}
+
+/// Single-slot cache. Same shape as [`crate::outline::OutlineCache`]:
+/// one entry, generation-keyed. The cache slot is `None` on cold
+/// start (before the first commit) and after a generation mismatch
+/// triggers a recompute.
+#[derive(Default)]
+pub struct SymbolPagerankCache {
+    inner: Mutex<Option<Arc<SymbolRanks>>>,
+}
+
+impl SymbolPagerankCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the cached ranks if they match `generation`. Cheap:
+    /// one mutex acquire + one Arc clone. Returns `None` when the
+    /// cache is empty or stale; the caller invokes [`Self::put`] to
+    /// fill the slot after a recompute.
+    pub fn get(&self, generation: u64) -> Option<Arc<SymbolRanks>> {
+        let g = self.inner.lock().ok()?;
+        let entry = g.as_ref()?;
+        if entry.generation == generation {
+            Some(entry.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Replace the cache slot. The stored ranks are wrapped in `Arc`
+    /// so cache hits hand out cheap clones — the caller only reads.
+    pub fn put(&self, ranks: SymbolRanks) {
+        if let Ok(mut g) = self.inner.lock() {
+            *g = Some(Arc::new(ranks));
+        }
+    }
+
+    /// Test-only: whether the slot is currently populated. Used by
+    /// the integration tests to verify cache invalidation behavior.
+    #[cfg(test)]
+    pub fn is_occupied(&self) -> bool {
+        self.inner.lock().map(|g| g.is_some()).unwrap_or(false)
+    }
+}
+
+impl std::fmt::Debug for SymbolPagerankCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (occupied, gen_str) = match self.inner.lock() {
+            Ok(g) => match g.as_ref() {
+                Some(r) => (true, r.generation.to_string()),
+                None => (false, "-".to_string()),
+            },
+            Err(_) => (false, "poisoned".to_string()),
+        };
+        f.debug_struct("SymbolPagerankCache")
+            .field("occupied", &occupied)
+            .field("generation", &gen_str)
+            .finish()
+    }
+}
+
+/// Compute symbol-level PageRank by enumerating workspace-defined
+/// sids, building the edge set from `SID_REFS_OUT`, applying Aider's
+/// edge-weight recipe, and running [`pagerank_compute`].
+///
+/// Returns the ranks keyed by sid; sids absent from this map have
+/// rank 0 by convention (e.g. they're external, unindexed, or
+/// belong to a future generation). Empty workspaces return an empty
+/// map without error.
+///
+/// `generation` is folded into the result so cache writers can pair
+/// the ranks with the generation they were computed against. The
+/// invariant per Deepening §C: read the generation *before* opening
+/// the read transaction below, never after — that's the caller's
+/// responsibility (see `find_symbol` handler in `methods/index.rs`).
+pub fn compute_symbol_ranks(store: &Store, generation: u64) -> anyhow::Result<SymbolRanks> {
+    // Enumerate workspace-defined sids and their per-sid def counts.
+    // The def count drives the "ubiquitous" edge-weight multiplier
+    // (>5 defs across the workspace → ×0.1 dampening).
+    let sid_info = collect_workspace_sids(store).context("collect_workspace_sids")?;
+    if sid_info.is_empty() {
+        return Ok(SymbolRanks {
+            generation,
+            sid_to_rank: HashMap::new(),
+        });
+    }
+
+    // Assign dense indices [0..n) to sids — pagerank::compute uses
+    // u32 node ids in that space.
+    let mut sid_to_idx: HashMap<u32, u32> = HashMap::with_capacity(sid_info.len());
+    let mut idx_to_sid: Vec<u32> = Vec::with_capacity(sid_info.len());
+    for (sid, _name, _def_count) in &sid_info {
+        sid_to_idx.insert(*sid, idx_to_sid.len() as u32);
+        idx_to_sid.push(*sid);
+    }
+
+    // Build edges from SID_REFS_OUT, scoped to workspace-defined
+    // callees (external sids would have no `sid_to_idx` entry and
+    // are skipped — Deepening §F1 already filters them at commit
+    // time, this is belt-and-suspenders).
+    let edges = build_edges(store, &sid_info, &sid_to_idx).context("build_edges")?;
+
+    // Run PageRank. Default uniform teleport (no personalization for
+    // v0.3 U4; mentioned-files-style biasing is a v0.4+ concern).
+    let n = idx_to_sid.len();
+    let raw = pagerank_compute(n, &edges, None);
+
+    // Translate dense ranks back to sid-keyed scores.
+    let mut sid_to_rank: HashMap<u32, f64> = HashMap::with_capacity(n);
+    for (i, r) in raw.iter().enumerate() {
+        sid_to_rank.insert(idx_to_sid[i], *r);
+    }
+
+    Ok(SymbolRanks {
+        generation,
+        sid_to_rank,
+    })
+}
+
+/// Collect every workspace-defined sid plus its `(name, def_count)`.
+/// `def_count` is the number of DEFS rows for this sid (= how many
+/// files define the symbol). Used by `build_edges` to compute the
+/// "ubiquitous" multiplier per Aider's recipe.
+fn collect_workspace_sids(store: &Store) -> anyhow::Result<Vec<(u32, String, u32)>> {
+    let out = store
+        .iter_workspace_sids()
+        .context("iter_workspace_sids storage error")?;
+    Ok(out)
+}
+
+/// Build the weighted edge set. Each `(caller_sid, callee_sid)` pair
+/// in `SID_REFS_OUT` contributes one `Edge`. Weight applies Aider's
+/// recipe to the *callee's* name (the symbol whose rank we're
+/// computing inbound flow for) — well-named compound names attract
+/// more rank; leading-underscore privates and ubiquitous names get
+/// dampened.
+fn build_edges(
+    store: &Store,
+    sid_info: &[(u32, String, u32)],
+    sid_to_idx: &HashMap<u32, u32>,
+) -> anyhow::Result<Vec<Edge>> {
+    // Index callee names + ubiquity for fast lookup.
+    let mut callee_meta: HashMap<u32, (&str, bool)> = HashMap::with_capacity(sid_info.len());
+    for (sid, name, def_count) in sid_info {
+        callee_meta.insert(*sid, (name.as_str(), *def_count > 5));
+    }
+
+    // Walk SID_REFS_OUT for each caller sid. The store helper returns
+    // the deduplicated callee set per caller; we count parallel call
+    // sites separately via REFS for the `num_refs` factor in the
+    // edge weight.
+    let mut edges: Vec<Edge> = Vec::with_capacity(sid_info.len() * 4);
+    for (caller_sid, _name, _def_count) in sid_info {
+        let callees = store.refs_from_symbol(*caller_sid)?;
+        if callees.is_empty() {
+            continue;
+        }
+        for callee_sid in callees {
+            // Self-loops shouldn't exist in well-formed graphs but
+            // skip defensively. Mutual recursion lands as two edges
+            // (A→B and B→A) which PageRank handles natively via
+            // teleportation.
+            if callee_sid == *caller_sid {
+                continue;
+            }
+            let (callee_name, is_ubiquitous) = match callee_meta.get(&callee_sid) {
+                Some(&(n, u)) => (n, u),
+                None => continue, // callee not in workspace-defined set
+            };
+            let src_idx = match sid_to_idx.get(caller_sid) {
+                Some(&i) => i,
+                None => continue,
+            };
+            let dst_idx = match sid_to_idx.get(&callee_sid) {
+                Some(&i) => i,
+                None => continue,
+            };
+
+            // num_refs is the per-(caller, callee) call-site count.
+            // SID_REFS_OUT is dedup'd by multimap semantics, so we
+            // join with REFS[callee_sid] filtered by caller-side
+            // RefSites whose caller_sid matches.
+            let num_refs = count_calls_between(store, *caller_sid, callee_sid)?;
+            if num_refs == 0 {
+                continue;
+            }
+
+            let w = edge_weight(callee_name, num_refs, false, false, is_ubiquitous);
+            edges.push(Edge {
+                src: src_idx,
+                dst: dst_idx,
+                weight: w,
+            });
+        }
+    }
+    Ok(edges)
+}
+
+/// Per-(caller, callee) call-site count. Walks `REFS[callee_sid]`
+/// and counts RefSites whose `caller_sid == Some(caller)`. O(N)
+/// per-callee scan — fine for v0.3 first cut; future optimization
+/// is to cache per-batch counts at commit time if perf bench shows
+/// this dominates.
+fn count_calls_between(store: &Store, caller_sid: u32, callee_sid: u32) -> anyhow::Result<u32> {
+    let sites = store.refs_to_symbol(callee_sid)?;
+    let mut count = 0u32;
+    for s in sites {
+        if s.caller_sid == Some(caller_sid) {
+            count = count.saturating_add(1);
+        }
+    }
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_workspace_returns_empty_ranks() {
+        // Build a tempfile-backed store with no files committed; the
+        // graph builder should return an empty rank map.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("db.redb");
+        let store = Store::open(&path).unwrap();
+        let ranks = compute_symbol_ranks(&store, 0).unwrap();
+        assert_eq!(ranks.generation, 0);
+        assert!(ranks.sid_to_rank.is_empty());
+    }
+
+    #[test]
+    fn cache_stores_and_invalidates_by_generation() {
+        let cache = SymbolPagerankCache::new();
+        assert!(cache.get(0).is_none(), "cold cache should miss");
+
+        cache.put(SymbolRanks {
+            generation: 7,
+            sid_to_rank: [(1, 0.5), (2, 0.5)].into_iter().collect(),
+        });
+        let hit = cache.get(7).expect("hit at gen=7");
+        assert_eq!(hit.generation, 7);
+        assert!((hit.rank_for(1) - 0.5).abs() < 1e-9);
+        assert!((hit.rank_for(2) - 0.5).abs() < 1e-9);
+        assert_eq!(hit.rank_for(999), 0.0, "unknown sid → 0 rank");
+
+        // Stale generation → miss (caller must recompute).
+        assert!(cache.get(8).is_none(), "gen=8 should not hit gen=7 slot");
+
+        // Re-putting at a new generation replaces the slot.
+        cache.put(SymbolRanks {
+            generation: 8,
+            sid_to_rank: [(3, 1.0)].into_iter().collect(),
+        });
+        assert!(cache.get(7).is_none(), "gen=7 should now miss");
+        let hit = cache.get(8).expect("hit at gen=8");
+        assert!((hit.rank_for(3) - 1.0).abs() < 1e-9);
+    }
+}

--- a/crates/rts-daemon/tests/symbol_pagerank_round_trip.rs
+++ b/crates/rts-daemon/tests/symbol_pagerank_round_trip.rs
@@ -1,0 +1,305 @@
+//! End-to-end test for v0.3 U4: symbol-level PageRank filling
+//! `Index.FindSymbol.matches[*].rank_score` and driving the
+//! default descending-rank sort.
+//!
+//! Hub-spoke fixture (4 callers around 1 hub):
+//!   `hub.rs`      defines `hub_compute`
+//!   `caller_a.rs` defines `caller_a` which calls `hub_compute`
+//!   `caller_b.rs` defines `caller_b` which calls `hub_compute`
+//!   `caller_c.rs` defines `caller_c` which calls `hub_compute`
+//!   `caller_d.rs` defines `caller_d` which calls `hub_compute`
+//!
+//! PageRank says `hub_compute` should rank highest (it has 4 inbound
+//! edges). Without the rank sort, the callers would alphabetize and
+//! `caller_a` would land first; with the rank sort, `hub_compute`
+//! lands first.
+//!
+//! Assertions:
+//!   * `find_symbol(pattern="*")` returns `hub_compute` first (top
+//!     of the rank-sorted list)
+//!   * Each `rank_score` is non-zero (PageRank computed)
+//!   * `sort: "lexical"` opt-out restores alphabetical-by-file order
+//!   * The `pagerank_symbolwise` capability is advertised via
+//!     `Daemon.Ping`
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn symbol_pagerank_ranks_hub_above_callers() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // Hub defines hub_compute; four callers reference it. PageRank
+    // should put hub_compute on top.
+    std::fs::write(
+        workspace.path().join("hub.rs"),
+        "pub fn hub_compute(x: u32) -> u32 { x + 1 }\n",
+    )?;
+    for tag in ["a", "b", "c", "d"] {
+        std::fs::write(
+            workspace.path().join(format!("caller_{tag}.rs")),
+            format!(
+                "pub fn caller_{tag}() {{\n    let _ = hub_compute({});\n}}\n",
+                tag.bytes().next().unwrap() as u32
+            ),
+        )?;
+    }
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+
+    // Wait for all 5 symbols.
+    wait_for_symbol(&mut stream, "hub_compute", Duration::from_secs(5)).await?;
+    for tag in ["a", "b", "c", "d"] {
+        wait_for_symbol(
+            &mut stream,
+            &format!("caller_{tag}"),
+            Duration::from_secs(5),
+        )
+        .await?;
+    }
+
+    // 1. Daemon.Ping advertises pagerank_symbolwise.
+    let ping = round_trip(&mut stream, "2", "Daemon.Ping", json!({})).await?;
+    let caps = ping["result"]["capabilities"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let cap_strs: Vec<&str> = caps.iter().filter_map(|v| v.as_str()).collect();
+    assert!(
+        cap_strs.contains(&"pagerank_symbolwise"),
+        "expected pagerank_symbolwise in caps; got {cap_strs:?}"
+    );
+    // Also smoke the other v0.3 capabilities since this is the first
+    // test to look at the full list.
+    for cap in [
+        "find_callers",
+        "read_symbol.include_callers",
+        "closure_walker",
+        "pagerank_filewise",
+    ] {
+        assert!(
+            cap_strs.contains(&cap),
+            "expected `{cap}` in caps; got {cap_strs:?}"
+        );
+    }
+
+    // 2. Default sort is rank-descending. find_symbol(pattern="*")
+    //    should put hub_compute first.
+    let resp = round_trip(
+        &mut stream,
+        "10",
+        "Index.FindSymbol",
+        json!({ "pattern": "*" }),
+    )
+    .await?;
+    assert!(resp["error"].is_null(), "find_symbol failed: {resp:?}");
+    let matches = resp["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        matches.len() >= 5,
+        "expected ≥5 matches; got {} ({matches:?})",
+        matches.len()
+    );
+    let top_name = matches[0]["qualified_name"].as_str().unwrap_or("");
+    assert_eq!(
+        top_name,
+        "hub_compute",
+        "expected hub_compute to outrank callers; got order [{}] (full ordering: {:?})",
+        top_name,
+        matches
+            .iter()
+            .map(|m| m["qualified_name"].as_str().unwrap_or(""))
+            .collect::<Vec<_>>()
+    );
+
+    // All entries should carry a non-zero rank_score now (uniform PageRank
+    // on isolated nodes would be 1/N ≈ 0.2 for a 5-node graph). The
+    // hub's rank should be measurably higher than the average caller.
+    let hub_rank = matches[0]["rank_score"].as_f64().unwrap_or(0.0);
+    assert!(hub_rank > 0.0, "hub rank_score must be > 0; got {hub_rank}");
+    let caller_ranks: Vec<f64> = matches
+        .iter()
+        .skip(1)
+        .take(4)
+        .map(|m| m["rank_score"].as_f64().unwrap_or(0.0))
+        .collect();
+    let avg_caller_rank = caller_ranks.iter().sum::<f64>() / caller_ranks.len() as f64;
+    assert!(
+        hub_rank > avg_caller_rank,
+        "hub_rank ({hub_rank}) should exceed avg caller rank ({avg_caller_rank}); ranks={caller_ranks:?}"
+    );
+
+    // 3. sort="lexical" opt-out restores alphabetical-by-file order.
+    //    caller_a.rs sorts first, hub_compute (hub.rs) is in the
+    //    middle, so caller_a should land first.
+    let resp_lex = round_trip(
+        &mut stream,
+        "11",
+        "Index.FindSymbol",
+        json!({ "pattern": "*", "sort": "lexical" }),
+    )
+    .await?;
+    let lex_matches = resp_lex["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let lex_top = lex_matches[0]["qualified_name"].as_str().unwrap_or("");
+    assert_eq!(
+        lex_top, "caller_a",
+        "with sort=lexical, caller_a.rs alphabetizes first; got {}",
+        lex_top
+    );
+    // rank_score is still populated under lexical sort (it's just not
+    // the sort key).
+    assert!(lex_matches[0]["rank_score"].as_f64().unwrap_or(0.0) > 0.0);
+
+    // 4. find_callers also fills rank_score now (the enclosing fn's rank).
+    let callers_resp = round_trip(
+        &mut stream,
+        "12",
+        "Index.FindCallers",
+        json!({ "name": "hub_compute" }),
+    )
+    .await?;
+    let callers = callers_resp["result"]["callers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(callers.len(), 4, "4 callers expected; got {callers:?}");
+    for c in &callers {
+        let r = c["rank_score"].as_f64().unwrap_or(0.0);
+        assert!(
+            r > 0.0,
+            "each caller entry should carry a non-zero rank_score; got {r} ({c:?})"
+        );
+    }
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}

--- a/docs/protocol-v0.md
+++ b/docs/protocol-v0.md
@@ -166,13 +166,16 @@ This is the **v2 safe-edit hook** (architecture-review high-leverage edit). When
   "id": "1",
   "result": {
     "protocol":     "0",                          // semver-style major; v1 is the breaking re-cut
-    "daemon":       { "name": "rts-daemon", "version": "0.2.0-alpha.32", "git_sha": "dd290c7..." },
-    "capabilities": ["outline", "find_symbol", "find_callers", "read_symbol", "read_symbol_at", "read_range",
+    "daemon":       { "name": "rts-daemon", "version": "0.2.0-alpha.34", "git_sha": "368bc97..." },
+    "capabilities": ["outline", "find_symbol", "read_symbol", "read_range",
                      "rank_score", "tree_shake", "partial_responses",
                      "content_version", "secrets_blocklist",
-                     "closure_walker", "fuzzy_match", "pagerank_filewise",
+                     "pagerank_filewise",
+                     "closure_walker",
+                     "read_symbol_at", "fuzzy_match",
                      "polling_fallback",
-                     "read_symbol.include_callers"],
+                     "find_callers", "read_symbol.include_callers",
+                     "pagerank_symbolwise"],
     "uptime_ms":    123456
   }
 }
@@ -194,7 +197,7 @@ Reserved for the **v0.3 code-graph KB** extension (see [v0.3 plan](plans/2026-05
 - ~~`find_callers`~~ — **advertised** as of `v0.2.0-alpha.32` (U2'). `Index.FindCallers` returns direct callers of a named symbol; see §7.7c.
 - `impact_of` — transitive caller closure (v0.3 U5).
 - ~~`read_symbol.include_callers`~~ — **advertised** as of `v0.2.0-alpha.32` (U2'). `Index.ReadSymbol.params.include_callers: bool` composes with `include_dependencies`; see §7.7.
-- `pagerank_symbolwise` — symbol-level PageRank fills `rank_score`; `find_symbol` results sort by descending rank when advertised. Clients without this capability MAY request `sort: "lexical"` to retain pre-v0.3 ordering.
+- ~~`pagerank_symbolwise`~~ — **advertised** as of `v0.2.0-alpha.34` (U4). Symbol-level PageRank fills `rank_score` in `Index.FindSymbol` + `Index.FindCallers` responses; `find_symbol` results sort by descending rank by default. Clients pinned to v0.2 insertion-order ordering can pass `sort: "lexical"` on `Index.FindSymbol.params` to opt out.
 - `call_graph` (umbrella; reserved but **not advertised by itself** — agents should branch on the four fine-grained strings above).
 
 ### 4.3 Version mismatch
@@ -423,11 +426,14 @@ AST-precise definition + references + signature for a named or pattern-matched s
   "name":    "build_index",          // optional; exact match
   "pattern": "build_*",              // optional; glob: `*` (any run, including empty) and `?` (single char). Mutually exclusive with name. Capability: `fuzzy_match` (alpha.24+).
   "kind":    "fn",                   // optional; one of: fn, struct, enum, type, trait, const, static, impl, method, class, interface, module
-  "file":    "src/index/mod.rs"      // optional; filter
+  "file":    "src/index/mod.rs",     // optional; filter
+  "sort":    "rank"                  // optional; "rank" (default; descending rank_score) | "lexical" (alphabetical-by-file). Capability: `pagerank_symbolwise` (alpha.34+).
 }
 ```
 
 The glob matcher has **no character classes** and **no escapes** — `*` and `?` only. Agents that need regex-like expressivity (e.g. character classes) should compose multiple `pattern` queries client-side; a flagged regex mode is on the v1.1 candidate list pending a concrete user request.
+
+**Sort order (alpha.34+, capability `pagerank_symbolwise`):** `matches[]` is sorted by descending `rank_score` (symbol-level PageRank over the workspace call graph) by default. Pass `sort: "lexical"` for back-compat with v0.2's alphabetical-by-`(file, start_byte)` ordering. The 256-entry cap applies *after* sorting, so `pattern="*"` with rank sort returns the top-K most-central symbols. Clients that don't advertise the capability still receive the new default sort — daemons advertising `pagerank_symbolwise` use ranked order unless `sort: "lexical"` is explicit.
 
 **`result`**:
 ```jsonc
@@ -960,7 +966,8 @@ These are normative for `params` validation. The daemon SHOULD reject schema-non
     "kind":    { "type": "string", "enum": ["fn", "struct", "enum", "type", "trait",
                                              "const", "static", "impl", "method",
                                              "class", "interface", "module"] },
-    "file":    { "type": "string" }
+    "file":    { "type": "string" },
+    "sort":    { "type": "string", "enum": ["rank", "lexical"], "default": "rank" }
   },
   "additionalProperties": false,
   "oneOf": [
@@ -1244,10 +1251,12 @@ This appendix tracks every additive wire-shape change between Draft 1 (P5 delive
 | `alpha.30` | (none — internal) | JS/TS tags.scm reference queries (extends alpha.27 to JS/TS). Same wire shape; better-quality contents on JS/TS workspaces. | — |
 | `alpha.31` | (none — internal) | **v0.3 U1**: persistent reference graph (REFS / FID_REFS / SID_REFS_OUT tables; SCHEMA_VERSION 1→2). `outline::compute` reads indexed edges. Same wire shape; no agent-visible changes. | — |
 | `alpha.32` | `find_callers`, `read_symbol.include_callers` | **v0.3 U2'**: new method `Index.FindCallers(name, kind?, file?)` returns direct callers. `Index.ReadSymbol.params.include_callers: bool` composes callers into the existing response with a separate `callers_truncated` flag. | §7.7, §7.7c, §18.4, §18.4b, §18.4c |
+| `alpha.33` | (none — internal) | **v0.3 U3**: `closure::compute` swaps from at-query-time tree-sitter parsing to reading `SID_REFS_OUT`. Same wire shape; faster cold calls. Also fixed a latent local-variable bug in U1's `enclosing_caller_sid` that under-populated `SID_REFS_OUT`. | — |
+| `alpha.34` | `pagerank_symbolwise` | **v0.3 U4**: symbol-level PageRank fills `rank_score` in `Index.FindSymbol` and `Index.FindCallers` responses (was a `0.0` placeholder). `Index.FindSymbol.matches[]` sorts by descending rank by default; `sort: "lexical"` opts out. Single-slot generation-keyed cache mirroring `OutlineCache` (alpha.20). | §4.1, §4.2, §7.6, §18.3 |
 
-Capability strings present in `Daemon.Ping.result.capabilities` after alpha.32 (canonical list, in advertisement order): `outline`, `find_symbol`, `find_callers`, `read_symbol`, `read_symbol_at`, `read_range`, `rank_score`, `tree_shake`, `partial_responses`, `content_version`, `secrets_blocklist`, `closure_walker`, `fuzzy_match`, `pagerank_filewise`, `polling_fallback`, `read_symbol.include_callers`.
+Capability strings present in `Daemon.Ping.result.capabilities` after alpha.34 (canonical list, in advertisement order): `outline`, `find_symbol`, `read_symbol`, `read_range`, `rank_score`, `tree_shake`, `partial_responses`, `content_version`, `secrets_blocklist`, `pagerank_filewise`, `closure_walker`, `read_symbol_at`, `fuzzy_match`, `polling_fallback`, `find_callers`, `read_symbol.include_callers`, `pagerank_symbolwise`.
 
-**Pending v0.3** (reserved in §4.2, not advertised at alpha.32): `impact_of` (U5), `pagerank_symbolwise` (U4).
+**Pending v0.3** (reserved in §4.2, not advertised at alpha.34): `impact_of` (U5).
 
 ### How to extend protocol-v0 in a future alpha
 


### PR DESCRIPTION
## Summary

The `rank_score` placeholder field in `Index.FindSymbol` and `Index.FindCallers` responses — `0.0` since alpha.18 — now carries the real symbol-level PageRank value, computed over the persistent call graph from [#29](https://github.com/njfio/rs-agent-code-utility/pull/29) (U1). `Index.FindSymbol.matches[]` sorts by descending rank by default, making `find_symbol(pattern="*")` the de-facto "top symbols in this workspace" query without a new endpoint.

## New module: `crate::symbol_pagerank`

- **Graph builder** over workspace-defined sids (nodes) + `SID_REFS_OUT` edges
- **Aider edge weights**: ×10 for well-named compound names (≥ 8 chars, snake_case or camelCase), ×0.1 for leading-underscore privates, ×0.1 for ubiquitous symbols (>5 defs across workspace)
- **Reuses `rust_tree_sitter::pagerank::compute`** with NetworkX defaults (α=0.85, max_iter=100, tol=1e-6)
- **`SymbolPagerankCache`**: single-slot mutex, generation-keyed, mirrors alpha.20's `OutlineCache` shape

## Surface changes

### Daemon

- `methods/index.rs::find_symbol` reads `state.index_generation` *before* opening any read txn ([Deepening §C cache TOCTOU invariant](https://github.com/njfio/rs-agent-code-utility/blob/main/docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md))
- Collects matches into typed tuples, **sorts then truncates** (pre-U4 truncated mid-iteration → could drop higher-rank matches in pattern queries)
- New `FindSymbolParams.sort: Option<String>` accepts `"rank"` (default) and `"lexical"`
- `CallerEntry` (find_callers + include_callers) `rank_score` now carries the enclosing caller's PageRank
- New `Store::iter_workspace_sids()` helper enumerates `(sid, name, def_count)` for the graph builder

### Capabilities catch-up

`DAEMON_CAPABILITIES` had drifted across alpha.18-33 and was advertising 7 strings while protocol-v0.md §4.1 documented 16. This PR brings it current:
- New for U4: **`pagerank_symbolwise`**
- Backfilled: `pagerank_filewise` (alpha.18), `closure_walker` (alpha.22), `read_symbol_at` + `fuzzy_match` (alpha.24), `polling_fallback` (alpha.25), `find_callers` + `read_symbol.include_callers` (alpha.32)

### Protocol

- §4.1 advertises `pagerank_symbolwise`
- §4.2 marks it as advertised (strikethrough on the previously-reserved entry)
- §7.6 documents the new `sort` param + rank-sort default
- §18.3 schema adds the `sort` enum
- Appendix F gains alpha.33 + alpha.34 rows; canonical capability list grows 14 → 17

## Wire-contract notes

**Additive but with a default-sort behavior change.** Clients that ignored `rank_score: 0.0` see no observable change. Clients that pinned to v0.2 insertion-order ordering should:
- Branch on the `pagerank_symbolwise` capability in `Daemon.Ping` before calling `Index.FindSymbol`, OR
- Pass `sort: "lexical"` explicitly (works on every alpha — older daemons silently ignore unknown params)

Per [Deepening §G4](https://github.com/njfio/rs-agent-code-utility/blob/main/docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md), the default-change was deliberate: plan §R5 specifies "results sort by descending rank" once rank is real, and gating behind the capability-string AND a sort opt-out covers both ranked-default + lexical-back-compat.

## Performance

- **First find_symbol after a writer commit pays the PageRank compute cost.** Plan §G3 / Deepening §C3 estimates 150-450ms on a 100k-LOC workspace. Plan §G1's warm-call target (< 5ms) is unaffected once the cache is filled.
- **Not landed this PR (deferred to follow-up if bench shows need)**:
  - Stale-rank serving during recompute (Deepening §C3)
  - Sorted-edge-vec collapse vs `HashMap<(u32,u32),f64>` (shared with file-level ranker)
  - Loosened TOL / capped iters for symbol-level

## Verification

- `cargo test --workspace`: **544 passed, 0 failed, 0 ignored** (was 541 in alpha.33; +3 = 2 unit + 1 integration)
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets`: no new warnings

### New tests

| | What |
|---|---|
| Unit | `symbol_pagerank::empty_workspace_returns_empty_ranks` |
| Unit | `symbol_pagerank::cache_stores_and_invalidates_by_generation` |
| Integration | `symbol_pagerank_round_trip::symbol_pagerank_ranks_hub_above_callers` — hub-spoke fixture (4 callers around 1 hub); asserts capability advertised, hub ranks first under default sort, rank_score > 0 everywhere, `sort: "lexical"` opt-out works, find_callers fills rank_score per CallerEntry |

## Post-Deploy Monitoring & Validation

- **What to monitor**: `Index.FindSymbol` warm/cold latency split. Cold (first call after a writer commit) on real workspaces; plan §G3 budget = 150-450ms on 100k LOC. Warm = sub-ms cache hit.
- **Validation**: `cargo test --workspace` → 544/0 on a fresh checkout. `rts-bench query find-symbol --pattern '*'` on the rust_tree_sitter library itself should return `CodebaseAnalyzer`, `Parser`, `Language` in the top-20 (plan §G4 coherence sanity check).
- **Healthy signals**: `find_symbol(pattern="*")` returns a stable top-K ordering across calls within the same `index_generation`. `Daemon.Ping.capabilities` now contains all 17 strings.
- **Failure / rollback**: any existing integration test failing → rollback to alpha.33 binary. find_symbol latency > 1s warm → cache invalidation broken; check `state.symbol_pagerank_cache` is hitting on the same generation.

## Related

- v0.3 plan §Phase 5 / Deepening §C3, §D, §G4
- Prereqs: [#29](https://github.com/njfio/rs-agent-code-utility/pull/29) (U1), [#30](https://github.com/njfio/rs-agent-code-utility/pull/30) (U2'), [#32](https://github.com/njfio/rs-agent-code-utility/pull/32) (U3)

## Next

After this merges: **U5** — `Index.ImpactOf` (transitive callers via BFS over reverse edges; depth + token budget + test-exclusion filter) + `scenario_refactor_impact` bench fixture. Last unit of the v0.3 plan.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.5 (1M context) via [Claude Code](https://claude.com/claude-code)