### PR TITLE
chore(polish): WORKSPACE_MISMATCH error code + G4 limitation docs (pre-v0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,56 @@ including the four v0.3 ones (`find_callers`, `impact_of`,
 `read_symbol.include_callers`, `pagerank_symbolwise`) — are documented
 in [docs/protocol-v0.md](docs/protocol-v0.md) §4.1 + Appendix F.
 
+## Known limitations
+
+### The PageRank graph is over *call* edges, not *type* edges
+
+v0.3's symbol-level PageRank ranks symbols by how often they're called
+(via tree-sitter's `@reference.call` capture and friends). It does
+**not** rank symbols by how often they appear in type positions
+(function signatures, struct fields, generic bounds, trait impls).
+Per the v0.3 plan's Scope Boundaries, type-relationship edges are
+deferred to v0.4+.
+
+**Consequence:** running `find_symbol(pattern="*")` on a type-heavy
+library (parser, type-system tool, trait-heavy abstraction) surfaces
+utility functions and tree-sitter wrappers in the top-K, not the
+library's "domain types." On `crates/rts-core` itself, the top-20
+includes `find_nodes_by_kind`, `child_by_field_name`, `children`,
+etc. — all genuinely call-central — but **not** `CodebaseAnalyzer`,
+`Parser`, `Language` (which are types referenced from type positions
+across the workspace, not call targets).
+
+For workspaces dominated by call patterns (web apps, services, CLI
+tools), the top-K closely matches "what's central in this codebase."
+For type-heavy libraries, the top-K is "what's the busiest helper
+machinery" — useful but not the same answer.
+
+### Rust prelude artifacts at the top of the rank
+
+On Rust workspaces, `Ok` and `Some` reliably appear near the top of
+`find_symbol(pattern="*")`. They're the AST-visible variant
+constructors in `Result::Ok(x)` and `Option::Some(x)`, which
+tree-sitter's `call_expression` pattern captures as call-shaped. They
+*are* genuinely high-fan-in (every function that returns a Result
+"calls" `Ok` to construct one), so the algorithm is correct.
+Filtering them at PageRank node-set construction would be language-
+specific noise reduction; v0.4+ candidate.
+
+### Single workspace per daemon process
+
+`rts-daemon` is workspace-pinned (protocol-v0 §5.5). Cross-repo
+queries require multiple daemon processes — one per workspace hash —
+each on its own socket. `rts-mcp` auto-spawns the right one given
+a workspace path; agents wiring multiple repos need multiple
+`claude mcp add rts-foo --workspace /foo/path` entries.
+
+### Windows is not yet supported
+
+The daemon uses Unix sockets. A Windows port using named pipes is on
+the v1.x candidate list — search "Windows" in
+[docs/protocol-v0.md](docs/protocol-v0.md) for the design sketch.
+
 ## Crate layout
 
 ```

--- a/crates/rts-daemon/src/error.rs
+++ b/crates/rts-daemon/src/error.rs
@@ -23,8 +23,19 @@ pub enum ErrorCode {
     InvalidWorkspacePath,
     /// A component of the mounted path was a symlink (security: refuse-symlink rule).
     MountHasSymlink,
-    /// `(dev, inode)` of the workspace path changed since the last mount.
+    /// `(dev, inode)` of the workspace path changed since the last mount
+    /// (symlink swap detected, mount move, dir replaced). Per
+    /// protocol-v0 §5.2 + §14.
     WorkspaceVanished,
+    /// A second `Workspace.Mount` from the same connection asked for a
+    /// different canonical path than the daemon is already pinned to.
+    /// Distinct from `WorkspaceVanished` (which is about a single
+    /// workspace whose underlying inode changed). Operator action:
+    /// either re-use the existing daemon for its pinned workspace, or
+    /// connect a fresh daemon process (sockets are per-workspace per
+    /// protocol-v0 §5.3, so this happens automatically when the path
+    /// hash differs).
+    WorkspaceMismatch,
     /// Path resolves to an NFS / SMB / fuse mount (unsupported in v0).
     WorkspaceOnNetworkMount,
     /// Path resolved outside the mounted workspace root.
@@ -73,6 +84,7 @@ impl ErrorCode {
             ErrorCode::InvalidWorkspacePath => "INVALID_WORKSPACE_PATH",
             ErrorCode::MountHasSymlink => "MOUNT_HAS_SYMLINK",
             ErrorCode::WorkspaceVanished => "WORKSPACE_VANISHED",
+            ErrorCode::WorkspaceMismatch => "WORKSPACE_MISMATCH",
             ErrorCode::WorkspaceOnNetworkMount => "WORKSPACE_ON_NETWORK_MOUNT",
             ErrorCode::OutOfRoot => "OUT_OF_ROOT",
             ErrorCode::PathTraversal => "PATH_TRAVERSAL",

--- a/crates/rts-daemon/src/methods/workspace.rs
+++ b/crates/rts-daemon/src/methods/workspace.rs
@@ -55,8 +55,11 @@ pub async fn mount(
             }
             Ok(_other) => {
                 return Err(ProtocolError::new(
-                    ErrorCode::WorkspaceVanished,
-                    "daemon is pinned to a different workspace; mount a fresh daemon for another path",
+                    ErrorCode::WorkspaceMismatch,
+                    "daemon is already pinned to a different workspace on this socket. \
+                     Per protocol-v0 §5.3 the socket path is per-workspace-hash; \
+                     connect via the correct socket, or start a fresh daemon for the \
+                     other workspace (auto-spawn handles this for new paths).",
                 ));
             }
             Err(e) => return Err(e),

--- a/docs/protocol-v0.md
+++ b/docs/protocol-v0.md
@@ -359,7 +359,7 @@ Establish (or join) the workspace this connection will operate on.
 }
 ```
 
-Errors: `INVALID_WORKSPACE_PATH`, `MOUNT_HAS_SYMLINK`, `WORKSPACE_VANISHED`, `WORKSPACE_ON_NETWORK_MOUNT`, `OUT_OF_ROOT` (if the path resolves outside the daemon's filesystem), `STORAGE_FULL` (if `${XDG_STATE_HOME}/rts/` is unwritable).
+Errors: `INVALID_WORKSPACE_PATH`, `MOUNT_HAS_SYMLINK`, `WORKSPACE_VANISHED`, **`WORKSPACE_MISMATCH`** (alpha.36+), `WORKSPACE_ON_NETWORK_MOUNT`, `OUT_OF_ROOT` (if the path resolves outside the daemon's filesystem), `STORAGE_FULL` (if `${XDG_STATE_HOME}/rts/` is unwritable).
 
 After `Workspace.Mount` returns, the connection is bound to that workspace; subsequent `Index.*` calls operate on it. A connection MUST `Mount` exactly once.
 
@@ -866,7 +866,8 @@ All errors use string codes (not JSON-RPC numeric codes — easier to grep, more
 | `INVALID_PARAMS` | params object failed schema validation | No (without param fix) |
 | `INVALID_WORKSPACE_PATH` | non-UTF-8 / non-existent / non-canonicalisable path | No |
 | `MOUNT_HAS_SYMLINK` | any path component was a symlink | No (resolve outside, pass canonical) |
-| `WORKSPACE_VANISHED` | `(dev, inode)` mismatch on remount | No |
+| `WORKSPACE_VANISHED` | `(dev, inode)` mismatch on remount — symlink swap, mount move, or dir replaced under the daemon | No (workspace went away) |
+| `WORKSPACE_MISMATCH` (alpha.36+) | second `Workspace.Mount` from the same connection asked for a different canonical path than this daemon is already pinned to. Use a fresh daemon socket for the other path (auto-spawn handles this if the path hash differs) | No (connect via the correct socket) |
 | `WORKSPACE_ON_NETWORK_MOUNT` | path is on NFS/SMB/etc. | No |
 | `OUT_OF_ROOT` | path resolved outside the mounted workspace | No |
 | `PATH_TRAVERSAL` | `..` segment in a client-provided path | No |


### PR DESCRIPTION
## Summary

Two pre-v0.3.0 polish items surfaced during the post-merge bench run ([#36](https://github.com/njfio/rs-agent-code-utility/pull/36)):

### 1. `WORKSPACE_MISMATCH` — split the overloaded `WORKSPACE_VANISHED` code

Per protocol-v0 §5.2, `WORKSPACE_VANISHED` is for the `(dev, inode)` symlink-swap case (workspace's underlying inode changed). But `methods/workspace.rs:58` was reusing it for "you connected to a daemon already pinned to a *different* workspace" — a genuinely different condition with a different operator action.

During the bench run, a leftover daemon on the default socket returned `WORKSPACE_VANISHED` for a fresh mount attempt on a different path. That's misleading: the workspace was fine; the daemon was just pinned elsewhere.

**Fix:** New `ErrorCode::WorkspaceMismatch` → `"WORKSPACE_MISMATCH"` wire string. `methods/workspace.rs` now uses it. The error message prose explains the real cause + the actionable fix ("connect via the correct socket, or auto-spawn a fresh daemon for the other workspace"). protocol-v0 §7.2 + §14 document the split.

Additive change — existing v0.2 clients ignore unknown error codes per §14, so no break.

### 2. G4 honest limitation docs in README

The post-merge G4 measurement showed the algorithm working correctly but the plan's expectation (`CodebaseAnalyzer`/`Parser`/`Language` in top-20) didn't materialize — those are types used in type positions; the v0.3 graph is over call edges (per Scope Boundary "type-relationship edges deferred to v0.4+"). On Rust workspaces, `Ok`/`Some` also reliably surface at the top because variant constructors parse as `call_expression`.

Added a "Known limitations" section to README documenting:
- PageRank is over call edges, not type edges
- `Ok`/`Some` artifact for Rust workspaces
- Single-workspace-per-daemon (existing limitation; worth restating)
- No Windows yet (existing limitation)

This makes the algorithm's scope obvious *before* someone runs `find_symbol(pattern="*")` on a type-heavy library and concludes the tool is broken.

## Verification

- `cargo test --workspace`: 550 passed, 0 failed (no behavior change; just adds an error variant)
- `cargo fmt --all --check`: clean
- `cargo clippy --workspace --all-targets`: no new warnings

## Diff size

71 insertions, 5 deletions across 4 files (error.rs, methods/workspace.rs, README.md, protocol-v0.md). No new tests added — the error code is a string change tested transitively by existing wire tests.

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required: error-code split is purely additive on the wire (existing clients ignore unknown codes); README change is docs-only.`

## Related

- [#36](https://github.com/njfio/rs-agent-code-utility/pull/36) — the post-merge bench run that surfaced both issues

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.5 (1M context) via [Claude Code](https://claude.com/claude-code)