### PR TITLE
feat(rts-bench): G5 deps-mode + honest bench-validity finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### G5 measurement infrastructure — `rts-bench latency --deps`
+
+New `--deps` flag on `rts-bench latency` switches the 30 % `read_symbol`
+bucket from `shape=signature` (historical default) to `shape=body,
+include_dependencies=true`. This is the only mix that exercises the
+v0.3 U3 closure walker; without it, the read_symbol bucket measures
+just the signature renderer + redb lookup, not the parse-vs-multimap
+change that G5 was specified against.
+
+The new `LatencyReport.read_symbol_mode` field records `"signature"`
+or `"body_with_deps"` so a downstream reader (or future bench-trend
+tool) can tell which mix produced a given JSON report.
+
+Tests:
+
+- `read_symbol_mode_as_str_is_stable` — on-wire string contract
+- `report_records_read_symbol_mode` — round-trips through serde
+
+This was filed as a v0.3.1 follow-up in the v0.3.0 release notes; it
+makes spec-faithful G5 measurement possible. **Note: G5 itself is not
+yet ✅ — see the bench-validity finding below for why the side-by-side
+numbers I collected this session are not yet reliable.**
+
+### Honest dogfooding finding — `rts-bench latency` read_symbol .ok rate
+
+While running `rts-bench latency --deps` against both v0.3 and a tag-
+built alpha.30 daemon (worktree at `v0.2.0-alpha.30`), I observed
+that **the read_symbol bucket has a 48/281 (≈17 %) success rate** on
+both binaries with the same seed. The other buckets are 444/444
+(`find_symbol`) and ~175/175 (`outline`).
+
+This is **not** new in v0.3 or in this PR's `--deps` flag — verified
+by inspecting the pre-existing `bench-latency-*.json` reports in
+`/tmp/g5-signature-bench.json` (signature mode, no `--deps`): same
+48/281 .ok rate. Re-running with `--deps` just made the pattern
+visible, because deps-mode read_symbols are slower (genuine work
+when they succeed) so the latency mix wasn't dominated by fast error
+responses.
+
+**Implication:** Every `read_symbol` percentile in the published
+G1/G5 numbers is computed over **a mix of 17 % real responses and
+83 % error responses** (`SYMBOL_NOT_FOUND` returns in microseconds).
+The headline "find_symbol warm p95 = 2.7 ms ✅" is correct
+(`find_symbol` is fully OK), but the read_symbol p99 deltas
+attributed to "v0.3 closure walker improvement" in the v0.3.0
+release notes are not what we thought they were — they're partly
+"how fast does each binary return SYMBOL_NOT_FOUND," not "how fast
+does the closure walker run."
+
+**Root cause hypothesis:** the latency bench's cold probe
+(`tools_call("find_symbol", probe_name, 30)` at
+`crates/rts-bench/src/main.rs:704`) waits only for the probe
+symbol's def to be indexed, not for the full 100k-LOC walk to
+complete. Subsequent warm queries pick random symbols from a 16,929-
+symbol pool; many of those symbols still aren't indexed when the
+query runs. For the synthetic fixture specifically, the failure
+pattern is correlated with file ordering (`synth_f0_*` ranks return
+empty; high-numbered file ranks like `synth_f1238_*` succeed). This
+is a fixture/walker race, not a daemon correctness bug — the daemon
+correctly returns `SYMBOL_NOT_FOUND` for sids it hasn't seen yet.
+
+**Action filed for v0.3.2:** before claiming G5 ✅, fix the cold
+probe to wait for **full** walk completion (e.g., poll
+`Workspace.Status.progress.files_done == files_total`), then re-run
+the side-by-side with the new `--deps` mix. The infrastructure for
+the measurement is now in place; what's missing is a reliable cold
+gate.
+
+**What this means for existing published G-numbers:**
+
+- **G1 (find_symbol warm p95)** ✅ — unaffected, find_symbol is 444/444 OK
+- **G2 (refactor token reduction)** ✅ — unaffected, measured on real
+  `rts-core` workspace via `task run scenario_refactor_impact`, not the synth latency mix
+- **G3 (first-mount on 100k LOC)** ✅ — unaffected, measured by
+  `rts-bench footprint`, not the latency mix
+- **G4 (PageRank top-K)** ✅ on Rust (post the prelude filter shipped above)
+- **G5 (closure-walker speedup)** 🟡 still — the prior "structural improvement
+  verified" claim stands (the `closure_round_trip` test passes); the absolute
+  speedup vs alpha.30 awaits the cold-probe fix above
+
 ### G4 noise reduction — Rust prelude filter
 
 Filter `Ok`, `Err`, `Some`, `None` from the PageRank node-set in

--- a/crates/rts-bench/src/latency.rs
+++ b/crates/rts-bench/src/latency.rs
@@ -129,16 +129,53 @@ impl Lcg {
     }
 }
 
+/// Read-symbol mode for the bench mix.
+///
+/// `Signature` calls `read_symbol` with `shape: "signature"` and no
+/// dependency walk — the historical bench default, exercises only the
+/// signature renderer + redb lookup.
+///
+/// `BodyWithDeps` calls `read_symbol` with `shape: "body"` and
+/// `include_dependencies: true` — the only path that exercises v0.3
+/// U3's closure walker (the alpha.30 → v0.3 change replaced the
+/// per-call parse + filter loop with one `SID_REFS_OUT` multimap
+/// read). G5's spec-faithful p95 measurement requires this mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadSymbolMode {
+    Signature,
+    BodyWithDeps,
+}
+
+impl ReadSymbolMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReadSymbolMode::Signature => "signature",
+            ReadSymbolMode::BodyWithDeps => "body_with_deps",
+        }
+    }
+}
+
 /// Run the latency benchmark. Returns one `Sample` per executed query.
+///
+/// `read_symbol_mode` controls how the 30% read_symbol bucket is
+/// executed. `Signature` is the historical default; `BodyWithDeps`
+/// exercises v0.3 U3's closure walker for G5 measurement.
 pub async fn run(
     session: &mut McpSession,
     symbols: &[String],
     files: &[String],
     queries: u32,
     seed: u64,
+    read_symbol_mode: ReadSymbolMode,
 ) -> Result<Vec<Sample>> {
     let mut rng = Lcg::new(seed);
     let mut out: Vec<Sample> = Vec::with_capacity(queries as usize);
+    let read_args = match read_symbol_mode {
+        ReadSymbolMode::Signature => json!({ "shape": "signature" }),
+        ReadSymbolMode::BodyWithDeps => {
+            json!({ "shape": "body", "include_dependencies": true })
+        }
+    };
     for _ in 0..queries {
         let kind = *rng.pick_weighted(QueryKind::MIX);
         let sample = match kind {
@@ -148,13 +185,12 @@ pub async fn run(
             }
             QueryKind::ReadSymbol => {
                 let name = &symbols[rng.pick_index(symbols.len())];
-                time_call(
-                    session,
-                    kind,
-                    "read_symbol",
-                    json!({ "name": name, "shape": "signature" }),
-                )
-                .await?
+                // Merge the per-call name onto the per-mode template.
+                let mut args = read_args.clone();
+                if let Value::Object(ref mut m) = args {
+                    m.insert("name".to_string(), Value::String(name.clone()));
+                }
+                time_call(session, kind, "read_symbol", args).await?
             }
             QueryKind::Outline => {
                 time_call(
@@ -210,6 +246,13 @@ pub struct LatencyReport {
     pub queries: u32,
     pub cold_count: u32,
     pub seed: u64,
+    /// Which `read_symbol` shape the 30% bucket exercised. Either
+    /// `"signature"` (historical default) or `"body_with_deps"` (G5
+    /// closure-walker mode). Stable on-the-wire field; older reports
+    /// pre-v0.3.1 will deserialise with this `None` and downstream
+    /// tools should treat that as `"signature"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub read_symbol_mode: Option<String>,
     /// Per-kind stats over warm samples (excludes the cold prefix).
     pub warm: IndexMap<String, KindStats>,
     /// Per-kind stats over the cold prefix.
@@ -261,6 +304,7 @@ pub fn build_report(
     synth_loc: usize,
     seed: u64,
     cold_count: u32,
+    read_symbol_mode: ReadSymbolMode,
     samples: &[Sample],
 ) -> LatencyReport {
     let queries = samples.len() as u32;
@@ -302,6 +346,7 @@ pub fn build_report(
         queries,
         cold_count,
         seed,
+        read_symbol_mode: Some(read_symbol_mode.as_str().to_string()),
         warm: warm_map,
         cold: cold_map,
         warm_all,
@@ -415,6 +460,39 @@ mod tests {
         );
         assert_eq!(stats.p99_micros, 99);
         assert_eq!(stats.max_micros, 100);
+    }
+
+    #[test]
+    fn read_symbol_mode_as_str_is_stable() {
+        // The string is on-the-wire in the JSON report. Don't change
+        // these without bumping the report version.
+        assert_eq!(ReadSymbolMode::Signature.as_str(), "signature");
+        assert_eq!(ReadSymbolMode::BodyWithDeps.as_str(), "body_with_deps");
+    }
+
+    #[test]
+    fn report_records_read_symbol_mode() {
+        // Build a tiny report and check the mode appears in the JSON.
+        let samples = vec![Sample {
+            kind: QueryKind::ReadSymbol,
+            elapsed_micros: 1234,
+            ok: true,
+        }];
+        let report = build_report(
+            Path::new("/tmp/synth"),
+            1_000,
+            42,
+            0,
+            ReadSymbolMode::BodyWithDeps,
+            &samples,
+        );
+        assert_eq!(
+            report.read_symbol_mode.as_deref(),
+            Some("body_with_deps"),
+            "G5 deps-mode runs must record body_with_deps in the JSON report"
+        );
+        let json = serde_json::to_value(&report).unwrap();
+        assert_eq!(json["read_symbol_mode"], "body_with_deps");
     }
 
     #[test]

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -71,6 +71,13 @@ enum Cmd {
         /// seed.
         #[arg(long, default_value_t = 0xC0FFEE_u64)]
         seed: u64,
+        /// Exercise the v0.3 U3 closure walker in the 30% read_symbol
+        /// bucket — sends `shape=body, include_dependencies=true`
+        /// instead of `shape=signature`. Required for the G5 spec
+        /// (closure-walker p95 ≥ 50 % faster than alpha.30); off by
+        /// default to preserve historical mix.
+        #[arg(long)]
+        deps: bool,
         /// Where to write the JSON report.
         #[arg(long)]
         out: Option<PathBuf>,
@@ -355,9 +362,10 @@ async fn main() -> Result<()> {
             queries,
             cold_count,
             seed,
+            deps,
             out,
             dry_run,
-        } => run_latency(synth_loc, queries, cold_count, seed, out, dry_run).await,
+        } => run_latency(synth_loc, queries, cold_count, seed, deps, out, dry_run).await,
         Cmd::Footprint {
             synth_loc,
             out,
@@ -666,9 +674,15 @@ async fn run_latency(
     queries: u32,
     cold_count: u32,
     seed: u64,
+    deps: bool,
     out: Option<PathBuf>,
     dry_run: bool,
 ) -> Result<()> {
+    let read_symbol_mode = if deps {
+        latency::ReadSymbolMode::BodyWithDeps
+    } else {
+        latency::ReadSymbolMode::Signature
+    };
     let rts_mcp_bin = resolve_bin("rts-mcp")?;
     let rts_daemon_bin = resolve_bin("rts-daemon")?;
 
@@ -706,18 +720,34 @@ async fn run_latency(
         .await?;
 
     println!(
-        "latency: workspace={} files={} symbols={} queries={} cold_count={}",
+        "latency: workspace={} files={} symbols={} queries={} cold_count={} read_symbol_mode={}",
         workspace.display(),
         files.len(),
         symbols.len(),
         queries,
         cold_count,
+        read_symbol_mode.as_str(),
     );
 
-    let samples = latency::run(&mut session, &symbols, &files, queries, seed).await?;
+    let samples = latency::run(
+        &mut session,
+        &symbols,
+        &files,
+        queries,
+        seed,
+        read_symbol_mode,
+    )
+    .await?;
     session.close().await?;
 
-    let report = latency::build_report(&workspace, synth_loc, seed, cold_count, &samples);
+    let report = latency::build_report(
+        &workspace,
+        synth_loc,
+        seed,
+        cold_count,
+        read_symbol_mode,
+        &samples,
+    );
     println!(
         "warm p50={}µs p95={}µs p99={}µs max={}µs (n={})",
         report.warm_all.p50_micros,


### PR DESCRIPTION
## Summary

Add `--deps` flag to `rts-bench latency` that switches the 30 % `read_symbol` bucket from `shape=signature` to `shape=body, include_dependencies=true`. This is the only mix that exercises the v0.3 U3 closure walker; the historical default measures the signature renderer + redb lookup, not the parse-vs-multimap change G5 was specified against.

Records `read_symbol_mode` in the JSON `LatencyReport` so downstream readers can tell which mix produced a given run. Two unit tests pin the on-wire string and serde round-trip.

This was filed as v0.3.1 follow-up #1 in the v0.3.0 release notes. **This ships the infrastructure; the absolute speedup vs alpha.30 awaits a separate cold-probe fix — see honest dogfooding finding below.**

## Honest dogfooding finding (not what I expected)

While running the side-by-side `--deps` bench against both v0.3 (this branch's main) and a tag-built alpha.30 daemon, I observed that **the `read_symbol` bucket has a 48/281 (≈17 %) success rate** on both binaries with the same seed. The other buckets are 444/444 (`find_symbol`) and ~175/175 (`outline`).

This is **not** new in v0.3 or in this PR — verified by inspecting pre-existing signature-mode bench reports: same 48/281 .ok rate. The new `--deps` flag did not cause it; it merely made the pattern visible, because deps-mode `read_symbol` calls are slower when they succeed and so the latency mix is no longer dominated by fast `SYMBOL_NOT_FOUND` error responses.

**Implication:** every `read_symbol` percentile in the published G5 prose is computed over a mix of 17 % real responses and 83 % `SYMBOL_NOT_FOUND` error responses (which return in microseconds). The headline `find_symbol` numbers are unaffected (444/444 OK), and G2/G3 are measured by other code paths (`task run` and `footprint`). G5 is the one that needs the cold-probe fix before its absolute speedup-vs-alpha.30 number can be claimed.

**Root cause hypothesis:** the latency bench's cold probe at `crates/rts-bench/src/main.rs:704` waits only for the probe symbol's def to be indexed, not for the full 100k-LOC walk to complete. Subsequent warm queries pick random symbols from a 16,929-symbol pool; many aren't indexed yet when the query runs. For the synthetic fixture specifically, the failure pattern is correlated with file ordering (`synth_f0_*` ranks return empty; high-numbered file ranks like `synth_f1238_*` succeed). This is a fixture/walker race, not a daemon correctness bug — the daemon correctly returns `SYMBOL_NOT_FOUND` for sids it hasn't seen yet.

**Action filed for v0.3.2:** gate warm queries on `Workspace.Status.progress.files_done == files_total` (or equivalent), then re-run the side-by-side. The infrastructure for the measurement is now in place; what's missing is a reliable cold gate.

## What this means for the existing published G-numbers

- **G1** (find_symbol warm p95 = 2.7 ms) ✅ — unaffected, find_symbol is 444/444 OK
- **G2** (refactor token reduction = 97.5 %) ✅ — measured on real `crates/rts-core` via `task run scenario_refactor_impact`, not the synth latency mix
- **G3** (first-mount on 100k LOC = 902 ms) ✅ — measured by `rts-bench footprint`, not the latency mix
- **G4** (PageRank top-K) ✅ on Rust workspaces post the prelude filter merged in #40
- **G5** (closure-walker speedup) 🟡 still — the prior "structural improvement verified" claim stands (the `closure_round_trip` integration test passes); the absolute speedup vs alpha.30 awaits the cold-probe fix above

## Why this PR is still worth landing now

The dogfooding finding is a v0.3.2 follow-up I can't fix without first knowing it exists — and I couldn't see it without `--deps` exposing the pattern. So this PR:

1. Ships the infrastructure (G5 measurement enabler — v0.3.1 follow-up #1, now resolved)
2. Documents the bench-validity finding for the next reader
3. Updates the CHANGELOG with the honest framing (instead of claiming G5 ✅ with sketchy numbers)

Future me, picking up the cold-probe fix, will have a clean platform to validate the actual v0.3 closure-walker improvement.

## Test plan

- [x] `cargo build --workspace --release` clean
- [x] `cargo test -p rts-bench` → 32 unit + 7 integration pass; +2 new tests (`read_symbol_mode_as_str_is_stable`, `report_records_read_symbol_mode`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p rts-bench` — only pre-existing dead_code warnings, none from this PR
- [x] Manual verify: `./target/release/rts-bench latency --synth-loc 100000 --queries 1000 --deps --out /tmp/g5-v0.3-clean.json` runs cleanly; JSON includes `"read_symbol_mode": "body_with_deps"`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is purely a developer-tool bench harness change. Affects only the `rts-bench latency` subcommand when `--deps` is explicitly passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.5, 1M context, extended thinking) + Compound Engineering v2.49.0