### PR TITLE
fix(rts-bench): cold gate + .ok-only percentiles (bench validity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,74 @@ makes spec-faithful G5 measurement possible. **Note: G5 itself is not
 yet ✅ — see the bench-validity finding below for why the side-by-side
 numbers I collected this session are not yet reliable.**
 
+### `rts-bench latency` — cold gate + `.ok`-only percentiles (bench validity fix)
+
+The post-session-2026-05-14 follow-up on the read_symbol .ok-rate
+finding. Two bench-side changes:
+
+1. **Cold gate replaced.** The pre-existing single-symbol probe
+   (`find_symbol(symbols[0]).await`) only proved one symbol was
+   indexed before the warm run started — the walker could still be
+   mid-walk. New gate polls `outline_workspace.files_considered`
+   every 200 ms and waits for two consecutive stable rounds (same
+   signal `rts-bench footprint` uses for `full_index_time_ms`).
+2. **Percentiles compute over `.ok` samples only.** The pre-existing
+   `stats_of` included error responses (mostly fast `SYMBOL_NOT_FOUND`
+   returns) in the percentile distribution, silently dragging p50/p95
+   downward. `count` still reports attempted; `ok` reports successful;
+   `p50/p95/p99/max/mean` now describe successful responses only.
+
+New regression test `percentiles_exclude_errored_samples` pins the
+new invariant: a mix of four 1–4 ms real responses and four
+microsecond errors must report p50=2 ms (over the real subset), not
+~15 µs (the pre-fix value).
+
+#### What spec-faithful G5 looks like with both fixes applied
+
+Side-by-side `rts-bench latency --synth-loc 100000 --queries 5000
+--cold-count 500 --deps --seed 12648430` against v0.3 (this commit's
+parent merge `c08f665`) and a tag-built `v0.2.0-alpha.30` daemon
+worktree (217 successful samples each, deterministic):
+
+| Bucket | v0.3 | alpha.30 | Δ |
+|---|---:|---:|---|
+| `read_symbol` p50 | 1403 µs | 798 µs | **v0.3 is 1.76× slower** |
+| `read_symbol` p95 | 2553 µs | 1018 µs | **v0.3 is 2.51× slower** |
+| `read_symbol` p99 | 5095 µs | 1141 µs | **v0.3 is 4.47× slower** |
+
+**G5 conclusion: spec target not met on this synth fixture.** The
+plan target was "closure-walker cold p95 ≥ 50 % faster than
+alpha.30 (1000-file real Rust workspace)." The structural fix is
+real (the parse + filter loop in alpha.30's read_symbol is replaced
+by one `SID_REFS_OUT` multimap read in v0.3), but on the synth
+fixture's 3-line function bodies the parse cost it replaced is so
+small that v0.3's other per-call additions (rank_score lookup,
+content_version computation, expanded response payload) net
+*slower*. Honest read: **G5 stays 🟡 with a regression risk noted**
+for v0.3.2 to investigate.
+
+The spec said "real Rust workspace, not synth"; this synth fixture
+may simply be the wrong instrument for G5. A 100-file real-Rust
+workspace with 20–50 line function bodies would shift the
+comparison: alpha.30's per-call parse cost grows linearly in body
+size, v0.3's stays constant. At some body size, v0.3 wins. Filed:
+extend `rts-bench latency` to accept `--workspace <path>` for real
+fixtures (currently v1.1, see `prepare_workspace`).
+
+#### Daemon-side walker plateau (separate v0.3.2 bug surfaced)
+
+While running this measurement I observed that
+`outline_workspace.files_considered` plateaus at **256 files** on
+the 1539-file 100k-LOC synth fixture, on **both** v0.3 and alpha.30.
+That's why the read_symbol bucket reports `ok ≈ 17 %` (≈ 256/1539
+files indexed → ≈ 17 % of random symbol picks land in an indexed
+file). Identical plateau on both binaries means the comparison
+above is fair (same input distribution on both sides), but
+**something in the writer or notify chain stops processing files
+after the first 256 on workspaces this size**. The G3 footprint
+number (`full_index = 1.4 s` on 100k LOC) describes time-to-plateau,
+not time-to-fully-indexed. Filed as a separate v0.3.2 daemon bug.
+
 ### Honest dogfooding finding — `rts-bench latency` read_symbol .ok rate
 
 While running `rts-bench latency --deps` against both v0.3 and a tag-

--- a/crates/rts-bench/src/latency.rs
+++ b/crates/rts-bench/src/latency.rs
@@ -312,17 +312,30 @@ pub fn build_report(
     let warm = &samples[(cold_count as usize).min(samples.len())..];
 
     let by_kind = |bucket: &[Sample], kind: QueryKind| -> KindStats {
+        // Percentiles describe response latency — they only make sense
+        // over successful responses. Including error responses (e.g.
+        // `SYMBOL_NOT_FOUND` returns in microseconds) silently drags
+        // p50/p95/p99 downward and corrupts comparisons. The CHANGELOG
+        // entry "Honest dogfooding finding — read_symbol .ok rate"
+        // documents how this masked a real bench-validity issue.
+        //
+        // `count` still reflects the total attempted, and `ok` reports
+        // how many of those succeeded. A caller seeing `ok` << `count`
+        // knows the per-bucket numbers describe a small sub-sample,
+        // not a corrupted mix.
         let mut bucket_samples: Vec<u128> = bucket
             .iter()
-            .filter(|s| matches!((s.kind, kind), (a, b) if a.as_str() == b.as_str()))
+            .filter(|s| s.kind.as_str() == kind.as_str() && s.ok)
             .map(|s| s.elapsed_micros)
             .collect();
-        let mut stats = stats_of(&mut bucket_samples);
-        let ok = bucket
+        let attempted = bucket
             .iter()
-            .filter(|s| s.kind.as_str() == kind.as_str() && s.ok)
+            .filter(|s| s.kind.as_str() == kind.as_str())
             .count() as u32;
-        stats.ok = ok;
+        let mut stats = stats_of(&mut bucket_samples);
+        stats.count = attempted;
+        // `stats_of` set `stats.ok = bucket_samples.len()` already;
+        // that's exactly the count of successful samples in this bucket.
         stats
     };
 
@@ -334,9 +347,16 @@ pub fn build_report(
         cold_map.insert(key, by_kind(cold, *kind));
     }
 
-    let mut all_warm: Vec<u128> = warm.iter().map(|s| s.elapsed_micros).collect();
+    // Same .ok-only invariant for the aggregate: warm_all percentiles
+    // describe successful warm responses, not a mix of real responses
+    // and fast errors.
+    let mut all_warm: Vec<u128> = warm
+        .iter()
+        .filter(|s| s.ok)
+        .map(|s| s.elapsed_micros)
+        .collect();
     let mut warm_all = stats_of(&mut all_warm);
-    warm_all.ok = warm.iter().filter(|s| s.ok).count() as u32;
+    warm_all.count = warm.len() as u32;
 
     LatencyReport {
         version: 1,
@@ -468,6 +488,55 @@ mod tests {
         // these without bumping the report version.
         assert_eq!(ReadSymbolMode::Signature.as_str(), "signature");
         assert_eq!(ReadSymbolMode::BodyWithDeps.as_str(), "body_with_deps");
+    }
+
+    #[test]
+    fn percentiles_exclude_errored_samples() {
+        // Eight samples, four genuine (1, 2, 3, 4 ms) and four
+        // microsecond-fast errors (the SYMBOL_NOT_FOUND shape). The
+        // pre-fix code computed percentiles over all eight and
+        // reported a p50 around 500 µs — completely fictional.
+        // Post-fix, percentiles describe only the four real responses.
+        let real = [1_000u128, 2_000, 3_000, 4_000];
+        let errs = [10u128, 12, 15, 20];
+        let samples: Vec<Sample> = real
+            .iter()
+            .map(|&us| Sample {
+                kind: QueryKind::ReadSymbol,
+                elapsed_micros: us,
+                ok: true,
+            })
+            .chain(errs.iter().map(|&us| Sample {
+                kind: QueryKind::ReadSymbol,
+                elapsed_micros: us,
+                ok: false,
+            }))
+            .collect();
+        let report = build_report(
+            Path::new("/tmp/synth"),
+            1_000,
+            42,
+            0, // no cold prefix — all eight are "warm"
+            ReadSymbolMode::BodyWithDeps,
+            &samples,
+        );
+        let rs = report.warm.get("read_symbol").unwrap();
+        assert_eq!(rs.count, 8, "count reports attempted samples");
+        assert_eq!(rs.ok, 4, "ok reports successful samples");
+        // p50 over [1000, 2000, 3000, 4000] = 2000 (nearest-rank: idx
+        // ceil(0.5*4)-1 = 1, value 2000). Pre-fix this was ~15 (the
+        // median of all eight).
+        assert_eq!(
+            rs.p50_micros, 2_000,
+            "p50 should describe real responses (2 ms), not be diluted \
+             by SYMBOL_NOT_FOUND errors"
+        );
+        // p95 over [1000..=4000] = 4000 (idx ceil(0.95*4)-1 = 3).
+        assert_eq!(rs.p95_micros, 4_000);
+        // warm_all aggregate also follows the .ok-only rule.
+        assert_eq!(report.warm_all.count, 8);
+        assert_eq!(report.warm_all.ok, 4);
+        assert_eq!(report.warm_all.p50_micros, 2_000);
     }
 
     #[test]

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -710,14 +710,14 @@ async fn run_latency(
         crate::mcp_runner::McpSession::spawn(&rts_mcp_bin, &rts_daemon_bin, &workspace, &extra_env)
             .await?;
 
-    // Wait for the writer to commit at least one symbol (initial walk
-    // completed). `tools_call`'s retry loop handles INDEX_NOT_READY,
-    // so a single call here is enough — when it returns the index is
-    // hot enough to query.
-    let probe = &symbols[0];
-    let _ = session
-        .tools_call("find_symbol", serde_json::json!({ "name": probe }), 30)
-        .await?;
+    // Cold gate: wait until the writer's initial walk plateaus on
+    // `outline_workspace.files_considered`. Matches the signal
+    // `rts-bench footprint` uses for `full_index_time_ms`. The
+    // previous single-symbol probe only proved ONE symbol was
+    // indexed; subsequent random warm picks could (and did) hit
+    // `SYMBOL_NOT_FOUND` and silently drag the measured p95 downward.
+    // See CHANGELOG `[Unreleased]` for the discovery writeup.
+    cold_gate_wait_for_walk_settled(&mut session).await?;
 
     println!(
         "latency: workspace={} files={} symbols={} queries={} cold_count={} read_symbol_mode={}",
@@ -775,6 +775,77 @@ async fn run_latency(
     latency::write_report(&out_path, &report)?;
     println!("wrote {}", out_path.display());
     Ok(())
+}
+
+/// Poll interval for the cold gate. Indexing is bursty (writer drains
+/// in 200 ms batches per protocol-v0 §15.6), so polling tighter than
+/// this wastes daemon CPU on hot-loop calls.
+const COLD_GATE_POLL_MS: u64 = 200;
+
+/// Hard ceiling on the cold-gate wait. Indexing 100k LOC finishes
+/// in ~1.4 s per `rts-bench footprint`, so 60 s is ample headroom.
+const COLD_GATE_TIMEOUT_SECS: u64 = 60;
+
+/// Wait for the writer to settle on its initial walk. Uses the same
+/// stability signal as `rts-bench footprint`: poll
+/// `outline_workspace.files_considered` every 200 ms and return when
+/// two consecutive rounds report the same non-zero count.
+///
+/// **Why this matters for measurement validity.** The pre-existing
+/// single-symbol cold probe at this site (find_symbol on
+/// `symbols[0]`) only proved that ONE symbol was indexed — the
+/// walker could still be mid-walk when warm queries began, and
+/// subsequent random picks would hit `SYMBOL_NOT_FOUND` (a
+/// microsecond-fast error response) that silently dragged the
+/// measured p50/p95 downward. The session-2026-05-14 dogfooding
+/// writeup in the CHANGELOG documents the discovery.
+///
+/// The matching change in `latency::build_report` computes
+/// percentiles over `.ok` samples only, so even if the writer races
+/// the bench on a pathological workspace, the latency stats reported
+/// describe real responses rather than a mix of real responses + fast
+/// errors.
+async fn cold_gate_wait_for_walk_settled(
+    session: &mut crate::mcp_runner::McpSession,
+) -> Result<()> {
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(COLD_GATE_TIMEOUT_SECS);
+    let mut last_seen: i64 = -1;
+    let mut round = 0u32;
+    loop {
+        round += 1;
+        let call = session
+            .tools_call(
+                "outline_workspace",
+                serde_json::json!({ "token_budget": 256 }),
+                30,
+            )
+            .await?;
+        let files_considered = if call.is_error {
+            -1
+        } else {
+            call.result_body
+                .as_ref()
+                .and_then(|v| v.get("files_considered").and_then(|x| x.as_i64()))
+                .unwrap_or(-1)
+        };
+        if files_considered > 0 && files_considered == last_seen {
+            eprintln!("cold gate: walk settled at {files_considered} files (round {round})");
+            return Ok(());
+        }
+        last_seen = files_considered;
+        if std::time::Instant::now() >= deadline {
+            eprintln!(
+                "cold gate: timed out at {COLD_GATE_TIMEOUT_SECS}s, last \
+                 files_considered={files_considered}. Continuing anyway — the \
+                 latency report's per-bucket `.ok` count will show whether the \
+                 warm queries hit real symbols. (See CHANGELOG entry for the \
+                 walk-truncation bug surfaced in session-2026-05-14.)"
+            );
+            return Ok(());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(COLD_GATE_POLL_MS)).await;
+    }
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Summary

Post-PR-#41 follow-up on the read_symbol .ok-rate finding. Two bench-side correctness fixes:

1. **Cold gate replaced.** The pre-existing single-symbol probe (`find_symbol(symbols[0])`) only proved one symbol was indexed before the warm run started — the walker could still be mid-walk. New gate polls `outline_workspace.files_considered` every 200 ms and waits for two consecutive stable rounds (same signal `rts-bench footprint` uses).

2. **Percentiles compute over `.ok` samples only.** The pre-existing `stats_of` included error responses (mostly fast `SYMBOL_NOT_FOUND`) in the distribution, silently dragging p50/p95 downward. `count` still reports attempted; `ok` reports successful; `p50/p95/p99/max/mean` now describe successful responses only.

New regression test `percentiles_exclude_errored_samples` pins the invariant: four 1–4 ms real samples + four microsecond errors must report p50 = 2 ms (over the real subset), not ~15 µs (the pre-fix value).

## Spec-faithful G5 measurement

Now that the bench reports honest numbers, here's the side-by-side: `--synth-loc 100000 --queries 5000 --cold-count 500 --deps --seed 12648430`, 217 successful read_symbol samples each side, against v0.3 (current `main`) and a tag-built `v0.2.0-alpha.30` daemon worktree:

| Bucket | v0.3 | alpha.30 | Δ |
|---|---:|---:|---|
| `read_symbol` p50 | 1403 µs | 798 µs | **v0.3 is 1.76× slower** |
| `read_symbol` p95 | 2553 µs | 1018 µs | **v0.3 is 2.51× slower** |
| `read_symbol` p99 | 5095 µs | 1141 µs | **v0.3 is 4.47× slower** |

**G5 spec target not met on this synth fixture.** The plan target was "closure-walker cold p95 ≥ 50 % faster than alpha.30." The structural fix is real (one `SID_REFS_OUT` multimap read in v0.3 replaces alpha.30's parse + filter loop in `read_symbol`), but on the synth's 3-line function bodies the parse cost it replaced is so small that v0.3's other per-call additions (rank_score lookup, content_version computation, expanded response payload) net **slower**.

**G5 stays 🟡** with a regression-risk note for v0.3.2 to investigate. The spec said "real Rust workspace," not synth — synth bodies may simply be the wrong instrument. Extending `rts-bench latency` to accept `--workspace <path>` for real fixtures (currently v1.1) is the natural v0.3.2 follow-up.

## Separate v0.3.2 daemon bug surfaced

While running this measurement, `outline_workspace.files_considered` plateaus at **256 files** on the 1539-file 100k-LOC synth, on **both** v0.3 and alpha.30. That's why the `.ok` rate sits around 17 % (≈ 256/1539 → 17 % of random picks land in an indexed file). Both binaries hit the plateau identically so the comparison above is fair, but **something in the writer or notify chain stops processing files after the first ~256** on workspaces this size. The published G3 `full_index = 1.4 s` describes time-to-plateau, not time-to-fully-indexed.

Filed as a separate v0.3.2 daemon bug.

## Why this PR is the right shape

It's tempting to chase G5 ✅ — but the honest measurement shows the spec target isn't met on this fixture, and faking the comparison (e.g. running on a tiny workspace that fits entirely in the plateau) would just produce another misleading number. The right move is:

1. Ship the bench-validity fixes (these are unambiguously correct)
2. Document the honest finding (v0.3 isn't faster than alpha.30 on synth read_symbol)
3. File the daemon plateau separately
4. Defer the G5 ✅ until real-workspace bench support exists

## Test plan

- [x] `cargo build --workspace --release` clean
- [x] `cargo test -p rts-bench` → 33 unit + 8 integration pass; +1 new test
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p rts-bench` — only pre-existing dead_code warning, none from this PR
- [x] Manual reproducibility: v0.3 read_symbol p95 stable at 1.84–2.55 ms across runs with `--queries 1000` and `--queries 5000`; alpha.30 stable at ~1.0 ms

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: pure developer-tool bench-harness change. Affects only `rts-bench latency` output (correctness, not behavior of the production daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.5, 1M context, extended thinking) + Compound Engineering v2.49.0