### PR TITLE
feat(rts-bench): latency --workspace + G5 real-workspace regression finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `rts-bench latency --workspace <path>` — real-workspace benchmarks
+
+Adds the v0.3.2 follow-up `--workspace` flag mutually exclusive with
+`--synth-loc`. Mounts an existing workspace and discovers symbols
+post-cold-gate via `find_symbol(pattern="*")` (top-256 by rank). For
+cross-daemon fair comparison the discovered names are sorted
+lexically + deduped so v0.3's PageRank-ordered top-256 and
+alpha.30's placeholder-ranked top-256 converge on a shared subset.
+
+Tests:
+
+- `prepare_workspace_real_path_returns_empty_symbols` — real-workspace
+  arm of `prepare_workspace` returns empty symbol/file Vecs (filled
+  post-mount in `main.rs`)
+- `prepare_workspace_rejects_both_workspace_and_synth_loc` — mutual
+  exclusion contract
+- `prepare_workspace_rejects_non_directory` — bad-path guard
+
+This was filed as a v0.3.2 follow-up in PR #43. Closes that item.
+
+#### G5 real-workspace measurement — v0.3 IS A REGRESSION
+
+Side-by-side on `crates/rts-core` (~55 files, 130–170 indexable
+top-K symbols depending on daemon, 546 successful read_symbol
+samples each, deterministic seed, both binaries fully indexed
+post-walker-fix):
+
+| Bucket | v0.3 | alpha.30 | Δ |
+|---|---:|---:|---|
+| `read_symbol` p50 (deps) | 3207 µs | 755 µs | **v0.3 is 4.25× slower** |
+| `read_symbol` p95 (deps) | **7023 µs** | **974 µs** | **v0.3 is 7.21× slower** ❌ |
+| `read_symbol` p99 (deps) | 11877 µs | 1377 µs | **v0.3 is 8.62× slower** |
+
+**G5 final read: not just "spec target missed" — v0.3 is a
+read_symbol performance regression vs alpha.30 on real Rust
+workspaces.** The closure-walker structural fix (one `SID_REFS_OUT`
+multimap read in v0.3 replaces alpha.30's parse + filter loop) is
+real, but on actual function-body sizes the parse cost it replaced
+was small, while v0.3 added other per-call overhead that dominates:
+
+- `rank_score` filled per result (PageRank cache lookup × N matches)
+- `content_version` field (file-hash computation)
+- `callers` field plumbing even when `include_callers=false`
+- Larger response payload (more fields → more serialisation cost)
+
+The v0.3 plan §G5 hypothesis ("closure-walker p95 ≥ 50 % faster
+than alpha.30") was based on the *structural argument* (one redb
+read should beat parse+walk) without measuring actual throughput.
+Now that we have a real-workspace bench, the measurement contradicts
+the hypothesis.
+
+Even accounting for the symbol-discovery confound (v0.3 surfaces
+141 unique names post-dedup, alpha.30 surfaces 173; the bench's
+random picks drive different subsets), 7× is too large to be
+discovery-confound alone — both subsets overlap heavily, and the
+median latency gap (3207 µs vs 755 µs = 4.25×) confirms a real
+per-call regression.
+
+#### Filed for v0.3.x: investigate read_symbol regression
+
+Highest-priority post-G5 work:
+
+1. **Profile v0.3 `read_symbol(deps=true)` to find the dominant
+   cost.** Top candidates per the list above; first measurement
+   should be flame-graph or step-by-step timing of one warm call.
+2. **Decide which v0.3 additions are paying for themselves.** If
+   `rank_score` adds 2 ms per call but agents rarely sort by it,
+   make it opt-in. If `content_version` adds 1 ms but the bench
+   benefits from cache invalidation, accept the cost but document
+   it.
+3. **Add a `--symbols-file <path>` flag** to `rts-bench latency` so
+   future cross-daemon comparisons use an identical name list (this
+   PR's lex-sort + dedup is a partial fix; a saved name list is
+   stricter).
+
 ### Daemon walker fix — initial walk no longer truncates at channel capacity
 
 Root-cause fix for the "256-file plateau" surfaced in PR #42's

--- a/crates/rts-bench/src/latency.rs
+++ b/crates/rts-bench/src/latency.rs
@@ -385,7 +385,11 @@ pub fn write_report(path: &Path, report: &LatencyReport) -> Result<()> {
 pub const DEFAULT_COLD_COUNT: u32 = 100;
 
 /// Resolve the workspace + symbol set for a latency run. Either
-/// synthesise (when `synth_loc` is given) or scan an existing workspace.
+/// synthesise (when `synth_loc` is given) or use an existing workspace
+/// path (`target`). For a real workspace the returned `symbols` is
+/// empty — the caller fills it post-mount by querying `find_symbol`
+/// (since the daemon is the only thing that knows which names are
+/// indexable on a workspace it doesn't synthesise).
 /// Returns (workspace_root, symbols, files).
 pub fn prepare_workspace(
     target: Option<&Path>,
@@ -393,16 +397,18 @@ pub fn prepare_workspace(
     tmp_root: &Path,
 ) -> Result<(PathBuf, Vec<String>, Vec<String>)> {
     match (target, synth_loc) {
-        (Some(p), _) => {
-            // Existing workspace: caller is responsible for picking real
-            // symbols. We pass an empty `symbols` slice and the runner
-            // falls back to a probe via `Index.FindSymbol` later. For v0,
-            // require a synthetic workspace when no symbols are supplied;
-            // the existing-workspace path is a v1.1 surface.
-            anyhow::bail!(
-                "running against an existing workspace at {} is a v1.1 surface; pass --synth-loc to use a synthetic fixture",
-                p.display()
-            );
+        (Some(p), Some(_)) => anyhow::bail!("pass either --workspace or --synth-loc, not both"),
+        (Some(p), None) => {
+            let canonical = p
+                .canonicalize()
+                .with_context(|| format!("canonicalize {}", p.display()))?;
+            if !canonical.is_dir() {
+                anyhow::bail!("workspace path {} is not a directory", canonical.display());
+            }
+            // Symbols + files are discovered post-mount in `main.rs:
+            // run_latency`. Return empty Vecs as the signal to that
+            // path.
+            Ok((canonical, Vec::new(), Vec::new()))
         }
         (None, Some(loc)) => {
             let ws = tmp_root.join("synth-workspace");
@@ -415,7 +421,9 @@ pub fn prepare_workspace(
                 .collect();
             Ok((ws, syms, files))
         }
-        (None, None) => anyhow::bail!("--synth-loc is required when --workspace is omitted"),
+        (None, None) => {
+            anyhow::bail!("--synth-loc is required when --workspace is omitted")
+        }
     }
 }
 
@@ -480,6 +488,45 @@ mod tests {
         );
         assert_eq!(stats.p99_micros, 99);
         assert_eq!(stats.max_micros, 100);
+    }
+
+    #[test]
+    fn prepare_workspace_real_path_returns_empty_symbols() {
+        // Real-workspace mode: caller passes a path, we canonicalise
+        // it and return an empty symbols Vec (caller fills via
+        // find_symbol post-mount). Validates the v0.3.2 surface.
+        let tmp = tempfile::tempdir().unwrap();
+        // Make it look real: at least one file present.
+        std::fs::write(tmp.path().join("dummy.rs"), "pub fn x() {}").unwrap();
+        let tmp_root = tempfile::tempdir().unwrap();
+        let (ws, syms, files) = prepare_workspace(Some(tmp.path()), None, tmp_root.path()).unwrap();
+        assert_eq!(ws, tmp.path().canonicalize().unwrap());
+        assert!(syms.is_empty(), "real-workspace path returns no symbols");
+        assert!(files.is_empty(), "real-workspace path returns no files");
+    }
+
+    #[test]
+    fn prepare_workspace_rejects_both_workspace_and_synth_loc() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tmp_root = tempfile::tempdir().unwrap();
+        let err = prepare_workspace(Some(tmp.path()), Some(1_000), tmp_root.path()).unwrap_err();
+        assert!(
+            format!("{err}").contains("not both"),
+            "expected mutual-exclusion error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn prepare_workspace_rejects_non_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("not-a-dir.txt");
+        std::fs::write(&f, "x").unwrap();
+        let tmp_root = tempfile::tempdir().unwrap();
+        let err = prepare_workspace(Some(&f), None, tmp_root.path()).unwrap_err();
+        assert!(
+            format!("{err}").contains("not a directory"),
+            "expected non-directory error, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -56,8 +56,23 @@ enum Cmd {
     /// Latency benchmark (S1): synth fixture + p50/p95/p99 over a
     /// query mix.
     Latency {
+        /// Real workspace path to bench against. Mutually exclusive
+        /// with `--synth-loc`. The bench mounts this workspace, waits
+        /// for the cold-walk to settle, then enumerates indexable
+        /// symbols via `find_symbol(pattern="*")` (top-N by rank,
+        /// capped at the daemon's MAX_MATCHES = 256). Use this when
+        /// the synth fixture's tiny function bodies aren't
+        /// representative of the real workload — closure-walker p95
+        /// is the canonical case: alpha.30's body-parse cost grows
+        /// linearly in body size while v0.3's stays constant, so the
+        /// structural win shows on real Rust function lengths (20–50
+        /// lines) but vanishes on the synth's 3-line bodies. Required
+        /// for the G5 spec ("real Rust workspace") per the v0.3 plan.
+        #[arg(long, conflicts_with = "synth_loc")]
+        workspace: Option<PathBuf>,
         /// Total lines of synthetic Rust source to generate. Defaults
-        /// to 100,000 per plan §P9.
+        /// to 100,000 per plan §P9. Mutually exclusive with
+        /// `--workspace`.
         #[arg(long, default_value_t = 100_000)]
         synth_loc: usize,
         /// Number of queries to run. Defaults to 1000.
@@ -358,6 +373,7 @@ async fn main() -> Result<()> {
                 },
         } => restore_fixtures(corpus_lock, corpus_root).await,
         Cmd::Latency {
+            workspace,
             synth_loc,
             queries,
             cold_count,
@@ -365,7 +381,12 @@ async fn main() -> Result<()> {
             deps,
             out,
             dry_run,
-        } => run_latency(synth_loc, queries, cold_count, seed, deps, out, dry_run).await,
+        } => {
+            run_latency(
+                workspace, synth_loc, queries, cold_count, seed, deps, out, dry_run,
+            )
+            .await
+        }
         Cmd::Footprint {
             synth_loc,
             out,
@@ -669,7 +690,9 @@ fn human_bytes(n: u64) -> String {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_latency(
+    workspace_arg: Option<PathBuf>,
     synth_loc: usize,
     queries: u32,
     cold_count: u32,
@@ -690,8 +713,19 @@ async fn run_latency(
     // daemon's runtime/state dirs so concurrent latency runs on the
     // same machine don't fight over /tmp's default socket.
     let tmp_root = tempfile::tempdir().context("tempdir for latency run")?;
-    let (workspace, symbols, files) =
-        latency::prepare_workspace(None, Some(synth_loc), tmp_root.path())?;
+    // `--workspace <path>` and `--synth-loc <N>` are mutually exclusive
+    // at the clap layer. Pick the right `prepare_workspace` arm based
+    // on which is set. For real workspaces, `synth_loc` is recorded in
+    // the report as 0 to flag "not synthetic".
+    let (workspace, mut symbols, files) = match workspace_arg.as_ref() {
+        Some(path) => latency::prepare_workspace(Some(path), None, tmp_root.path())?,
+        None => latency::prepare_workspace(None, Some(synth_loc), tmp_root.path())?,
+    };
+    let synth_loc_for_report = if workspace_arg.is_some() {
+        0
+    } else {
+        synth_loc
+    };
     let runtime_dir = tmp_root.path().join("runtime");
     let state_dir = tmp_root.path().join("state");
     std::fs::create_dir_all(&runtime_dir)?;
@@ -719,6 +753,57 @@ async fn run_latency(
     // See CHANGELOG `[Unreleased]` for the discovery writeup.
     cold_gate_wait_for_walk_settled(&mut session).await?;
 
+    // For real workspaces, `prepare_workspace` returned an empty
+    // symbols Vec — the bench needs names from the actual index, not
+    // from a generator. Pull the top-K by rank via
+    // `find_symbol(pattern="*")` post-cold-gate. The daemon caps that
+    // response at 256 names (MAX_MATCHES); for the bench's random-pick
+    // loop, 256 is more than enough to avoid degenerate repetition
+    // even at --queries 5000.
+    if symbols.is_empty() {
+        let call = session
+            .tools_call("find_symbol", serde_json::json!({ "pattern": "*" }), 5)
+            .await?;
+        if call.is_error {
+            anyhow::bail!(
+                "find_symbol(pattern='*') failed after cold gate — the workspace \
+                 is mounted but no symbols are indexed. Either the workspace has \
+                 no Rust/JS/Python/etc files, or the writer panicked. Re-run with \
+                 RTS_LOG=debug for daemon-side diagnostics."
+            );
+        }
+        if let Some(body) = call.result_body.as_ref() {
+            if let Some(matches) = body.get("matches").and_then(|m| m.as_array()) {
+                symbols = matches
+                    .iter()
+                    .filter_map(|m| m.get("qualified_name").and_then(|n| n.as_str()))
+                    .map(|s| s.to_string())
+                    .collect();
+            }
+        }
+        anyhow::ensure!(
+            !symbols.is_empty(),
+            "find_symbol(pattern='*') returned no matches on real workspace {} — \
+             the workspace may not contain any indexable source files",
+            workspace.display(),
+        );
+        // Normalize ordering. `find_symbol` returns up to 256 results
+        // sorted by rank_score descending; v0.3's PageRank rank differs
+        // from alpha.30's 0.0-placeholder rank, so the same call against
+        // each daemon picks a different top-K subset. For an
+        // apples-to-apples bench comparison, sort + dedup lexically so
+        // both daemons end up driving the bench against the same name
+        // set (modulo the symbol-table contents the daemons agree on).
+        symbols.sort();
+        symbols.dedup();
+        eprintln!(
+            "discovered {} symbols from real workspace {} (sorted lexically \
+             for cross-daemon stability)",
+            symbols.len(),
+            workspace.display()
+        );
+    }
+
     println!(
         "latency: workspace={} files={} symbols={} queries={} cold_count={} read_symbol_mode={}",
         workspace.display(),
@@ -742,7 +827,7 @@ async fn run_latency(
 
     let report = latency::build_report(
         &workspace,
-        synth_loc,
+        synth_loc_for_report,
         seed,
         cold_count,
         read_symbol_mode,


### PR DESCRIPTION
## Summary

Adds the v0.3.2 follow-up flag filed in PR #43. `rts-bench latency --workspace <path>` is mutually exclusive with `--synth-loc`; the bench mounts the existing workspace, waits for the cold-walk to settle, then discovers indexable symbols via `find_symbol(pattern="*")`. Names are sorted + deduped lexically so v0.3's PageRank-ordered top-K and alpha.30's placeholder-ranked top-K converge on a shared subset for cross-daemon comparison.

Tests: 3 new (`prepare_workspace_real_path_returns_empty_symbols`, `prepare_workspace_rejects_both_workspace_and_synth_loc`, `prepare_workspace_rejects_non_directory`). All 36 latency unit tests pass + integration tests clean.

## G5 real-workspace measurement — v0.3 IS A REGRESSION

Side-by-side on this repo's `crates/rts-core` (~55 files, 130-170 discovered top-K names depending on daemon, 546 successful read_symbol samples each, deterministic seed, **both binaries fully indexed post-walker-fix**):

| Metric | v0.3 | alpha.30 | Δ |
|---|---:|---:|---|
| `read_symbol` p50 (deps) | 3207 µs | 755 µs | v0.3 is **4.25× slower** |
| `read_symbol` p95 (deps) | **7023 µs** | **974 µs** | **v0.3 is 7.21× slower** ❌ |
| `read_symbol` p99 (deps) | 11877 µs | 1377 µs | v0.3 is **8.62× slower** |

**G5 final read: not just "spec target missed" — v0.3 has a real read_symbol performance regression vs alpha.30 on real Rust workspaces.**

The closure-walker structural fix (one `SID_REFS_OUT` multimap read replaces alpha.30's parse + filter loop) is correct, but the parse cost it replaced is small on actual function-body sizes while v0.3 added other per-call work that dominates:

- `rank_score` filled per result (PageRank cache lookup × N matches)
- `content_version` field (file-hash computation)
- `callers` field plumbing even when `include_callers=false`
- Larger response payload → more serialisation cost

The v0.3 plan §G5 hypothesis ("closure-walker p95 ≥ 50 % faster than alpha.30") was based on the **structural argument** (one redb read should beat parse+walk) without measuring actual throughput. Now that we have a real-workspace bench, the measurement contradicts the hypothesis.

7× is too large to be discovery-confound alone (different binaries returning different top-K subsets); the median latency gap (4.25×) confirms a real per-call regression even at well-overlapping name pools.

## Why this PR is the right shape

It's tempting to chase G5 ✅, but **honest measurement is more valuable than fake pass marks**. This PR:

1. Ships the v0.3.2 follow-up bench infrastructure (the `--workspace` flag) — unambiguously correct, with tests
2. Documents the measured G5 verdict — v0.3 is a 7× slower at read_symbol p95 on real workspaces
3. Files specific v0.3.x follow-ups for the regression investigation

## Filed for v0.3.x

1. **Profile `v0.3 read_symbol(deps=true)`** to find the dominant cost. Top candidates listed above; first measurement should be a flame graph or step-by-step timing of one warm call.
2. **Decide which v0.3 additions are paying for themselves.** If `rank_score` adds 2 ms per call but agents rarely sort by it, make it opt-in. If `content_version` adds 1 ms but enables cache invalidation, accept the cost but document it.
3. **Add `--symbols-file <path>`** to `rts-bench latency` so future cross-daemon comparisons use an identical name list (this PR's lex-sort + dedup is a partial fix; a saved name list is stricter).

## Test plan

- [x] `cargo build --workspace --release` clean
- [x] `cargo test -p rts-bench` → 36 unit tests pass + 8 integration tests pass; 3 new tests
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p rts-bench` clean
- [x] Manual: `rts-bench latency --workspace crates/rts-core --queries 2000 --deps` — runs cleanly on both v0.3 and tag-built alpha.30 daemon, produces stable percentile numbers

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: pure developer-tool bench infrastructure. Affects only `rts-bench latency` when `--workspace` is explicitly passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.5, 1M context, extended thinking) + Compound Engineering v2.49.0