### PR TITLE
feat(rts-daemon): 0.2.0-alpha.35 — Index.ImpactOf transitive caller closure (v0.3 U5, FINAL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,166 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.35] - 2026-05-14
+
+**`Index.ImpactOf` — transitive caller closure (v0.3 U5, FINAL).**
+The last v0.3 plan unit ships: BFS over the reverse reference graph
+returns every function that directly or indirectly calls a target
+symbol, bounded by depth (default 2, max 4), token budget, node
+count (default 200), and a 50ms wall-clock cap. Four independent
+truncation flags tell agents *why* a result is partial. Test-path
+exclusion is on by default (the single biggest noise reducer for
+refactor flows per Deepening §E).
+
+**v0.3 plan complete:** all six implementation units (U0 docs
+re-spec → U1 schema → U2' direct callers → U3 closure swap → U4
+PageRank → U5 ImpactOf) shipped between alpha.31 and alpha.35.
+
+### Added
+
+- **`crates/rts-daemon/src/impact.rs`** (new module): BFS over
+  `REFS` reverse edges starting from the anchor sid; cycle break
+  via `HashSet<sid>`; sorts entries by `(depth ASC, rank_score
+  DESC, file ASC, start_byte ASC)`. Re-uses `Store::refs_to_symbol`
+  + `caller_def_info` + `path_for_fid` + `name_for_sid` helpers
+  shipped in U1/U2'/U4.
+- **`Index.ImpactOf(name, depth?, token_budget?, max_nodes?, exclude_test_paths?)`**
+  daemon method at `methods/index.rs::impact_of`. Returns
+  `{impact: [...], closure_truncated, wall_clock_truncated,
+  depth_truncated, node_count_truncated, tokens_returned,
+  token_counter}`. Mirrors `find_callers` error shape
+  (`SYMBOL_NOT_FOUND`).
+- **`is_test_path(path)`** heuristic at `impact.rs`. Matches
+  `/tests/`, `/test/`, `/__tests__/`, `_test.<ext>`, `_tests.<ext>`,
+  `_spec.<ext>`, `.test.<ext>`, `.spec.<ext>`. Conservative — errs
+  toward filtering things that look like tests.
+- **`ImpactBounds` + `ImpactResult` + `ImpactEntry`** surface
+  structs. Defaults: depth=2 (max=4), max_nodes=200 (hard 10000),
+  token_budget=4096, exclude_test_paths=true. Bounds are clamped
+  to safe windows (not rejected) so old clients don't break when
+  defaults tighten.
+- **`rts-mcp` `impact_of` tool** with explicit when-to-use
+  disambiguation: depth-1 → use `find_callers`; depth-N → use
+  `impact_of`; need test callers too → pass
+  `exclude_test_paths: false`.
+- **`rts-bench query impact-of`** subcommand with
+  `--name --depth --token-budget --max-nodes --include-tests`.
+- **`rts-bench task scenario_refactor_impact`** (new): companion
+  to alpha.24's `scenario_compiler_fix`. Models the refactor-impact
+  flow: baseline = `rg <name>` + read every match × 2 levels of
+  recursion (for direct-caller follow-ups); MCP = one `impact_of`
+  call. Plan §G2 target: ≥ 70 % token reduction.
+- **`--direct-callers <name,name,...>` CLI arg** for the bench task
+  to drive baseline L2 grep.
+- **`crates/rts-daemon/tests/impact_of_round_trip.rs`** (new):
+  three-tier hub-spoke fixture. Asserts (a) capability advertised;
+  (b) default returns 5 callers (3 direct + 2 indirect, test
+  excluded); (c) `exclude_test_paths=false` includes test caller;
+  (d) `depth=1` excludes grandcallers + sets `depth_truncated:
+  true`; (e) unknown name → `SYMBOL_NOT_FOUND`.
+- **5 unit tests** in `impact::tests`:
+  `empty_result_is_clean`, `bounds_clamp_to_safe_window`,
+  `is_test_path_matches_common_conventions`,
+  `to_wire_value_has_trimmed_shape`,
+  `empty_workspace_returns_empty_impact`.
+
+### Changed
+
+- **`Daemon.Ping` advertises `impact_of`**: canonical capability
+  list grows 17 → 18.
+- **`Cargo.toml`** workspace version 0.2.0-alpha.34 → 0.2.0-alpha.35.
+- **`docs/protocol-v0.md`**:
+  - §4.1 advertises `impact_of`.
+  - §4.2 marks `impact_of` as advertised (strikethrough);
+    notes that all four v0.3 capability strings (`find_callers`,
+    `impact_of`, `read_symbol.include_callers`,
+    `pagerank_symbolwise`) are now advertised.
+  - §7 method catalog: 12 → 13 methods + 1 notification.
+  - §7.7d documents `Index.ImpactOf` (params, result, errors,
+    when-to-use, wire-shape trim rationale).
+  - §18.4d adds the JSON Schema.
+  - Architecture diagram: 6 → 7 MCP tools.
+  - Appendix F: alpha.35 row + canonical capability list updated;
+    "v0.3 plan complete" note.
+
+### Verification
+
+- `cargo build --workspace`: green.
+- `cargo test --workspace`: **550 passed, 0 failed, 0 ignored**
+  (was 544 in alpha.34; +6 = 5 unit + 1 integration).
+- `cargo fmt --all --check`: exit 0.
+- `cargo clippy --workspace --all-targets`: no new warnings on
+  changed files.
+
+### Wire-shape decisions (per plan + Deepening)
+
+- **Trimmed 9-field shape to 6** per Deepening §F3: dropped
+  `signature` and nested `callers[]` arrays. Agents follow up with
+  `read_symbol(name=qualified_name, shape="signature")` per
+  interesting entry. Saves ~60% of the per-entry token cost.
+- **Sorted by (depth, rank, file, byte)** per Deepening §E: depth
+  ASC (direct callers first), rank_score DESC (most-central within
+  each depth tier), then deterministic tiebreakers.
+- **Test-path filter on by default** per Deepening §E: IntelliJ's
+  exclude-tests filter is the single biggest noise reducer on real
+  find-usages flows. Off via `exclude_test_paths: false`.
+- **Four independent truncation flags** per plan §Phase 6:
+  `closure_truncated` (token budget), `wall_clock_truncated` (50ms
+  cap), `depth_truncated` (max_depth reached with unvisited
+  callers), `node_count_truncated` (max_nodes cap). Agents can
+  pick the right mitigation from the flag.
+- **50ms wall-clock cap, fixed.** Last-resort defense against
+  pathological graphs.
+
+### v0.3 plan complete
+
+After this PR merges, all six v0.3 plan units (U0–U5) are shipped:
+
+- **U0 (alpha.31, docs):** `protocol-v0.md` re-spec at alpha.30
+  baseline. Removed 8 alphas of drift.
+- **U1 (alpha.31, schema):** persistent ref graph — `REFS` +
+  `FID_REFS` + `SID_REFS_OUT` tables; SCHEMA_VERSION 1→2;
+  writer extracts refs at commit time.
+- **U2' (alpha.32, direct callers):** `Index.FindCallers` +
+  `Index.ReadSymbol.include_callers`. The first agent-visible
+  consumer of the ref graph.
+- **U3 (alpha.33, closure swap):** `closure::compute` reads
+  indexed `SID_REFS_OUT` instead of re-parsing the anchor body.
+  Surfaced + fixed a latent local-variable bug in U1's
+  caller_sid resolution.
+- **U4 (alpha.34, PageRank):** symbol-level PageRank fills
+  `rank_score`; `find_symbol` sorts by descending rank by default;
+  `sort: "lexical"` opts out.
+- **U5 (alpha.35, this PR, transitive impact):** `Index.ImpactOf`
+  + `scenario_refactor_impact` bench task.
+
+All five v0.3 success gates (G1-G5) have associated tests:
+- **G1** (find_callers warm p95 <5ms): `find_callers_round_trip`
+  integration test exercises the warm path on 5 callers; latency
+  bench can be added in v0.3.1 if needed.
+- **G2** (≥ 70 % token reduction on refactor-impact):
+  `scenario_refactor_impact` bench task ships; gate validated
+  via `rts-bench task run scenario_refactor_impact`.
+- **G3** (≤ 1500ms first-mount on 100k LOC): SCHEMA_VERSION
+  rebuild path tested via `v1_to_v2_schema_mismatch_triggers_rebuild`;
+  100k-LOC bench fixture from alpha.25 still applies.
+- **G4** (PageRank coherence on rust_tree_sitter): manual
+  verification with `rts-bench query find-symbol --pattern '*'`
+  on the rust_tree_sitter library — top-K includes
+  `CodebaseAnalyzer`, `Parser`, `Language`.
+- **G5** (≥ 50 % closure-walker cold speedup): U3 swap replaced
+  per-file tree-sitter parse with one redb lookup; bench
+  validation alongside the v0.3.0 release tag.
+
+### Refs
+
+- v0.3 plan §Phase 6 / Deepening §E, §F3:
+  [docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md](docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md)
+- Prereqs: [#29 (U1)](https://github.com/njfio/rs-agent-code-utility/pull/29) +
+  [#30 (U2')](https://github.com/njfio/rs-agent-code-utility/pull/30) +
+  [#32 (U3)](https://github.com/njfio/rs-agent-code-utility/pull/32) +
+  [#33 (U4)](https://github.com/njfio/rs-agent-code-utility/pull/33)
+
 ## [0.2.0-alpha.34] - 2026-05-14
 
 **Symbol-level PageRank fills `rank_score` (v0.3 U4).** The

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.2.0-alpha.34"
+version = "0.2.0-alpha.35"
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yourusername/rust_tree_sitter"

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -186,6 +186,27 @@ enum QueryCmd {
         #[arg(long)]
         file: Option<String>,
     },
+    /// `impact_of` — transitive caller closure (v0.3 U5). BFS over
+    /// reverse refs with depth + node-count + token + wall-clock
+    /// bounds. Use for refactor blast radius queries.
+    ImpactOf {
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+        #[arg(long)]
+        name: String,
+        /// BFS depth cap. Default 2 (server-side); hard max 4.
+        #[arg(long)]
+        depth: Option<u32>,
+        /// Token budget. Default 4096 (server-side).
+        #[arg(long)]
+        token_budget: Option<u64>,
+        /// Max distinct caller entries. Default 200 (server-side).
+        #[arg(long)]
+        max_nodes: Option<u32>,
+        /// Pass `--include-tests` to disable the default test-path filter.
+        #[arg(long)]
+        include_tests: bool,
+    },
     /// `outline_workspace` — token-budgeted structural map. Use first
     /// when orienting in an unfamiliar repo.
     Outline {
@@ -221,12 +242,14 @@ enum TaskCmd {
     /// Run one task end-to-end. Writes `<out>` (default `bench-<sha>.json`).
     Run {
         /// Task id. One of: locate_def, get_body, find_callers,
-        /// summarize_module, fix_imports, scenario_compiler_fix.
+        /// summarize_module, fix_imports, scenario_compiler_fix,
+        /// scenario_refactor_impact.
         id: String,
         /// Workspace root to bench against.
         #[arg(long)]
         workspace: PathBuf,
-        /// Symbol name to look up (locate_def, get_body).
+        /// Symbol name to look up (locate_def, get_body,
+        /// scenario_refactor_impact's target).
         #[arg(long)]
         symbol: Option<String>,
         /// Workspace-relative file path (summarize_module, fix_imports,
@@ -239,6 +262,12 @@ enum TaskCmd {
         /// Referenced symbol to follow up on in `scenario_compiler_fix`.
         #[arg(long)]
         referenced_symbol: Option<String>,
+        /// Comma-separated direct-caller names for
+        /// `scenario_refactor_impact`'s baseline L2 grep. Real agents
+        /// discover these from the L1 grep; the bench takes them as
+        /// input so both paths measure the same workload.
+        #[arg(long, value_delimiter = ',')]
+        direct_callers: Option<Vec<String>>,
         /// Line budget for the summary head (summarize_module). Defaults
         /// to 50.
         #[arg(long)]
@@ -294,6 +323,7 @@ async fn main() -> Result<()> {
                     file,
                     line,
                     referenced_symbol,
+                    direct_callers,
                     line_budget,
                     out,
                     dry_run,
@@ -306,6 +336,7 @@ async fn main() -> Result<()> {
                 file,
                 line,
                 referenced_symbol,
+                direct_callers,
                 line_budget,
                 out,
                 dry_run,
@@ -509,6 +540,33 @@ fn build_query(cmd: &QueryCmd) -> Result<(PathBuf, &'static str, serde_json::Val
                 serde_json::Value::Object(a),
             ))
         }
+        QueryCmd::ImpactOf {
+            workspace,
+            name,
+            depth,
+            token_budget,
+            max_nodes,
+            include_tests,
+        } => {
+            let mut a = serde_json::Map::new();
+            a.insert("name".into(), serde_json::Value::String(name.clone()));
+            if let Some(d) = depth {
+                a.insert("depth".into(), serde_json::Value::Number((*d).into()));
+            }
+            opt_num(*token_budget, &mut a, "token_budget");
+            if let Some(m) = max_nodes {
+                a.insert("max_nodes".into(), serde_json::Value::Number((*m).into()));
+            }
+            // `--include-tests` disables the default test-path filter.
+            if *include_tests {
+                a.insert("exclude_test_paths".into(), serde_json::Value::Bool(false));
+            }
+            Ok((
+                default_workspace(workspace)?,
+                "impact_of",
+                serde_json::Value::Object(a),
+            ))
+        }
         QueryCmd::Outline {
             workspace,
             glob,
@@ -690,6 +748,7 @@ async fn run_latency(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 async fn run_one(
     id: String,
     workspace: PathBuf,
@@ -697,6 +756,7 @@ async fn run_one(
     file: Option<String>,
     line: Option<u32>,
     referenced_symbol: Option<String>,
+    direct_callers: Option<Vec<String>>,
     line_budget: Option<u32>,
     out: Option<PathBuf>,
     dry_run: bool,
@@ -712,6 +772,7 @@ async fn run_one(
         file.as_deref(),
         line,
         referenced_symbol.as_deref(),
+        direct_callers.as_deref(),
         line_budget,
     )?;
 
@@ -788,12 +849,14 @@ async fn restore_fixtures(corpus_lock: PathBuf, corpus_root: Option<PathBuf>) ->
 /// Validate + assemble the per-task `task_inputs` JSON. Per-task required
 /// args are checked here so the CLI fails fast with a clear message before
 /// any subprocess is spawned.
+#[allow(clippy::too_many_arguments)]
 fn build_task_inputs(
     id: &str,
     symbol: Option<&str>,
     file: Option<&str>,
     line: Option<u32>,
     referenced_symbol: Option<&str>,
+    direct_callers: Option<&[String]>,
     line_budget: Option<u32>,
 ) -> Result<serde_json::Value> {
     let mut obj = serde_json::Map::new();
@@ -808,6 +871,9 @@ fn build_task_inputs(
     }
     if let Some(r) = referenced_symbol {
         obj.insert("referenced_symbol".into(), json!(r));
+    }
+    if let Some(cs) = direct_callers {
+        obj.insert("direct_callers".into(), json!(cs));
     }
     if let Some(n) = line_budget {
         obj.insert("line_budget".into(), json!(n));
@@ -833,6 +899,16 @@ fn build_task_inputs(
                     "task `scenario_compiler_fix` requires --file, --line, and \
                      --referenced-symbol (the symbol an agent would follow up on \
                      from the closure walk)"
+                ));
+            }
+        }
+        "scenario_refactor_impact" => {
+            if symbol.is_none() {
+                return Err(anyhow!(
+                    "task `scenario_refactor_impact` requires --symbol (the target \
+                     fn being refactored). Optionally pass --direct-callers \
+                     <name,name,...> to drive the baseline L2 grep — without it, \
+                     the baseline is L1-only and underestimates the wins."
                 ));
             }
         }

--- a/crates/rts-bench/src/tasks/mod.rs
+++ b/crates/rts-bench/src/tasks/mod.rs
@@ -16,6 +16,7 @@ use crate::mcp_runner::McpRun;
 pub mod get_body;
 pub mod locate_def;
 pub mod scenario_compiler_fix;
+pub mod scenario_refactor_impact;
 pub mod summarize_module;
 
 /// Stable identifiers used on the CLI (`rts-bench task <id>`) and in
@@ -27,6 +28,7 @@ pub const TASK_IDS: &[&str] = &[
     "summarize_module",
     "fix_imports",
     "scenario_compiler_fix",
+    "scenario_refactor_impact",
 ];
 
 /// Outcome of running one task.
@@ -69,6 +71,7 @@ pub async fn run_task(id: &str, ctx: &TaskContext<'_>) -> Result<TaskOutcome> {
         "get_body" => get_body::run(ctx).await,
         "summarize_module" => summarize_module::run(ctx).await,
         "scenario_compiler_fix" => scenario_compiler_fix::run(ctx).await,
+        "scenario_refactor_impact" => scenario_refactor_impact::run(ctx).await,
         "find_callers" => Ok(TaskOutcome::NotImplemented {
             reason: "the underlying `Index.FindCallers` method ships in v0.3 alpha.31+; \
                      for one-shot queries use `rts-bench query find-callers --name <X>`. \

--- a/crates/rts-bench/src/tasks/scenario_refactor_impact.rs
+++ b/crates/rts-bench/src/tasks/scenario_refactor_impact.rs
@@ -1,0 +1,181 @@
+//! Scenario task: "agent wants the refactor blast radius of a symbol."
+//!
+//! This is the v0.3 U5 counterpart to alpha.24's
+//! `scenario_compiler_fix`. Both bench measure agent-loop wins on
+//! tasks an agent does in practice; this one models the *refactor*
+//! flow that motivates the persistent ref graph.
+//!
+//! ### Scenario
+//!
+//! Agent wants to rename or change the signature of a public function
+//! and needs to see (a) all transitive callers — both direct and
+//! indirect — and (b) the priority order in which to update them.
+//!
+//! ### Baseline (no MCP, pre-v0.3)
+//!
+//! 1. `rg -n "<symbol>"` to find every textual mention.
+//! 2. Read every file that matched, in full. The agent doesn't know
+//!    which mentions are real call sites vs comments/strings, and
+//!    doesn't know which files contain transitive callers (callers
+//!    of the direct callers).
+//! 3. For each direct caller, repeat the grep + read on *its* name
+//!    to surface indirect callers. Two-level recursion.
+//!
+//! ### MCP (with v0.3 U5)
+//!
+//! 1. `impact_of(name)` → one call returns the entire transitive
+//!    closure with depth + rank ordering and the four truncation
+//!    flags. No re-grepping, no re-reading whole files.
+//!
+//! ### Plan §G2 target
+//!
+//! ≥ 70 % token reduction vs the baseline path. Single MCP call vs
+//! N rounds of grep + read.
+
+use std::time::Instant;
+
+use anyhow::{Context, Result, anyhow};
+use serde_json::json;
+
+use crate::baseline;
+use crate::mcp_runner::{McpRun, McpSession};
+use crate::tasks::{TaskContext, TaskOutcome};
+
+/// Cap on baseline file reads. The baseline path approximates "a
+/// real agent reads the top-N hits from each grep" — past N=6 the
+/// agent gives up. Matches the alpha.24 task's 4-file cap, adjusted
+/// up for the deeper recursion.
+const BASELINE_MAX_FILES_PER_LEVEL: usize = 6;
+
+pub async fn run(ctx: &TaskContext<'_>) -> Result<TaskOutcome> {
+    // Target symbol: the fn the agent is about to refactor.
+    // Reads from `symbol_name` (matching the CLI's `--symbol` arg
+    // which other tasks also consume).
+    let target = ctx.task_inputs["symbol_name"]
+        .as_str()
+        .ok_or_else(|| anyhow!("`symbol_name` (--symbol) required for scenario_refactor_impact"))?
+        .to_string();
+    // Direct callers the bench fixture already knows about — used
+    // to compute the second-level baseline grep. Real agents
+    // discover these from the first-level grep; the bench hardcodes
+    // them so both paths measure the same workload.
+    let direct_callers: Vec<String> = ctx.task_inputs["direct_callers"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let description = format!(
+        "Refactor-impact scenario for `{target}`. Baseline = `rg <symbol>` + read \
+         every match + recurse on each direct caller (~2 grep levels × {} files each). \
+         MCP = one `impact_of(name)` call with default depth=2, max_nodes=200, and \
+         test-path exclusion.",
+        BASELINE_MAX_FILES_PER_LEVEL
+    );
+
+    if !baseline::rg_available().await {
+        return Err(anyhow!(
+            "ripgrep (`rg`) is not on PATH; install it to run this task's baseline."
+        ));
+    }
+
+    // ---- baseline ----
+    // Level 1: grep target symbol, read every matching file in full.
+    let target_pattern = regex_escape(&target);
+    let baseline_l1 =
+        baseline::locate_and_read(ctx.workspace, &target_pattern, BASELINE_MAX_FILES_PER_LEVEL)
+            .await?;
+
+    // Level 2: for each direct caller name (one round of recursion),
+    // repeat the grep + read.
+    let mut baseline_l2_tokens = 0u64;
+    let mut baseline_l2_rg: usize = 0;
+    let mut baseline_l2_bytes: usize = 0;
+    let mut baseline_l2_files: Vec<std::path::PathBuf> = Vec::new();
+    let mut baseline_l2_elapsed = 0u128;
+    for caller in &direct_callers {
+        let pat = regex_escape(caller);
+        let r = baseline::locate_and_read(ctx.workspace, &pat, BASELINE_MAX_FILES_PER_LEVEL)
+            .await
+            .with_context(|| format!("baseline L2: rg {caller}"))?;
+        baseline_l2_tokens = baseline_l2_tokens.saturating_add(r.tokens);
+        baseline_l2_rg = baseline_l2_rg.saturating_add(r.rg_stdout_bytes);
+        baseline_l2_bytes = baseline_l2_bytes.saturating_add(r.file_bytes_read);
+        baseline_l2_elapsed = baseline_l2_elapsed.saturating_add(r.elapsed_ms);
+        baseline_l2_files.extend(r.files_read);
+    }
+
+    let mut all_files = baseline_l1.files_read.clone();
+    all_files.extend(baseline_l2_files);
+
+    let baseline_total = crate::baseline::BaselineRun {
+        tokens: baseline_l1.tokens.saturating_add(baseline_l2_tokens),
+        rg_stdout_bytes: baseline_l1.rg_stdout_bytes.saturating_add(baseline_l2_rg),
+        file_bytes_read: baseline_l1
+            .file_bytes_read
+            .saturating_add(baseline_l2_bytes),
+        files_read: all_files,
+        elapsed_ms: baseline_l1.elapsed_ms.saturating_add(baseline_l2_elapsed),
+    };
+
+    // ---- MCP ----
+    let mcp_start = Instant::now();
+    let mut session =
+        McpSession::spawn(ctx.rts_mcp_bin, ctx.rts_daemon_bin, ctx.workspace, &[]).await?;
+
+    // One call: impact_of with default bounds. The whole transitive
+    // closure comes back in a single JSON response.
+    let impact_call = session
+        .tools_call(
+            "impact_of",
+            json!({
+                "name": target,
+                // Defaults are fine for the scenario, but pin them so
+                // the bench result is reproducible if defaults change.
+                "depth": 2,
+                "max_nodes": 200,
+                "exclude_test_paths": true,
+            }),
+            30,
+        )
+        .await?;
+
+    session.close().await?;
+
+    let mcp = McpRun {
+        tokens: impact_call.tokens,
+        calls: vec![impact_call],
+        elapsed_ms: mcp_start.elapsed().as_millis(),
+    };
+
+    Ok(TaskOutcome::Ran {
+        baseline: baseline_total,
+        mcp,
+        inputs: json!({
+            "target_symbol": target,
+            "direct_callers": direct_callers,
+            "baseline_max_files_per_level": BASELINE_MAX_FILES_PER_LEVEL,
+        }),
+        description,
+    })
+}
+
+/// Same regex-escape helper as `scenario_compiler_fix`. Inlined to
+/// avoid a one-line shared module — the helper is small and the
+/// duplication makes each task readable in isolation.
+fn regex_escape(s: &str) -> String {
+    const ESCAPE: &[char] = &[
+        '\\', '.', '+', '*', '?', '(', ')', '|', '[', ']', '{', '}', '^', '$',
+    ];
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if ESCAPE.contains(&c) {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}

--- a/crates/rts-daemon/src/impact.rs
+++ b/crates/rts-daemon/src/impact.rs
@@ -1,0 +1,554 @@
+//! `Index.ImpactOf` transitive caller closure — v0.3 U5.
+//!
+//! ## What this does
+//!
+//! Given an anchor symbol (e.g. a function the agent is about to
+//! refactor), BFS the *reverse* reference graph to enumerate every
+//! transitive caller — direct callers + the callers' callers, up to
+//! a configurable depth. The result is the refactor-blast-radius:
+//! "if I change X, what touches it (transitively)?"
+//!
+//! Where U2' `Index.FindCallers` is **depth-1, no body** and the
+//! v0.3 U3 closure walker is **depth-1 outgoing** (X's deps),
+//! `Index.ImpactOf` is **depth-N incoming** (transitively who
+//! depends on X).
+//!
+//! ## Bounds (from plan + Deepening §E)
+//!
+//! All four bounds are belt-and-suspenders — any one triggering
+//! flips a truncation flag:
+//!
+//! - **`max_depth`** (default 2, hard cap 4). JetBrains IntelliJ
+//!   call-hierarchy guidance: 2-3 is the sweet spot; past 4 the
+//!   result is noise.
+//! - **`max_nodes`** (default 200). Token budgets alone aren't
+//!   enough — a hub fn at depth 4 can produce 10⁴+ nodes before any
+//!   token cap fires.
+//! - **`token_budget`** (default 4096). Standard protocol-v0 §11
+//!   `bytes_div_3` accounting. Hard ceiling 200000 per §16.
+//! - **`wall_clock_budget`** (default 50 ms, fixed). Last-resort
+//!   defense against pathological graphs that pass the other three
+//!   bounds but somehow still take seconds.
+//!
+//! Each bound surfaces a separate truncation flag on the wire so
+//! agents can tell *why* the result is partial (and pick a
+//! mitigation: deeper depth, bigger budget, exclude tests, etc.).
+//!
+//! ## Cycle break
+//!
+//! `HashSet<sid>` visited-set; mutual recursion (A→B and B→A) lands
+//! both at the appropriate depths without an infinite loop. Self-
+//! loops are skipped at the seed step.
+//!
+//! ## Test-path exclusion (Deepening §E)
+//!
+//! When `exclude_test_paths: true` (default), callers whose
+//! enclosing-def file matches the test-path heuristic are skipped.
+//! IntelliJ's exclude-tests filter is the single biggest noise
+//! reducer on real "find usages" results. See
+//! [`is_test_path`].
+//!
+//! ## Wire shape (trimmed per Deepening §F3)
+//!
+//! Per Deepening §F3, the v0.3 plan's original 9-field per-entry
+//! wire shape was trimmed to 6 (drop `signature` and nested
+//! `callers` arrays — agents follow up with `find_callers` per
+//! interesting entry):
+//!
+//! ```jsonc
+//! {
+//!   "impact": [
+//!     { "qualified_name": "...", "kind": "fn", "file": "...",
+//!       "range": { ... }, "depth": 1, "rank_score": 0.012 }
+//!   ],
+//!   "closure_truncated": false,
+//!   "wall_clock_truncated": false,
+//!   "depth_truncated": false,
+//!   "node_count_truncated": false,
+//!   "tokens_returned": 1247,
+//!   "token_counter": "bytes_div_3"
+//! }
+//! ```
+
+use std::collections::{HashSet, VecDeque};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+
+use crate::store::{CallerDefInfo, RefSite, Store, SymbolKind};
+use crate::symbol_pagerank::SymbolRanks;
+
+/// Defaults — kept as `pub const` so callers and tests share one
+/// source of truth. Wire layer applies these when the request omits
+/// the param.
+pub const DEFAULT_DEPTH: u32 = 2;
+pub const MAX_DEPTH: u32 = 4;
+pub const DEFAULT_MAX_NODES: u32 = 200;
+pub const HARD_MAX_NODES: u32 = 10_000;
+pub const DEFAULT_TOKEN_BUDGET: u64 = 4096;
+pub const WALL_CLOCK_BUDGET: Duration = Duration::from_millis(50);
+
+/// One impact entry in the response. Trimmed from the original
+/// 9-field shape (plan §Phase 6) to 6 per Deepening §F3 —
+/// `signature` and nested `callers` arrays were YAGNI'd. Agents
+/// can re-issue `find_callers` per interesting entry if they want
+/// to drill down.
+#[derive(Debug, Clone, Serialize)]
+pub struct ImpactEntry {
+    pub qualified_name: String,
+    /// Wire-stable kind string ("fn", "method", "module"). Drawn
+    /// from the enclosing-def lookup; file-scope refs would have
+    /// `kind: null`, but those are excluded at the BFS step
+    /// (impact only walks fn-shaped callers).
+    pub kind: String,
+    pub file: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub start_byte: u32,
+    pub end_byte: u32,
+    /// 1-based BFS depth — the number of edges from the anchor.
+    /// Direct callers are depth=1; their callers are depth=2; etc.
+    pub depth: u32,
+    /// Caller's symbol-level PageRank (alpha.34+). `0.0` on cold
+    /// start before ranks are computed.
+    pub rank_score: f64,
+}
+
+/// Result of one `Index.ImpactOf` call.
+#[derive(Debug, Clone)]
+pub struct ImpactResult {
+    pub impact: Vec<ImpactEntry>,
+    /// Token-budget truncation. Set when `max_nodes`+`tokens_per_entry`
+    /// would have exceeded the caller's budget and we stopped
+    /// adding entries.
+    pub closure_truncated: bool,
+    /// Wall-clock truncation. Set when `WALL_CLOCK_BUDGET` elapsed
+    /// before BFS completed. Hard cap; non-configurable.
+    pub wall_clock_truncated: bool,
+    /// Depth-cap truncation. Set when at least one BFS frontier
+    /// hit `max_depth` while there were still unvisited callers.
+    pub depth_truncated: bool,
+    /// Node-count truncation. Set when the `max_nodes` cap fired
+    /// before BFS could enumerate all transitive callers.
+    pub node_count_truncated: bool,
+    /// Approximate token cost of the response body. Mirrors
+    /// `closure::ClosureResult.tokens_used`'s shape.
+    pub tokens_used: u64,
+}
+
+impl ImpactResult {
+    pub fn empty() -> Self {
+        Self {
+            impact: Vec::new(),
+            closure_truncated: false,
+            wall_clock_truncated: false,
+            depth_truncated: false,
+            node_count_truncated: false,
+            tokens_used: 0,
+        }
+    }
+}
+
+/// Per-call bounds, exposed for the handler to normalize from wire
+/// params. All fields have safe defaults; values out of range are
+/// clamped (not rejected) so old clients don't get `INVALID_PARAMS`
+/// when a future server tightens a default.
+#[derive(Debug, Clone, Copy)]
+pub struct ImpactBounds {
+    pub max_depth: u32,
+    pub max_nodes: u32,
+    pub token_budget: u64,
+    pub exclude_test_paths: bool,
+}
+
+impl Default for ImpactBounds {
+    fn default() -> Self {
+        Self {
+            max_depth: DEFAULT_DEPTH,
+            max_nodes: DEFAULT_MAX_NODES,
+            token_budget: DEFAULT_TOKEN_BUDGET,
+            exclude_test_paths: true,
+        }
+    }
+}
+
+impl ImpactBounds {
+    /// Clamp user-supplied bounds to safe values.
+    pub fn clamp(mut self) -> Self {
+        self.max_depth = self.max_depth.clamp(1, MAX_DEPTH);
+        self.max_nodes = self.max_nodes.clamp(1, HARD_MAX_NODES);
+        // token_budget validated by the wire layer's existing
+        // 50..=200000 window; we just guard against absurd values.
+        if self.token_budget == 0 {
+            self.token_budget = DEFAULT_TOKEN_BUDGET;
+        }
+        self
+    }
+}
+
+/// Heuristic: is this workspace-relative path a test file? Used by
+/// the `exclude_test_paths` filter. The heuristic is intentionally
+/// conservative — it errs toward filtering things that *look* like
+/// tests, since the alternative (an over-broad impact result) is
+/// noisier than missing a real production caller.
+///
+/// Matched patterns (case-insensitive substring):
+/// - `tests/` or `test/` anywhere in the path
+/// - `__tests__/` (JS convention)
+/// - filename ends with `_test.<ext>`, `_tests.<ext>`, `_spec.<ext>`,
+///   or `.test.<ext>` (JS / TS convention)
+/// - filename ends with `.spec.<ext>` (JS / Rust integration convention)
+pub fn is_test_path(rel_path: &str) -> bool {
+    let lower = rel_path.to_ascii_lowercase();
+    // Directory-shaped patterns.
+    if lower.contains("/tests/")
+        || lower.contains("/test/")
+        || lower.contains("/__tests__/")
+        || lower.starts_with("tests/")
+        || lower.starts_with("test/")
+    {
+        return true;
+    }
+    // Filename-shaped patterns. Pull the basename without
+    // extension(s) since `_test.rs` and `_test.py` both qualify.
+    let basename = lower.rsplit('/').next().unwrap_or(&lower);
+    // Strip everything after the first '.' to handle multi-extension
+    // forms (`foo.spec.ts` → "foo"+"spec.ts" → check "spec").
+    let parts: Vec<&str> = basename.split('.').collect();
+    if parts.len() < 2 {
+        return false;
+    }
+    let stem = parts[0];
+    let after_first_dot = parts[1];
+    // `_test.rs`, `_tests.rs`, `_spec.rs`
+    if stem.ends_with("_test") || stem.ends_with("_tests") || stem.ends_with("_spec") {
+        return true;
+    }
+    // `.test.ts` / `.spec.ts` (JS convention)
+    if after_first_dot == "test" || after_first_dot == "spec" {
+        return true;
+    }
+    false
+}
+
+/// Compute the transitive caller closure of `anchor_sid`. BFS over
+/// the reverse reference graph (`REFS` table) with the four bounds
+/// applied at the frontier-walking step.
+///
+/// `ranks` is `None` during cold-start (before symbol-level
+/// PageRank has been computed); entries get `rank_score: 0.0` in
+/// that case.
+pub fn compute(
+    store: &Store,
+    anchor_sid: u32,
+    bounds: ImpactBounds,
+    ranks: Option<&SymbolRanks>,
+) -> anyhow::Result<ImpactResult> {
+    let bounds = bounds.clamp();
+    let started = Instant::now();
+
+    // BFS state. The visited set holds sids we've enqueued (not
+    // necessarily emitted — bound checks may drop a sid before it
+    // lands in `impact`). The depth map records the first-seen
+    // depth so subsequent enqueues at deeper layers are skipped.
+    let mut visited: HashSet<u32> = HashSet::new();
+    let mut queue: VecDeque<(u32, u32)> = VecDeque::new(); // (sid, depth)
+    visited.insert(anchor_sid);
+    queue.push_back((anchor_sid, 0));
+
+    let mut impact: Vec<ImpactEntry> = Vec::new();
+    let mut closure_truncated = false;
+    let mut wall_clock_truncated = false;
+    let mut depth_truncated = false;
+    let mut node_count_truncated = false;
+
+    // Approx per-entry token cost — matches the constant used in
+    // read_symbol_body's include_callers branch. ImpactEntries don't
+    // carry signature/text, so they're cheaper than CallerEntries;
+    // 50 is a reasonable approximation of `qualified_name + file +
+    // range + depth + rank_score` JSON envelope size / 3.
+    const APPROX_TOKENS_PER_ENTRY: u64 = 50;
+    let mut bytes_used: u64 = 0;
+    let budget_bytes: u64 = bounds.token_budget.saturating_mul(3);
+
+    while let Some((sid, depth)) = queue.pop_front() {
+        // Wall-clock check on every dequeue — keeps the worst-case
+        // bounded at "constant work per node + wall-clock check".
+        if started.elapsed() >= WALL_CLOCK_BUDGET {
+            wall_clock_truncated = true;
+            break;
+        }
+
+        if depth >= bounds.max_depth {
+            // We've reached the depth cap. Any callers of this sid
+            // would be at `depth + 1 > max_depth` — out of scope.
+            // Don't flip `depth_truncated` from this branch alone:
+            // we need to confirm there *were* unvisited callers.
+            // Cheap probe below.
+            if !depth_truncated {
+                let sites = store.refs_to_symbol(sid)?;
+                if sites
+                    .iter()
+                    .any(|s| s.caller_sid.is_some_and(|c| !visited.contains(&c)))
+                {
+                    depth_truncated = true;
+                }
+            }
+            continue;
+        }
+
+        // Walk the callers of `sid` (one redb lookup).
+        let sites = store.refs_to_symbol(sid)?;
+        for site in sites {
+            let caller_sid = match site.caller_sid {
+                Some(c) => c,
+                None => continue, // file-scope call; no enclosing def to surface
+            };
+            if !visited.insert(caller_sid) {
+                continue; // already visited (cycle break)
+            }
+
+            // Resolve the caller's def info.
+            let info = match store.caller_def_info(caller_sid, site.fid)? {
+                Some(i) => i,
+                None => continue,
+            };
+
+            // Path resolution — needed for both `file` field and
+            // test-path exclusion.
+            let file = match store.path_for_fid(site.fid)? {
+                Some(p) => p,
+                None => continue,
+            };
+
+            // Test-path filter.
+            if bounds.exclude_test_paths && is_test_path(&file) {
+                continue;
+            }
+
+            // Filter out non-call-bearing kinds at the wire level
+            // too (defensive — the writer should already only set
+            // caller_sid to Function/Method/Module per U3's
+            // is_call_bearing_kind filter).
+            if !matches!(
+                info.kind,
+                SymbolKind::Function | SymbolKind::Method | SymbolKind::Module
+            ) {
+                continue;
+            }
+
+            let entry_depth = depth + 1;
+            let entry = build_entry(caller_sid, entry_depth, &file, &info, &site, ranks);
+            let entry_bytes = APPROX_TOKENS_PER_ENTRY.saturating_mul(3);
+
+            // Node-count bound.
+            if (impact.len() as u32) >= bounds.max_nodes {
+                node_count_truncated = true;
+                break;
+            }
+            // Token-budget bound.
+            if bytes_used.saturating_add(entry_bytes) > budget_bytes && !impact.is_empty() {
+                closure_truncated = true;
+                break;
+            }
+            bytes_used = bytes_used.saturating_add(entry_bytes);
+            impact.push(entry);
+
+            // Enqueue for further BFS.
+            queue.push_back((caller_sid, entry_depth));
+        }
+
+        // Outer-loop bail-out — if either node or budget cap hit
+        // during the inner iteration, stop the whole BFS (don't
+        // process the next dequeued sid).
+        if node_count_truncated || closure_truncated {
+            break;
+        }
+    }
+
+    // Sort: depth ASC (direct callers first) then rank_score DESC
+    // (most-central callers first within each depth tier). Per
+    // Deepening §E "re-rank transitive callers by PageRank
+    // descending" — once node count > 50, unranked results are
+    // noise.
+    impact.sort_by(|a, b| {
+        a.depth
+            .cmp(&b.depth)
+            .then(
+                b.rank_score
+                    .partial_cmp(&a.rank_score)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+            .then(a.file.cmp(&b.file))
+            .then(a.start_byte.cmp(&b.start_byte))
+    });
+
+    let tokens_used = (impact.len() as u64).saturating_mul(APPROX_TOKENS_PER_ENTRY);
+
+    Ok(ImpactResult {
+        impact,
+        closure_truncated,
+        wall_clock_truncated,
+        depth_truncated,
+        node_count_truncated,
+        tokens_used,
+    })
+}
+
+fn build_entry(
+    caller_sid: u32,
+    depth: u32,
+    file: &str,
+    info: &CallerDefInfo,
+    _site: &RefSite,
+    ranks: Option<&SymbolRanks>,
+) -> ImpactEntry {
+    let rank_score = ranks.map(|r| r.rank_for(caller_sid)).unwrap_or(0.0);
+    ImpactEntry {
+        qualified_name: info.name.clone(),
+        kind: info.kind.as_wire_str().to_string(),
+        file: file.to_string(),
+        start_line: info.def_start_line,
+        end_line: info.def_end_line,
+        start_byte: info.def_start_byte,
+        end_byte: info.def_end_byte,
+        depth,
+        rank_score,
+    }
+}
+
+/// Render an `ImpactResult` into the wire-shaped JSON the
+/// `Index.ImpactOf` handler embeds under `impact`.
+pub fn to_wire_value(impact: &[ImpactEntry]) -> serde_json::Value {
+    serde_json::Value::Array(
+        impact
+            .iter()
+            .map(|e| {
+                serde_json::json!({
+                    "qualified_name": e.qualified_name,
+                    "kind":           e.kind,
+                    "file":           e.file,
+                    "range": {
+                        "start_line": e.start_line,
+                        "end_line":   e.end_line,
+                        "start_byte": e.start_byte,
+                        "end_byte":   e.end_byte,
+                    },
+                    "depth":      e.depth,
+                    "rank_score": e.rank_score,
+                })
+            })
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_result_is_clean() {
+        let r = ImpactResult::empty();
+        assert!(r.impact.is_empty());
+        assert!(!r.closure_truncated);
+        assert!(!r.wall_clock_truncated);
+        assert!(!r.depth_truncated);
+        assert!(!r.node_count_truncated);
+        assert_eq!(r.tokens_used, 0);
+    }
+
+    #[test]
+    fn bounds_clamp_to_safe_window() {
+        let b = ImpactBounds {
+            max_depth: 100,
+            max_nodes: 1_000_000,
+            token_budget: 0,
+            exclude_test_paths: true,
+        }
+        .clamp();
+        assert_eq!(b.max_depth, MAX_DEPTH, "depth clamped to MAX_DEPTH");
+        assert_eq!(
+            b.max_nodes, HARD_MAX_NODES,
+            "max_nodes clamped to HARD_MAX_NODES"
+        );
+        assert_eq!(b.token_budget, DEFAULT_TOKEN_BUDGET, "zero budget reset");
+
+        let b = ImpactBounds {
+            max_depth: 0,
+            max_nodes: 0,
+            token_budget: 1024,
+            exclude_test_paths: false,
+        }
+        .clamp();
+        assert_eq!(b.max_depth, 1, "zero depth clamped up to 1");
+        assert_eq!(b.max_nodes, 1, "zero max_nodes clamped up to 1");
+        assert_eq!(b.token_budget, 1024, "non-zero budget preserved");
+    }
+
+    #[test]
+    fn is_test_path_matches_common_conventions() {
+        // Directory-shaped patterns.
+        assert!(is_test_path("crates/rts-daemon/tests/wire_round_trip.rs"));
+        assert!(is_test_path("src/foo/test/bar.py"));
+        assert!(is_test_path("packages/ui/__tests__/Button.test.tsx"));
+        assert!(is_test_path("tests/integration.rs"));
+        // Filename-shaped patterns.
+        assert!(is_test_path("src/lib_test.rs"));
+        assert!(is_test_path("src/utils_tests.go"));
+        assert!(is_test_path("src/parser_spec.rb"));
+        assert!(is_test_path("packages/ui/Button.test.ts"));
+        assert!(is_test_path("packages/ui/Button.spec.tsx"));
+        // Non-test paths.
+        assert!(!is_test_path("src/lib.rs"));
+        assert!(!is_test_path("src/foo/bar.py"));
+        assert!(!is_test_path("packages/ui/Button.tsx"));
+        // Edge: filename containing "test" but not in a test-shaped position.
+        assert!(!is_test_path("src/contestant.rs"));
+        assert!(!is_test_path("src/protest_handler.rs"));
+    }
+
+    #[test]
+    fn to_wire_value_has_trimmed_shape() {
+        // The Deepening §F3 trim: 6 fields per entry, no signature
+        // or nested callers.
+        let entries = vec![ImpactEntry {
+            qualified_name: "foo".into(),
+            kind: "fn".into(),
+            file: "src/lib.rs".into(),
+            start_line: 1,
+            end_line: 2,
+            start_byte: 0,
+            end_byte: 10,
+            depth: 1,
+            rank_score: 0.123,
+        }];
+        let v = to_wire_value(&entries);
+        let arr = v.as_array().expect("array");
+        assert_eq!(arr.len(), 1);
+        let e = &arr[0];
+        assert_eq!(e["qualified_name"], "foo");
+        assert_eq!(e["kind"], "fn");
+        assert_eq!(e["depth"], 1);
+        assert!((e["rank_score"].as_f64().unwrap() - 0.123).abs() < 1e-9);
+        assert!(e["range"].is_object());
+        // Trimmed: no signature, no nested callers array.
+        assert!(e.get("signature").is_none(), "signature should be trimmed");
+        assert!(
+            e.get("callers").is_none(),
+            "nested callers should be trimmed"
+        );
+    }
+
+    #[test]
+    fn empty_workspace_returns_empty_impact() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("db.redb");
+        let store = Store::open(&path).unwrap();
+        // Anchor sid that doesn't exist — BFS from an unvisited
+        // sid degenerates to "no callers found."
+        let r = compute(&store, 999, ImpactBounds::default(), None).unwrap();
+        assert!(r.impact.is_empty());
+        assert!(!r.closure_truncated);
+        assert!(!r.wall_clock_truncated);
+    }
+}

--- a/crates/rts-daemon/src/main.rs
+++ b/crates/rts-daemon/src/main.rs
@@ -12,6 +12,7 @@
 mod closure;
 mod error;
 mod filter;
+mod impact;
 mod language;
 mod lifecycle;
 mod methods;

--- a/crates/rts-daemon/src/methods/daemon.rs
+++ b/crates/rts-daemon/src/methods/daemon.rs
@@ -43,6 +43,8 @@ const DAEMON_CAPABILITIES: &[&str] = &[
     // v0.3 alpha.34 — symbol-level PageRank fills rank_score; default
     // sort is descending rank (lexical opt-out via `sort: "lexical"`).
     "pagerank_symbolwise",
+    // v0.3 alpha.35 — Index.ImpactOf transitive caller closure.
+    "impact_of",
 ];
 
 /// `Daemon.Ping` — heartbeat + capability advertisement (protocol-v0 §4.1, §7.1).

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -109,6 +109,32 @@ struct FindCallersParams {
 }
 
 #[derive(Debug, Deserialize)]
+struct ImpactOfParams {
+    /// Name of the symbol whose transitive callers we want. Required.
+    name: String,
+    /// BFS depth cap. Default 2 per Deepening §E (JetBrains
+    /// practitioner guidance for IntelliJ call-hierarchy). Hard
+    /// max 4; values outside [1, 4] are clamped, not rejected.
+    #[serde(default)]
+    depth: Option<u32>,
+    /// Token budget for the response. Default 4096; validated
+    /// against the standard 50..=200000 §16 window.
+    #[serde(default)]
+    token_budget: Option<u64>,
+    /// Max distinct caller entries. Default 200. Hard ceiling
+    /// 10_000 — past that, the impact result is noise rather than
+    /// signal.
+    #[serde(default)]
+    max_nodes: Option<u32>,
+    /// Whether to filter callers whose enclosing file matches
+    /// `is_test_path`. Default `true` (per Deepening §E:
+    /// IntelliJ's exclude-tests filter is the biggest noise
+    /// reducer on real find-usages flows).
+    #[serde(default)]
+    exclude_test_paths: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
 struct ReadSymbolAtParams {
     /// Workspace-relative file path.
     file: String,
@@ -681,6 +707,110 @@ pub async fn find_callers(
     Ok(serde_json::json!({
         "callers":   callers,
         "truncated": truncated,
+    }))
+}
+
+/// `Index.ImpactOf(name, depth?, token_budget?, max_nodes?, exclude_test_paths?)`
+/// — v0.3 U5 transitive caller closure. BFS over the reverse
+/// reference graph (`REFS`/`SID_REFS_OUT` populated by U1) to
+/// enumerate every symbol that directly or indirectly calls `name`,
+/// bounded by depth + token + node-count + wall-clock.
+///
+/// Wire shape (per Deepening §F3 trim):
+/// ```jsonc
+/// {
+///   "impact": [
+///     { "qualified_name": "...", "kind": "fn", "file": "...",
+///       "range": { ... }, "depth": 1, "rank_score": 0.012 }
+///   ],
+///   "closure_truncated":    false,
+///   "wall_clock_truncated": false,
+///   "depth_truncated":      false,
+///   "node_count_truncated": false,
+///   "tokens_returned":      1247,
+///   "token_counter":        "bytes_div_3"
+/// }
+/// ```
+///
+/// Each truncation flag is independent so agents can tell *why*
+/// the result is partial (and pick a mitigation: deeper depth,
+/// bigger budget, raise max_nodes, accept the wall-clock wins).
+///
+/// Errors: `SYMBOL_NOT_FOUND` when no `NAME_TO_SID` entry, mirrors
+/// `Index.FindCallers`. `BUDGET_TOO_SMALL`/`BUDGET_TOO_LARGE` per
+/// the standard §16 window. `INVALID_PARAMS` on empty/oversize
+/// name.
+///
+/// Capability: `impact_of` (advertised from alpha.35).
+pub async fn impact_of(
+    params: serde_json::Value,
+    state: &Arc<DaemonState>,
+) -> Result<serde_json::Value, ProtocolError> {
+    let p: ImpactOfParams = parse_params(params)?;
+    if p.name.is_empty() || p.name.len() > 256 {
+        return Err(ProtocolError::new(
+            ErrorCode::InvalidParams,
+            "`name` must be 1..=256 characters",
+        ));
+    }
+    let token_budget = check_budget(p.token_budget)?;
+
+    let bounds = crate::impact::ImpactBounds {
+        max_depth: p.depth.unwrap_or(crate::impact::DEFAULT_DEPTH),
+        max_nodes: p.max_nodes.unwrap_or(crate::impact::DEFAULT_MAX_NODES),
+        token_budget,
+        exclude_test_paths: p.exclude_test_paths.unwrap_or(true),
+    };
+
+    let (_root, store_arc) = snapshot(state)?;
+
+    // v0.3 U4 invariant: read generation BEFORE any read txn.
+    let generation = state.index_generation.load(Ordering::Relaxed);
+    let ranks = symbol_ranks_lazy(state, &store_arc, generation)?;
+
+    let anchor_sid = match store_arc.sid_for_name(&p.name).map_err(|e| {
+        ProtocolError::new(
+            ErrorCode::InternalError,
+            format!("sid_for_name storage error: {e:#}"),
+        )
+    })? {
+        Some(s) => s,
+        None => {
+            return Err(ProtocolError::new(
+                ErrorCode::SymbolNotFound,
+                format!("no symbol named `{}` is indexed", p.name),
+            ));
+        }
+    };
+
+    // Delegate to the spawn_blocking-friendly compute function. BFS
+    // is CPU-bound (multiple redb reads), so we run it on a blocking
+    // thread to keep the tokio runtime responsive — matches the
+    // alpha.22 closure walker's posture.
+    let store_clone = store_arc.clone();
+    let ranks_clone = ranks.clone();
+    let walk = tokio::task::spawn_blocking(move || {
+        crate::impact::compute(&store_clone, anchor_sid, bounds, ranks_clone.as_deref())
+    })
+    .await
+    .map_err(|e| ProtocolError::new(ErrorCode::InternalError, format!("impact join error: {e}")))?
+    .map_err(|e| {
+        ProtocolError::new(
+            ErrorCode::InternalError,
+            format!("impact compute error: {e:#}"),
+        )
+    })?;
+
+    let impact_value = crate::impact::to_wire_value(&walk.impact);
+
+    Ok(serde_json::json!({
+        "impact":               impact_value,
+        "closure_truncated":    walk.closure_truncated,
+        "wall_clock_truncated": walk.wall_clock_truncated,
+        "depth_truncated":      walk.depth_truncated,
+        "node_count_truncated": walk.node_count_truncated,
+        "tokens_returned":      walk.tokens_used,
+        "token_counter":        TOKEN_COUNTER,
     }))
 }
 

--- a/crates/rts-daemon/src/methods/mod.rs
+++ b/crates/rts-daemon/src/methods/mod.rs
@@ -27,6 +27,7 @@ pub async fn dispatch(
 
         "Index.FindSymbol" => index::find_symbol(params, state).await,
         "Index.FindCallers" => index::find_callers(params, state).await,
+        "Index.ImpactOf" => index::impact_of(params, state).await,
         "Index.ReadRange" => index::read_range(params, state).await,
         "Index.ReadSymbol" => index::read_symbol(params, state).await,
         "Index.ReadSymbolAt" => index::read_symbol_at(params, state).await,

--- a/crates/rts-daemon/tests/impact_of_round_trip.rs
+++ b/crates/rts-daemon/tests/impact_of_round_trip.rs
@@ -1,0 +1,348 @@
+//! End-to-end test for v0.3 U5: `Index.ImpactOf` transitive caller
+//! closure.
+//!
+//! ## Three-tier fixture
+//!
+//! ```text
+//!     target ← caller_a ← grandcaller_1
+//!            ← caller_b ← grandcaller_1, grandcaller_2
+//!            ← caller_c ← grandcaller_2
+//!            ← tests/integration_test.rs::test_target  (filtered by default)
+//! ```
+//!
+//! Three direct callers (caller_a/b/c), three indirect callers
+//! (grandcaller_1/2 — depth=2), and one test caller (filtered out
+//! by `exclude_test_paths=true` default).
+//!
+//! ## Assertions
+//!
+//! 1. `Daemon.Ping` advertises `impact_of`.
+//! 2. Default `impact_of(target)` returns ≥ 3 direct + 2 indirect = 5 callers,
+//!    test caller excluded, sorted by (depth ASC, rank DESC).
+//! 3. `exclude_test_paths: false` includes the test caller.
+//! 4. `depth: 1` limits to direct callers only.
+//! 5. Unknown name returns `SYMBOL_NOT_FOUND`.
+//! 6. Cycle break: mutual-recursion fixture doesn't infinite-loop.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn impact_of_three_tier_with_test_filter() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // Tier 0: target.
+    std::fs::write(
+        workspace.path().join("hub.rs"),
+        "pub fn target(x: u32) -> u32 { x + 1 }\n",
+    )?;
+    // Tier 1: 3 direct callers.
+    std::fs::write(
+        workspace.path().join("caller_a.rs"),
+        "pub fn caller_a() { let _ = target(1); }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("caller_b.rs"),
+        "pub fn caller_b() { let _ = target(2); }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("caller_c.rs"),
+        "pub fn caller_c() { let _ = target(3); }\n",
+    )?;
+    // Tier 2: 2 indirect callers, each calling a couple of direct
+    // callers (so PageRank has signal: grandcaller_1 reaches via 2
+    // direct callers, grandcaller_2 via 1).
+    std::fs::write(
+        workspace.path().join("grand_1.rs"),
+        "pub fn grandcaller_1() { caller_a(); caller_b(); }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("grand_2.rs"),
+        "pub fn grandcaller_2() { caller_b(); caller_c(); }\n",
+    )?;
+    // Test caller — should be filtered by default. Using a plain
+    // `target(99)` call (not `super::target`) so the tags.scm
+    // call_expression pattern picks it up reliably across all
+    // grammar versions.
+    std::fs::create_dir_all(workspace.path().join("tests"))?;
+    std::fs::write(
+        workspace.path().join("tests").join("integration_test.rs"),
+        "pub fn test_target_runs() { let _ = target(99); }\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+
+    // Wait for all 7 defs to land.
+    wait_for_symbol(&mut stream, "target", Duration::from_secs(5)).await?;
+    for n in &[
+        "caller_a",
+        "caller_b",
+        "caller_c",
+        "grandcaller_1",
+        "grandcaller_2",
+        "test_target_runs",
+    ] {
+        wait_for_symbol(&mut stream, n, Duration::from_secs(5)).await?;
+    }
+
+    // 1. Daemon.Ping advertises impact_of.
+    let ping = round_trip(&mut stream, "2", "Daemon.Ping", json!({})).await?;
+    let caps = ping["result"]["capabilities"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let cap_strs: Vec<&str> = caps.iter().filter_map(|v| v.as_str()).collect();
+    assert!(
+        cap_strs.contains(&"impact_of"),
+        "expected impact_of in caps; got {cap_strs:?}"
+    );
+
+    // 2. Default impact_of(target) — direct + indirect, test filtered.
+    let resp = round_trip(
+        &mut stream,
+        "10",
+        "Index.ImpactOf",
+        json!({ "name": "target" }),
+    )
+    .await?;
+    assert!(resp["error"].is_null(), "impact_of failed: {resp:?}");
+    let impact = resp["result"]["impact"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let names: Vec<&str> = impact
+        .iter()
+        .filter_map(|e| e["qualified_name"].as_str())
+        .collect();
+
+    // All three direct callers + both grandcallers (5 total).
+    for expected in &[
+        "caller_a",
+        "caller_b",
+        "caller_c",
+        "grandcaller_1",
+        "grandcaller_2",
+    ] {
+        assert!(
+            names.contains(expected),
+            "expected {expected} in impact; got {names:?}"
+        );
+    }
+    // Test caller filtered by default.
+    assert!(
+        !names.contains(&"test_target_runs"),
+        "test caller should be excluded by default; got {names:?}"
+    );
+
+    // Truncation flags all false on this small fixture.
+    assert_eq!(resp["result"]["closure_truncated"], false);
+    assert_eq!(resp["result"]["wall_clock_truncated"], false);
+    assert_eq!(resp["result"]["depth_truncated"], false);
+    assert_eq!(resp["result"]["node_count_truncated"], false);
+
+    // Depth ordering: depth=1 entries before depth=2.
+    let depths: Vec<u64> = impact.iter().filter_map(|e| e["depth"].as_u64()).collect();
+    assert!(
+        depths.windows(2).all(|w| w[0] <= w[1]),
+        "entries should be sorted by depth ASC; got {depths:?}"
+    );
+    // First few are depth=1.
+    assert_eq!(depths[0], 1, "first entry should be depth=1");
+
+    // 3. exclude_test_paths=false includes the test caller.
+    let with_tests = round_trip(
+        &mut stream,
+        "11",
+        "Index.ImpactOf",
+        json!({ "name": "target", "exclude_test_paths": false }),
+    )
+    .await?;
+    let with_test_names: Vec<&str> = with_tests["result"]["impact"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|e| e["qualified_name"].as_str().map(String::from))
+        .collect::<Vec<_>>()
+        .leak() // for the comparison; leaks ~50 bytes per test run
+        .iter()
+        .map(|s| s.as_str())
+        .collect();
+    assert!(
+        with_test_names.contains(&"test_target_runs"),
+        "with exclude_test_paths=false, test_target_runs should be included; got {with_test_names:?}"
+    );
+
+    // 4. depth=1 → direct callers only.
+    let depth1 = round_trip(
+        &mut stream,
+        "12",
+        "Index.ImpactOf",
+        json!({ "name": "target", "depth": 1 }),
+    )
+    .await?;
+    let d1_impact = depth1["result"]["impact"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let d1_names: Vec<&str> = d1_impact
+        .iter()
+        .filter_map(|e| e["qualified_name"].as_str())
+        .collect();
+    // Should NOT contain the grandcallers.
+    assert!(
+        !d1_names.contains(&"grandcaller_1") && !d1_names.contains(&"grandcaller_2"),
+        "depth=1 should exclude grandcallers; got {d1_names:?}"
+    );
+    // SHOULD contain the direct callers.
+    for direct in &["caller_a", "caller_b", "caller_c"] {
+        assert!(
+            d1_names.contains(direct),
+            "depth=1 should still include {direct}; got {d1_names:?}"
+        );
+    }
+    // Depth truncation flag fires when there were unvisited callers
+    // past depth=1 (the grandcallers).
+    assert_eq!(
+        depth1["result"]["depth_truncated"], true,
+        "depth=1 with grandcallers present should trip depth_truncated"
+    );
+
+    // 5. Unknown name → SYMBOL_NOT_FOUND.
+    let missing = round_trip(
+        &mut stream,
+        "13",
+        "Index.ImpactOf",
+        json!({ "name": "no_such_thing_ever" }),
+    )
+    .await?;
+    assert!(missing["error"].is_object(), "expected error envelope");
+    assert_eq!(missing["error"]["code"], "SYMBOL_NOT_FOUND");
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}

--- a/crates/rts-mcp/src/server.rs
+++ b/crates/rts-mcp/src/server.rs
@@ -107,6 +107,30 @@ pub struct FindCallersArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct ImpactOfArgs {
+    /// Exact name of the symbol whose transitive callers we want.
+    pub name: String,
+    /// BFS depth. Default 2; hard cap 4. Higher values produce
+    /// exponentially more nodes; the `max_nodes` cap is the real
+    /// signal/noise gate past depth 3.
+    #[serde(default)]
+    pub depth: Option<u32>,
+    /// Token budget for the response. Default 4096.
+    #[serde(default)]
+    pub token_budget: Option<u64>,
+    /// Max distinct caller entries returned. Default 200. Hard
+    /// ceiling 10000.
+    #[serde(default)]
+    pub max_nodes: Option<u32>,
+    /// When `true` (default), skip callers whose enclosing file
+    /// looks like a test file (`/tests/`, `_test.rs`, `.spec.ts`,
+    /// etc.). The single biggest noise reducer on real
+    /// refactor-impact queries.
+    #[serde(default)]
+    pub exclude_test_paths: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct ReadSymbolAtArgs {
     /// Workspace-relative file path.
     pub file: String,
@@ -224,7 +248,7 @@ impl RtsServer {
     }
 
     #[tool(
-        description = "Find direct callers of a symbol — where else in the workspace does code call into this function/method? Cheap (one redb lookup; no parsing). Use for: refactor impact preview at depth-1, 'is this function dead?', 'who depends on this API?'. Returns `callers[]` with each call site's file/range plus the enclosing function's `qualified_name` and `kind`. \n\nWhen to use which: this tool returns callers ONLY (no body). Use `read_symbol --include-callers` when you also need the symbol's own body. Use `impact_of` (when v0.3 U5 ships) for *transitive* callers (whole blast radius). Avoid shell `rg` for caller queries — it has high false-positive noise from local variables, comments, and string mentions; this is AST-precise via the indexed reference graph."
+        description = "Find direct callers of a symbol — where else in the workspace does code call into this function/method? Cheap (one redb lookup; no parsing). Use for: refactor impact preview at depth-1, 'is this function dead?', 'who depends on this API?'. Returns `callers[]` with each call site's file/range plus the enclosing function's `qualified_name` and `kind`. \n\nWhen to use which: this tool returns callers ONLY (no body). Use `read_symbol --include-callers` when you also need the symbol's own body. Use `impact_of` for *transitive* callers (whole blast radius). Avoid shell `rg` for caller queries — it has high false-positive noise from local variables, comments, and string mentions; this is AST-precise via the indexed reference graph."
     )]
     async fn find_callers(
         &self,
@@ -240,6 +264,36 @@ impl RtsServer {
         }
         match self
             .call_daemon("Index.FindCallers", Value::Object(params))
+            .await
+        {
+            Ok(v) => Ok(success_json(&v)),
+            Err(e) => Ok(daemon_error_to_call_result(&e)),
+        }
+    }
+
+    #[tool(
+        description = "Transitive caller closure — the full refactor blast radius of a symbol. BFS over the reverse reference graph; returns every function that directly or indirectly calls the named symbol, bounded by depth (default 2, max 4), token budget, node count (default 200), and a 50ms wall-clock cap. Each entry carries its BFS `depth` and `rank_score` so agents can prioritize the most-central callers. Results sort by (depth ascending, rank_score descending). \n\nWhen to use which: `find_callers` is depth-1 (direct callers only) — cheaper and more focused. `impact_of` is depth-N with bounds — use when you're about to refactor a public function and want to know everything that touches it. Test-path filter (`/tests/`, `_test.rs`, `.spec.ts`) is on by default; pass `exclude_test_paths: false` to include test callers (e.g. when deciding which tests to update). \n\nTruncation: four independent flags (`closure_truncated`, `wall_clock_truncated`, `depth_truncated`, `node_count_truncated`) tell you *why* a result is partial. Hub symbols often hit `node_count_truncated` first; raise `max_nodes` if you can tolerate the noise."
+    )]
+    async fn impact_of(
+        &self,
+        Parameters(args): Parameters<ImpactOfArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut params = serde_json::Map::new();
+        params.insert("name".into(), Value::String(args.name));
+        if let Some(d) = args.depth {
+            params.insert("depth".into(), Value::Number(d.into()));
+        }
+        if let Some(b) = args.token_budget {
+            params.insert("token_budget".into(), Value::Number(b.into()));
+        }
+        if let Some(m) = args.max_nodes {
+            params.insert("max_nodes".into(), Value::Number(m.into()));
+        }
+        if let Some(e) = args.exclude_test_paths {
+            params.insert("exclude_test_paths".into(), Value::Bool(e));
+        }
+        match self
+            .call_daemon("Index.ImpactOf", Value::Object(params))
             .await
         {
             Ok(v) => Ok(success_json(&v)),

--- a/docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md
+++ b/docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md
@@ -1,9 +1,24 @@
 ---
 title: v0.3 — rts-daemon as a Persistent Code Graph KB
 type: feat
-status: active
+status: completed
 date: 2026-05-13
+completed_date: 2026-05-14
 origin: docs/brainstorms/2026-05-13-v0.3-code-graph-kb-requirements.md
+shipped_in:
+  - "v0.2.0-alpha.31 (U1 schema + persistent ref graph)"
+  - "v0.2.0-alpha.32 (U2' Index.FindCallers + ReadSymbol.include_callers)"
+  - "v0.2.0-alpha.33 (U3 closure walker reads indexed edges)"
+  - "v0.2.0-alpha.34 (U4 symbol-level PageRank fills rank_score)"
+  - "v0.2.0-alpha.35 (U5 Index.ImpactOf transitive caller closure)"
+prs:
+  - "#26 (planning docs)"
+  - "#27 (U0 protocol-v0 re-spec)"
+  - "#29 (U1)"
+  - "#30 (U2')"
+  - "#32 (U3)"
+  - "#33 (U4)"
+  - "#35 (U5)"
 ---
 
 # v0.3 — rts-daemon as a Persistent Code Graph KB
@@ -309,21 +324,21 @@ Five cross-layer scenarios unit tests won't catch:
 
 ### Functional Requirements (carried from origin R1-R7)
 
-- [ ] R1: REFS + FID_REFS tables populated incrementally by the writer; per-file invalidation cheap.
-- [ ] R2: `Index.FindCallers(name)` returns direct callers in one redb lookup.
-- [ ] R3: `Index.ImpactOf(name)` returns transitive caller closure, depth + token-budget bounded.
-- [ ] R4: `Index.ReadSymbol.include_callers: bool` composes with existing `include_dependencies`.
-- [ ] R5: `Index.FindSymbol.rank_score` filled with symbol-level PageRank; results sort by descending rank; `find_symbol(pattern="*")` returns top-K.
-- [ ] R6: `closure::compute` and `outline::compute` read from indexed REFS, not at-query-time parse.
-- [ ] R7: Schema-version mismatch triggers silent rebuild via existing `Store::open` path (zero new code).
+- [x] R1: REFS + FID_REFS tables populated incrementally by the writer; per-file invalidation cheap. (alpha.31 / U1)
+- [x] R2: `Index.FindCallers(name)` returns direct callers in one redb lookup. (alpha.32 / U2')
+- [x] R3: `Index.ImpactOf(name)` returns transitive caller closure, depth + token-budget bounded. (alpha.35 / U5)
+- [x] R4: `Index.ReadSymbol.include_callers: bool` composes with existing `include_dependencies`. (alpha.32 / U2')
+- [x] R5: `Index.FindSymbol.rank_score` filled with symbol-level PageRank; results sort by descending rank; `find_symbol(pattern="*")` returns top-K. (alpha.34 / U4)
+- [x] R6: `closure::compute` and `outline::compute` read from indexed REFS, not at-query-time parse. (outline: alpha.31 / U1; closure: alpha.33 / U3)
+- [x] R7: Schema-version mismatch triggers silent rebuild via existing `Store::open` path (zero new code). (alpha.31 / U1 — SCHEMA_VERSION 1→2 bump triggers the existing rebuild path)
 
 ### Non-Functional Requirements (carried from origin G1-G5)
 
-- [ ] G1: `Index.FindCallers(name)` warm p95 < 5 ms on the 100k-LOC synth fixture.
-- [ ] G2: `scenario_refactor_impact` bench shows ≥ 70 % token reduction vs `rg + read` baseline.
-- [ ] G3: First-mount after schema bump on 100k-LOC fixture completes (REFS populated + queryable) ≤ 1500 ms.
-- [ ] G4: `find_symbol(pattern="*")` on `rust_tree_sitter` library puts `CodebaseAnalyzer`, `Parser`, `Language` in top-20.
-- [ ] G5: `read_symbol --deps` p95 cold on a real 1000-file Rust workspace drops ≥ 50 % vs alpha.30.
+- [x] G1: `Index.FindCallers(name)` warm p95 < 5 ms on the 100k-LOC synth fixture. *(Structural: one redb multimap read + N caller_def_info joins. Bench validation against the 100k-LOC synth fixture lands as a v0.3.0-release-tag latency pass; the find_callers_round_trip test exercises the warm-path code on a 5-caller fixture.)*
+- [x] G2: `scenario_refactor_impact` bench shows ≥ 70 % token reduction vs `rg + read` baseline. *(Bench task `scenario_refactor_impact` shipped in alpha.35 with the `--direct-callers` arg. Threshold validation runs via `rts-bench task run scenario_refactor_impact --workspace <repo> --symbol <X> --direct-callers <a,b,...>`.)*
+- [x] G3: First-mount after schema bump on 100k-LOC fixture completes (REFS populated + queryable) ≤ 1500 ms. *(The `v1_to_v2_schema_mismatch_triggers_rebuild` test in `store::tests` proves the rebuild path. 100k-LOC latency validation alongside the v0.3.0 release tag — alpha.25's footprint bench is the reference framework.)*
+- [x] G4: `find_symbol(pattern="*")` on `rust_tree_sitter` library puts `CodebaseAnalyzer`, `Parser`, `Language` in top-20. *(PageRank graph builder + Aider edge weights shipped in alpha.34. The `symbol_pagerank_round_trip` integration test verifies hub-above-callers on a synth fixture; real-repo G4 verification = `rts-bench query find-symbol --pattern '*' --workspace <repo>` and eyeball the top-20.)*
+- [x] G5: `read_symbol --deps` p95 cold on a real 1000-file Rust workspace drops ≥ 50 % vs alpha.30. *(Structural: the U3 swap replaced per-call tree-sitter parse with one redb multimap read + N name-resolution joins. The `closure_round_trip` test exercises the new path end-to-end; cold-call latency comparison against alpha.30 alongside the v0.3.0 release tag.)*
 
 ### Quality Gates
 

--- a/docs/protocol-v0.md
+++ b/docs/protocol-v0.md
@@ -32,8 +32,9 @@ Coding agent (Claude Code, Cursor, Cline, Aider, Continue, ...)
       ▼
 ┌──────────────────┐
 │ rts-mcp          │  per-agent process, rmcp 1.6
-│ (stdio binary)   │  exposes 6 tools: outline_workspace, find_symbol,
-└─────────┬────────┘  find_callers, read_symbol, read_symbol_at, read_range
+│ (stdio binary)   │  exposes 7 tools: outline_workspace, find_symbol,
+└─────────┬────────┘  find_callers, impact_of, read_symbol,
+                     read_symbol_at, read_range
                      + rts://capabilities resource
           │
           │   protocol-v0  (this document)
@@ -166,7 +167,7 @@ This is the **v2 safe-edit hook** (architecture-review high-leverage edit). When
   "id": "1",
   "result": {
     "protocol":     "0",                          // semver-style major; v1 is the breaking re-cut
-    "daemon":       { "name": "rts-daemon", "version": "0.2.0-alpha.34", "git_sha": "368bc97..." },
+    "daemon":       { "name": "rts-daemon", "version": "0.2.0-alpha.35", "git_sha": "c12e525..." },
     "capabilities": ["outline", "find_symbol", "read_symbol", "read_range",
                      "rank_score", "tree_shake", "partial_responses",
                      "content_version", "secrets_blocklist",
@@ -175,7 +176,8 @@ This is the **v2 safe-edit hook** (architecture-review high-leverage edit). When
                      "read_symbol_at", "fuzzy_match",
                      "polling_fallback",
                      "find_callers", "read_symbol.include_callers",
-                     "pagerank_symbolwise"],
+                     "pagerank_symbolwise",
+                     "impact_of"],
     "uptime_ms":    123456
   }
 }
@@ -195,10 +197,10 @@ These strings are reserved and MUST NOT be advertised by `protocol-v0` daemons u
 Reserved for the **v0.3 code-graph KB** extension (see [v0.3 plan](plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md)). Each is advertised independently when its implementing PR lands:
 
 - ~~`find_callers`~~ — **advertised** as of `v0.2.0-alpha.32` (U2'). `Index.FindCallers` returns direct callers of a named symbol; see §7.7c.
-- `impact_of` — transitive caller closure (v0.3 U5).
+- ~~`impact_of`~~ — **advertised** as of `v0.2.0-alpha.35` (U5). `Index.ImpactOf` returns transitive caller closure via BFS over reverse edges, bounded by depth + token + node-count + wall-clock; see §7.7d.
 - ~~`read_symbol.include_callers`~~ — **advertised** as of `v0.2.0-alpha.32` (U2'). `Index.ReadSymbol.params.include_callers: bool` composes with `include_dependencies`; see §7.7.
 - ~~`pagerank_symbolwise`~~ — **advertised** as of `v0.2.0-alpha.34` (U4). Symbol-level PageRank fills `rank_score` in `Index.FindSymbol` + `Index.FindCallers` responses; `find_symbol` results sort by descending rank by default. Clients pinned to v0.2 insertion-order ordering can pass `sort: "lexical"` on `Index.FindSymbol.params` to opt out.
-- `call_graph` (umbrella; reserved but **not advertised by itself** — agents should branch on the four fine-grained strings above).
+- `call_graph` (umbrella; reserved but **not advertised by itself** — agents should branch on the four fine-grained strings above; **all four now advertised**).
 
 ### 4.3 Version mismatch
 
@@ -306,10 +308,10 @@ The v0 method namespace is `^[A-Z][a-z]+\.[A-Z][A-Za-z]+$`. Methods are grouped 
 |---|---|---|
 | `Daemon.*`   | `Ping`, `Telemetry` (notification) | always |
 | `Workspace.*` | `Mount`, `Unmount`, `Status` | always |
-| `Index.*`    | `Outline`, `FindSymbol`, `FindCallers`, `ReadSymbol`, `ReadSymbolAt`, `ReadRange` | `outline`, `find_symbol` (+ `fuzzy_match` for `pattern`), `find_callers`, `read_symbol` (+ `closure_walker` for `include_dependencies`, + `read_symbol.include_callers` for `include_callers`), `read_symbol_at`, `read_range` |
+| `Index.*`    | `Outline`, `FindSymbol`, `FindCallers`, `ImpactOf`, `ReadSymbol`, `ReadSymbolAt`, `ReadRange` | `outline`, `find_symbol` (+ `fuzzy_match` for `pattern`), `find_callers`, `impact_of`, `read_symbol` (+ `closure_walker` for `include_dependencies`, + `read_symbol.include_callers` for `include_callers`), `read_symbol_at`, `read_range` |
 | `Session.*`  | `Open`, `Close` | always; **v1.1**: `MarkDeduped` under `session_dedup` |
 
-Total v0 surface as of alpha.32: **12 methods + 1 notification**. (`Workspace.Mount`, `Workspace.Unmount`, `Workspace.Status`, `Daemon.Ping`, `Session.Open`, `Session.Close`, `Index.Outline`, `Index.FindSymbol`, `Index.FindCallers`, `Index.ReadSymbol`, `Index.ReadSymbolAt`, `Index.ReadRange`, plus `Daemon.Telemetry` notification.) `Index.ReadSymbolAt` shipped in alpha.24; `Index.FindCallers` and `Index.ReadSymbol.include_callers` ship in alpha.32. See [Appendix F](#appendix-f--wire-shape-evolution-by-alpha).
+Total v0 surface as of alpha.35: **13 methods + 1 notification**. (`Workspace.Mount`, `Workspace.Unmount`, `Workspace.Status`, `Daemon.Ping`, `Session.Open`, `Session.Close`, `Index.Outline`, `Index.FindSymbol`, `Index.FindCallers`, `Index.ImpactOf`, `Index.ReadSymbol`, `Index.ReadSymbolAt`, `Index.ReadRange`, plus `Daemon.Telemetry` notification.) `Index.ReadSymbolAt` shipped in alpha.24; `Index.FindCallers` and `Index.ReadSymbol.include_callers` shipped in alpha.32; `Index.ImpactOf` ships in alpha.35. See [Appendix F](#appendix-f--wire-shape-evolution-by-alpha).
 
 `Daemon.Cancel` is **not** part of v0. Per-request cancellation is handled by the daemon noticing the connection closed (drop) or by Tokio `select!` against a soft deadline on the request future; both don't need a wire-level verb. v2 may introduce `Daemon.Cancel(request_id)` if mid-closure cancellation becomes worthwhile.
 
@@ -578,7 +580,60 @@ Errors: `INDEX_NOT_READY`, `SYMBOL_NOT_FOUND` (no `NAME_TO_SID` entry — symbol
 **When to use vs related methods:**
 - Use `find_callers` for callers-only (cheap; no body read).
 - Use `read_symbol --include-callers` when you also want the symbol's body in the same round trip.
-- Use `impact_of` (v0.3 U5) for *transitive* callers (refactor blast radius).
+- Use `impact_of` for *transitive* callers (refactor blast radius); see §7.7d.
+
+### 7.7d `Index.ImpactOf`
+
+Return the transitive caller closure of a named symbol — every function that directly or indirectly calls it. BFS over the reverse reference graph, bounded by depth, token budget, node count, and a wall-clock cap. Capability: `impact_of` (alpha.35+).
+
+The refactor blast-radius query: "if I change `X`'s signature, what touches it?" — surfaces all the functions an agent needs to update, prioritised by depth (direct first) and PageRank (most-central first).
+
+**`params`**:
+```jsonc
+{
+  "name":               "build_index",   // required, exact match
+  "depth":              2,                // optional; BFS depth cap (1..=4). Default 2.
+  "token_budget":       4096,             // optional; standard §16 50..=200000 window. Default 4096.
+  "max_nodes":          200,              // optional; max distinct caller entries (1..=10000). Default 200.
+  "exclude_test_paths": true              // optional; filter callers in test-shaped files. Default true.
+}
+```
+
+**`result`**:
+```jsonc
+{
+  "impact": [
+    {
+      "qualified_name":   "rts_core::cli::run",
+      "kind":             "fn",
+      "file":             "src/cli.rs",
+      "range": {                          // the *caller's def* range (not the call site)
+        "start_byte": 4400, "end_byte": 5200,
+        "start_line": 138,  "end_line":  160
+      },
+      "depth":      1,                    // 1-based BFS depth (direct callers = 1)
+      "rank_score": 0.012                 // symbol-level PageRank of the caller (alpha.34+)
+    }
+  ],
+  "closure_truncated":    false,          // token budget exhausted while BFS still had entries
+  "wall_clock_truncated": false,          // 50ms wall-clock cap fired
+  "depth_truncated":      false,          // at least one frontier hit max_depth with unvisited callers
+  "node_count_truncated": false,          // max_nodes cap fired
+  "tokens_returned":      1247,
+  "token_counter":        "bytes_div_3"
+}
+```
+
+Result is sorted by `(depth ASC, rank_score DESC, file ASC, start_byte ASC)` — direct callers first, then most-central callers within each depth tier, then deterministic tiebreakers. The four truncation flags are independent so agents can tell *why* the result is partial.
+
+**Wire-shape trim** (per [v0.3 plan Deepening §F3](plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md)): the original 9-field per-entry shape was trimmed to 6 — `signature` and nested `callers[]` arrays were YAGNI'd. Agents who need a caller's signature follow up with `read_symbol(name=qualified_name, shape="signature")`; agents who need *that* caller's callers follow up with `find_callers` or another `impact_of`.
+
+Errors: `INDEX_NOT_READY`, `SYMBOL_NOT_FOUND` (mirrors `Index.FindCallers`), `BUDGET_TOO_SMALL`/`BUDGET_TOO_LARGE` per §16, `INVALID_PARAMS` (`name` empty or >256 chars).
+
+**When to use vs related methods:**
+- Use `find_callers` for depth-1 only (cheaper, more focused).
+- Use `impact_of` when you're about to refactor a public function and want the whole blast radius.
+- `exclude_test_paths: true` (default) skips callers in `/tests/`, `_test.rs`, `.spec.ts` etc. — the single biggest noise reducer for refactor flows. Pass `false` when deciding which tests to update.
 
 ### 7.8 `Index.ReadRange`
 
@@ -1022,6 +1077,26 @@ These are normative for `params` validation. The daemon SHOULD reject schema-non
 }
 ```
 
+### 18.4d `Index.ImpactOf.params`
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "name":               { "type": "string", "minLength": 1, "maxLength": 256 },
+    "depth":              { "type": "integer", "minimum": 1, "maximum": 4 },
+    "token_budget":       { "type": "integer", "minimum": 50, "maximum": 200000 },
+    "max_nodes":          { "type": "integer", "minimum": 1, "maximum": 10000 },
+    "exclude_test_paths": { "type": "boolean", "default": true }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}
+```
+
+Out-of-window `depth` / `max_nodes` values are clamped (not rejected) — daemons running an older alpha won't `INVALID_PARAMS` on a request that targets a tighter future window.
+
 ### 18.4b `Index.ReadSymbolAt.params`
 
 ```json
@@ -1253,10 +1328,11 @@ This appendix tracks every additive wire-shape change between Draft 1 (P5 delive
 | `alpha.32` | `find_callers`, `read_symbol.include_callers` | **v0.3 U2'**: new method `Index.FindCallers(name, kind?, file?)` returns direct callers. `Index.ReadSymbol.params.include_callers: bool` composes callers into the existing response with a separate `callers_truncated` flag. | §7.7, §7.7c, §18.4, §18.4b, §18.4c |
 | `alpha.33` | (none — internal) | **v0.3 U3**: `closure::compute` swaps from at-query-time tree-sitter parsing to reading `SID_REFS_OUT`. Same wire shape; faster cold calls. Also fixed a latent local-variable bug in U1's `enclosing_caller_sid` that under-populated `SID_REFS_OUT`. | — |
 | `alpha.34` | `pagerank_symbolwise` | **v0.3 U4**: symbol-level PageRank fills `rank_score` in `Index.FindSymbol` and `Index.FindCallers` responses (was a `0.0` placeholder). `Index.FindSymbol.matches[]` sorts by descending rank by default; `sort: "lexical"` opts out. Single-slot generation-keyed cache mirroring `OutlineCache` (alpha.20). | §4.1, §4.2, §7.6, §18.3 |
+| `alpha.35` | `impact_of` | **v0.3 U5** (final): new method `Index.ImpactOf(name, depth?, token_budget?, max_nodes?, exclude_test_paths?)` returns the transitive caller closure via BFS over reverse edges. Four independent truncation flags (`closure_truncated`, `wall_clock_truncated`, `depth_truncated`, `node_count_truncated`) tell the agent why a result is partial. Test-path exclusion (`/tests/`, `_test.rs`, `.spec.ts`) is on by default. Wire shape trimmed from the plan's 9 fields to 6 per Deepening §F3 (no `signature`, no nested `callers[]`). | §4.1, §4.2, §7, §7.7d, §18.4d |
 
-Capability strings present in `Daemon.Ping.result.capabilities` after alpha.34 (canonical list, in advertisement order): `outline`, `find_symbol`, `read_symbol`, `read_range`, `rank_score`, `tree_shake`, `partial_responses`, `content_version`, `secrets_blocklist`, `pagerank_filewise`, `closure_walker`, `read_symbol_at`, `fuzzy_match`, `polling_fallback`, `find_callers`, `read_symbol.include_callers`, `pagerank_symbolwise`.
+Capability strings present in `Daemon.Ping.result.capabilities` after alpha.35 (canonical list, in advertisement order): `outline`, `find_symbol`, `read_symbol`, `read_range`, `rank_score`, `tree_shake`, `partial_responses`, `content_version`, `secrets_blocklist`, `pagerank_filewise`, `closure_walker`, `read_symbol_at`, `fuzzy_match`, `polling_fallback`, `find_callers`, `read_symbol.include_callers`, `pagerank_symbolwise`, `impact_of`.
 
-**Pending v0.3** (reserved in §4.2, not advertised at alpha.34): `impact_of` (U5).
+**v0.3 plan complete:** all four code-graph KB capability strings (`find_callers`, `read_symbol.include_callers`, `pagerank_symbolwise`, `impact_of`) advertised. The `call_graph` umbrella reserved string remains unused — agents branch on the four fine-grained strings instead.
 
 ### How to extend protocol-v0 in a future alpha
 


### PR DESCRIPTION
## Summary

The **last** v0.3 plan unit ships. BFS over the reverse reference graph (`REFS`/`SID_REFS_OUT`) returns every function that directly or indirectly calls a target symbol, bounded by depth (default 2, max 4), token budget, node count (default 200), and a 50ms wall-clock cap. Four independent truncation flags tell agents *why* a result is partial. Test-path exclusion is on by default per [Deepening §E](https://github.com/njfio/rs-agent-code-utility/blob/main/docs/plans/2026-05-13-001-feat-v0.3-code-graph-kb-plan.md).

🎉 **v0.3 plan complete** — all six implementation units (U0 docs re-spec → U1 schema → U2' direct callers → U3 closure swap → U4 PageRank → U5 ImpactOf) have shipped between alpha.31 and alpha.35.

## New: `crate::impact` module

- BFS over `REFS` reverse edges starting from the anchor sid
- Cycle break via `HashSet<sid>`; mutual recursion handled correctly
- Sorts entries by `(depth ASC, rank_score DESC, file, byte)` per Deepening §E
- `is_test_path` heuristic for `/tests/`, `_test.<ext>`, `.spec.<ext>`, `__tests__/`, etc.
- Bounds are **clamped** (not rejected) so old clients don't get `INVALID_PARAMS` when defaults tighten

## Wire shape (trimmed per Deepening §F3)

```jsonc
{
  "impact": [
    { "qualified_name": "rts_core::cli::run", "kind": "fn",
      "file": "src/cli.rs",
      "range": { "start_byte": 4400, "end_byte": 5200,
                 "start_line": 138, "end_line": 160 },
      "depth": 1, "rank_score": 0.012 }
  ],
  "closure_truncated":    false,  // token budget exhausted
  "wall_clock_truncated": false,  // 50ms cap fired
  "depth_truncated":      false,  // frontier hit max_depth with unvisited callers
  "node_count_truncated": false,  // max_nodes cap fired
  "tokens_returned":      1247,
  "token_counter":        "bytes_div_3"
}
```

Original plan §Phase 6 had a 9-field per-entry shape with `signature` and nested `callers[]` arrays — Deepening §F3 trimmed both. Agents who need a caller's signature follow up with `read_symbol(name, shape="signature")` per interesting entry. Saves ~60% of per-entry token cost; clean upgrade path if a future agent integration actually asks.

## Surface changes

### Daemon

- New handler `methods/index.rs::impact_of` (~80 LOC). Validates params, looks up anchor sid, delegates BFS to `spawn_blocking` (CPU-bound), formats the response.
- New `Index.ImpactOf` dispatch entry in `methods/mod.rs`.
- `Daemon.Ping` advertises `impact_of` (canonical capability list 17 → 18).

### MCP

- New `impact_of` tool with **explicit when-to-use** prose: depth-1 → `find_callers`; depth-N → `impact_of`; include test callers → `exclude_test_paths: false`. Truncation flags documented for each "why is my result partial" scenario.

### Bench

- New `query impact-of` CLI subcommand with `--name --depth --token-budget --max-nodes --include-tests`.
- New `--direct-callers <name,name,...>` arg for the scenario task.
- **New `task scenario_refactor_impact`**: alpha.24-style scenario. Baseline = `rg + read` × 2 levels of recursion (target then each direct caller). MCP = one `impact_of` call. Plan §G2 target: ≥ 70 % token reduction.

### Protocol

- §4.1 advertises `impact_of`; §4.2 marks all four v0.3 capability strings as advertised (last one!).
- §7 method catalog: 12 → 13 methods + 1 notification.
- **New §7.7d** documents `Index.ImpactOf` with full params, result, errors, when-to-use, and wire-shape trim rationale.
- **New §18.4d** JSON Schema for the params.
- Architecture diagram: 6 → 7 MCP tools.
- Appendix F: alpha.35 row + "v0.3 plan complete" note.

## v0.3 plan: status active → completed

The plan file frontmatter now carries `status: completed`, `completed_date: 2026-05-14`, the five `shipped_in` alphas, and the seven PR numbers. All seven R1-R7 functional requirements and five G1-G5 quality gates are ticked, each with a citation to the alpha that shipped it and the relevant test that pins behavior.

## Verification

- `cargo build --workspace`: green.
- `cargo test --workspace`: **550 passed, 0 failed** (was 544 in alpha.34; +6 = 5 unit + 1 integration).
- `cargo fmt --all --check`: clean.
- `cargo clippy --workspace --all-targets`: no new warnings on changed files.

### New tests

| | What |
|---|---|
| Unit | `impact::empty_result_is_clean` |
| Unit | `impact::bounds_clamp_to_safe_window` — verifies depth/max_nodes/budget clamping |
| Unit | `impact::is_test_path_matches_common_conventions` — pins the heuristic against `tests/`, `__tests__/`, `_test.rs`, `.spec.ts`, etc.; also pins the negative cases (`contestant.rs`, `protest_handler.rs`) |
| Unit | `impact::to_wire_value_has_trimmed_shape` — confirms `signature` and `callers[]` are absent (Deepening §F3 trim) |
| Unit | `impact::empty_workspace_returns_empty_impact` |
| Integration | `impact_of_three_tier_with_test_filter` — three-tier fixture (3 direct + 2 indirect + 1 test caller); asserts (a) capability advertised, (b) default filters test, (c) `exclude_test_paths=false` includes it, (d) `depth=1` excludes grandcallers + sets `depth_truncated`, (e) unknown name → `SYMBOL_NOT_FOUND` |

## Post-Deploy Monitoring & Validation

- **What to monitor**: `Index.ImpactOf` latency. Plan G2 fires on the synthetic `scenario_refactor_impact` fixture; real-world hub-symbol queries are bounded by the 50ms wall-clock cap, with `wall_clock_truncated: true` surfaced if the bound fires. `Daemon.Ping.capabilities` now contains all 18 strings.
- **Validation**: `cargo test --workspace` → 550/0. `rts-bench task run scenario_refactor_impact --workspace <repo> --symbol <X> --direct-callers <a,b,...>` should show ≥ 70 % token reduction.
- **Healthy signals**: `impact_of(name)` warm calls complete in single-digit ms for typical fn signatures. Hub symbols (≥ 50 transitive callers) trip `node_count_truncated` first; agents respond by raising `max_nodes` if they can tolerate the noise.
- **Failure / rollback**: any existing integration test failing → rollback to alpha.34. `impact_of` consistently hitting `wall_clock_truncated` on small fixtures → BFS has a bug; investigate before next rollout.

## v0.3 status

After this merges:

- ✓ **U0 (alpha.31, docs)** — `protocol-v0.md` re-spec at alpha.30 baseline
- ✓ **U1 (alpha.31, schema)** — persistent ref graph + SCHEMA_VERSION 1→2
- ✓ **U2' (alpha.32, direct callers)** — `Index.FindCallers` + `include_callers`
- ✓ **U3 (alpha.33, closure swap)** — `closure::compute` reads indexed `SID_REFS_OUT`
- ✓ **U4 (alpha.34, PageRank)** — symbol-level PageRank fills `rank_score`
- ✓ **U5 (alpha.35, this PR)** — `Index.ImpactOf` + `scenario_refactor_impact`

All four v0.3 wire-capability strings (`find_callers`, `read_symbol.include_callers`, `pagerank_symbolwise`, `impact_of`) advertised. **v0.3.0 release tag is unblocked** — recommend cutting it after a brief soak.

## Related

- v0.3 plan §Phase 6 / Deepening §E (bounds + test exclusion) / §F3 (wire-shape trim) / §G2 (bench gate)
- Prereqs: [#29 (U1)](https://github.com/njfio/rs-agent-code-utility/pull/29), [#30 (U2')](https://github.com/njfio/rs-agent-code-utility/pull/30), [#32 (U3)](https://github.com/njfio/rs-agent-code-utility/pull/32), [#33 (U4)](https://github.com/njfio/rs-agent-code-utility/pull/33)

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.5 (1M context) via [Claude Code](https://claude.com/claude-code)