### PR TITLE
perf(rts-daemon): remove spawn_blocking from read_symbol closure walk (-21% p95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Read-symbol perf — remove `spawn_blocking` from closure walk (additional 21% p95 win)
+
+Follow-up to the content_version + signature caches. With those in,
+profiling showed `closure_walk` was still spending ~50-100 µs per
+call on `tokio::task::spawn_blocking` overhead (thread pool handoff
++ `JoinHandle` setup + `await`). On the warm bench path, that's
+pure overhead — the underlying work (redb reads + occasional
+`std::fs::read` + tree-sitter renders) doesn't block long enough
+to justify moving off the runtime.
+
+**Change:** `read_symbol`'s closure walk now calls
+`crate::closure::compute` synchronously instead of through
+`spawn_blocking`. The caller (`read_symbol`'s `dispatch` task) is
+already its own per-connection tokio task — blocking here doesn't
+starve the runtime, it just stops one in-flight request from
+yielding mid-walk.
+
+**Trade-off accepted:** a true cold-disk read on the first call
+for a file could in principle block the runtime worker. In practice:
+
+- The file cache + the OS page cache + the signature cache keep
+  cold reads rare
+- The daemon's other concurrent work (writer task) runs on its own
+  tokio task and doesn't share this scheduler frame
+- 21% p95 win across all warm calls outweighs the worst-case cold-
+  read latency cost (still bounded by the per-request 30 s deadline)
+
+**Measured impact** on the same bench harness
+(`rts-bench latency --workspace crates/rts-core --queries 5000 --cold-count 500 --deps`):
+
+| Metric | With spawn_blocking | Sync (this change) | Δ |
+|---|---:|---:|---|
+| `read_symbol` p50 | 2269 µs | **2023 µs** | **−11 %** |
+| `read_symbol` p95 | 5829 µs | **4618 µs** | **−21 %** |
+| `read_symbol` p99 | 10831 µs | **8307 µs** | **−23 %** |
+
+**Cumulative session progress** (v0.3.0 release → now):
+
+| Metric | v0.3.0 release | After all fixes | Δ |
+|---|---:|---:|---|
+| `read_symbol` p50 | 3207 µs | **2023 µs** | **−37 %** |
+| `read_symbol` p95 | 7023 µs | **4618 µs** | **−34 %** |
+| `read_symbol` p99 | 11877 µs | **8307 µs** | **−30 %** |
+
+**Remaining gap to alpha.30:** alpha.30 read_symbol p95 = 974 µs.
+Post-fix v0.3 = 4618 µs. **Still 4.7× slower** (down from 7.2×
+pre-fix). Remaining structural gaps:
+
+- `find_symbol_resolve_loop` at 168 µs avg (N sequential redb reads
+  per dep — could batch)
+- Larger v0.3 JSON response shape (rank_score, content_version,
+  callers fields plumbed even when empty)
+
+The same `spawn_blocking` pattern is still used by
+`Index.ImpactOf` (BFS over the caller graph, line 792 in
+`methods/index.rs`) and `find_callers`'s rank computation (line
+1549). Those have larger per-call work, so the overhead matters
+less proportionally — left in for now; convert if profiling
+shows them on a hot path.
+
+Tests: 129 unit + 24 integration pass; no test changes needed.
+
 ### Read-symbol perf — content_version + signature caches (root-cause fix)
 
 Following the profile harness shipped in PR #45, this pass identifies

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -1238,31 +1238,33 @@ async fn read_symbol_body(
     // the remainder, and `closure_truncated` fires if any didn't fit.
     let (deps_value, closure_truncated, deps_truncated_names, dep_tokens) = if include_deps {
         let remaining_budget = budget.saturating_sub(body_tokens);
-        let root_owned = root.to_path_buf();
-        let store_arc = store_arc.clone();
-        let chosen_clone = chosen.clone();
-        // v0.3 U3 (alpha.33): closure::compute no longer needs the
-        // anchor body — outgoing refs come from the indexed
-        // SID_REFS_OUT table populated at commit time. body_text
-        // stays in scope for the body-text return.
+        // v0.3.x perf fix: removed `spawn_blocking` for the closure
+        // walk. The walk does redb reads (single-digit µs each), at
+        // most a few `std::fs::metadata` + `std::fs::read` calls
+        // (cached after the file_cache hit on first read in this
+        // call), and tree-sitter signature renders (CPU-bound but
+        // short — and now signature-cached across calls).
         //
-        // Clone the Arc into the blocking task so the signature
-        // cache survives across calls (Arc::clone is cheap; the
-        // Mutex inside is shared, not duplicated).
-        let state_cloned = state.clone();
-        let walk = tokio::task::spawn_blocking(move || {
-            crate::closure::compute(
-                &root_owned,
-                &store_arc,
-                &chosen_clone,
-                remaining_budget,
-                &state_cloned.signature_cache,
-            )
-        })
-        .await
-        .map_err(|e| {
-            ProtocolError::new(ErrorCode::InternalError, format!("closure join error: {e}"))
-        })?;
+        // Pre-fix: each call cost ~50-100 µs of spawn_blocking
+        // handoff (thread pool scheduling + Arc<JoinHandle> setup +
+        // await). On the warm path (bench measures), that's pure
+        // overhead — the underlying work doesn't block long enough
+        // to justify moving off the runtime. For a 200 µs closure
+        // walk, 50 µs of overhead is 25%.
+        //
+        // The trade-off: a true cold-disk read on the first call
+        // for a file could in principle block the runtime worker.
+        // In practice the OS page cache + the file_cache + the
+        // signature cache keep this rare; the daemon's other
+        // concurrent work (writer task) runs on its own task and
+        // doesn't share this thread's scheduler frame anyway.
+        let walk = crate::closure::compute(
+            root,
+            store_arc,
+            &chosen,
+            remaining_budget,
+            &state.signature_cache,
+        );
         mark!(t_section, "closure_walk");
         let value = crate::closure::to_wire_value(&walk.dependencies);
         (


### PR DESCRIPTION
## Summary

Follow-up to the content_version + signature caches that landed in #45. With those in, profiling showed `closure_walk` still spending **~50-100 µs per call** on `tokio::task::spawn_blocking` overhead (thread pool handoff + `JoinHandle` setup + `await`). On the warm bench path that's pure overhead — the underlying work doesn't block long enough to justify moving off the runtime.

## Change

`read_symbol`'s closure walk now calls `crate::closure::compute` synchronously instead of through `spawn_blocking`. The caller (`read_symbol`'s `dispatch` task) is already its own per-connection tokio task — blocking here doesn't starve the runtime, it just stops one in-flight request from yielding mid-walk.

## Trade-off accepted

A true cold-disk read could in principle block the runtime worker. In practice:
- File cache + OS page cache + signature cache keep cold reads rare
- The daemon's writer task runs on its own tokio task and doesn't share this scheduler frame
- 21% p95 win > worst-case cold-read cost (still bounded by per-request 30s deadline)

## Measured impact

`rts-bench latency --workspace crates/rts-core --queries 5000 --cold-count 500 --deps`:

| Metric | With `spawn_blocking` | Sync (this change) | Δ |
|---|---:|---:|---|
| `read_symbol` p50 | 2269 µs | **2023 µs** | **−11 %** |
| `read_symbol` p95 | 5829 µs | **4618 µs** | **−21 %** |
| `read_symbol` p99 | 10831 µs | **8307 µs** | **−23 %** |

## Cumulative session progress (v0.3.0 release → now)

| Metric | v0.3.0 release | After all fixes | Δ |
|---|---:|---:|---|
| `read_symbol` p50 | 3207 µs | **2023 µs** | **−37 %** |
| `read_symbol` p95 | 7023 µs | **4618 µs** | **−34 %** |
| `read_symbol` p99 | 11877 µs | **8307 µs** | **−30 %** |

## Remaining gap to alpha.30

Alpha.30 read_symbol p95 = 974 µs. Post-fix v0.3 = 4618 µs. **Still 4.7× slower** (down from 7.2× pre-session). Remaining structural gaps:

- `find_symbol_resolve_loop` at 168 µs avg (N sequential redb reads per dep — could batch into one multimap scan)
- Larger v0.3 JSON response shape (rank_score, content_version, callers fields plumbed even when empty)

Same `spawn_blocking` pattern still used by `Index.ImpactOf` (BFS over caller graph) and `find_callers`'s rank computation. Those have larger per-call work; left in for now — convert if profiling shows them on a hot path.

## Test plan

- [x] `cargo build --workspace --release` clean
- [x] `cargo test -p rts-daemon` → 129 unit + 24 integration pass
- [x] `cargo fmt --check` + `cargo clippy` clean
- [x] Manual bench reproduction — stable across runs

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: pure latency reduction. The change is the *only* surface-area change; no wire-shape or behavioral impact. If a future caller observes worse latency on cold-disk paths (e.g. very large workspaces with cold OS cache), they'd see it via `Workspace.Status.progress` / bench numbers, not via correctness regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.5, 1M context, extended thinking) + Compound Engineering v2.49.0