### PR TITLE
perf(rts-daemon): batch find_symbol in closure resolve loop (-31% p95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Read-symbol perf — batched `find_symbol` in the closure resolve loop (-31% p95)
+
+Profiling on the post-sync-closure baseline showed
+`find_symbol_resolve_loop` still spending **168 µs avg per closure
+walk** — N sequential `Store::find_symbol(name)` calls, each
+paying its own `db.begin_read()` + table-open cost. Across N≈5
+candidates per call on `crates/rts-core`, that's ~30 µs of pure
+txn-setup overhead per dep.
+
+**Change:** new `Store::find_symbols_batch(&[String]) →
+HashMap<String, Vec<FoundSymbol>>`. Opens one read transaction,
+one shared `fid → path` cache, and walks each name's defs.
+`closure::compute` calls this once instead of `find_symbol` N
+times.
+
+**Measured impact**
+(`rts-bench latency --workspace crates/rts-core --queries 5000 --cold-count 500 --deps`):
+
+| Metric | Pre-batch (post-sync-closure) | Post-batch | Δ |
+|---|---:|---:|---|
+| `read_symbol` p50 | 2023 µs | **1720 µs** | **−15 %** |
+| `read_symbol` p95 | 4618 µs | **3205 µs** | **−31 %** |
+| `read_symbol` p99 | 8307 µs | **6663 µs** | **−20 %** |
+| `find_symbol` p95 | 2446 µs | **1482 µs** | **−39 %** |
+
+(`find_symbol`'s own p95 also dropped — likely a side effect of
+reduced redb transaction contention on the read path; the bench
+runs find_symbol and read_symbol interleaved.)
+
+**Cumulative session progress** (v0.3.0 release → now):
+
+| Metric | v0.3.0 release | After all fixes | Δ |
+|---|---:|---:|---|
+| `read_symbol` p50 | 3207 µs | **1720 µs** | **−46 %** |
+| `read_symbol` p95 | 7023 µs | **3205 µs** | **−54 %** |
+| `read_symbol` p99 | 11877 µs | **6663 µs** | **−44 %** |
+
+**Remaining gap to alpha.30:** alpha.30 read_symbol p95 = 974 µs.
+Post-fix v0.3 = 3205 µs. **Still 3.3× slower** (down from 7.2×
+pre-session, 4.7× post-sync-closure).
+
+Tests: 131 unit + 24 integration pass; +2 new
+(`find_symbols_batch_matches_per_name_find_symbol`,
+`find_symbols_batch_empty_input_returns_empty_map`).
+
 ### Read-symbol perf — remove `spawn_blocking` from closure walk (additional 21% p95 win)
 
 Follow-up to the content_version + signature caches. With those in,

--- a/crates/rts-daemon/src/closure.rs
+++ b/crates/rts-daemon/src/closure.rs
@@ -186,24 +186,26 @@ pub fn compute(
         return ClosureResult::empty();
     }
 
-    // Resolve each candidate to a def site (first match wins, same as
-    // `read_symbol`). Skip names that resolve to the anchor itself
-    // (e.g. via overload — defensive; same name + same file id).
+    // Batched resolve: one read txn for ALL candidates instead of
+    // N. Profiling on `crates/rts-core` showed this loop averaging
+    // 168 µs across N≈5 names per closure walk — the per-name
+    // `find_symbol` paid the txn-open cost N times. The batched
+    // variant shares one txn + one fid→path cache across all names.
+    //
+    // First-match policy preserved: for each name's def set we sort
+    // by `(file, start_byte)` and skip the anchor's own def.
+    let names_vec: Vec<String> = candidates.iter().cloned().collect();
+    let hits_by_name = match store.find_symbols_batch(&names_vec) {
+        Ok(m) => m,
+        Err(_) => Default::default(),
+    };
     let mut resolved: Vec<(String, FoundSymbol)> = Vec::with_capacity(candidates.len());
     for name in &candidates {
-        let hits = match store.find_symbol(name) {
-            Ok(h) => h,
-            Err(_) => continue,
+        let mut hits = match hits_by_name.get(name) {
+            Some(v) if !v.is_empty() => v.clone(),
+            _ => continue,
         };
-        if hits.is_empty() {
-            continue;
-        }
-        // First-match policy: lowest (file, start_byte). Avoids
-        // anchor-self when the anchor's name was somehow still in
-        // play.
-        let mut hits = hits;
         hits.sort_by(|a, b| a.file.cmp(&b.file).then(a.start_byte.cmp(&b.start_byte)));
-        // Don't surface the anchor as its own dep.
         let chosen = match hits
             .into_iter()
             .find(|h| !(h.fid == anchor.fid && h.start_byte == anchor.start_byte))

--- a/crates/rts-daemon/src/store/mod.rs
+++ b/crates/rts-daemon/src/store/mod.rs
@@ -811,6 +811,67 @@ impl Store {
         }
         Ok(out)
     }
+
+    /// Batched `find_symbol` for N names. Opens one read transaction,
+    /// one shared `fid → path` cache, and walks each name's defs.
+    /// Per-name cost drops from `(txn open + table opens + lookups)`
+    /// to `(lookups + shared cache)` — measurable on the closure walker
+    /// which previously called `find_symbol` once per resolved
+    /// candidate (168 µs avg total across N≈5 names per call on
+    /// `crates/rts-core`).
+    ///
+    /// Names absent from `NAME_TO_SID` produce an empty Vec at that key.
+    /// Returned map is keyed by the input `name`; callers that need a
+    /// specific name's defs just `.get(name)`.
+    pub fn find_symbols_batch(
+        &self,
+        names: &[String],
+    ) -> anyhow::Result<HashMap<String, Vec<FoundSymbol>>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let name_to_sid = txn.open_table(NAME_TO_SID)?;
+        let defs = txn.open_multimap_table(DEFS)?;
+        let fid_to_path = txn.open_table(FID_TO_PATH)?;
+
+        let mut fid_path_cache: HashMap<u32, String> = HashMap::new();
+        let mut out: HashMap<String, Vec<FoundSymbol>> = HashMap::with_capacity(names.len());
+        for name in names {
+            let sid = match name_to_sid.get(name.as_str())? {
+                Some(v) => v.value(),
+                None => {
+                    out.entry(name.clone()).or_default();
+                    continue;
+                }
+            };
+            let entry = out.entry(name.clone()).or_default();
+            for row in defs.get(&sid)? {
+                let row = row?;
+                let def: DefSite = from_bytes(row.value()).context("decode DefSite")?;
+                let path = match fid_path_cache.get(&def.fid) {
+                    Some(p) => p.clone(),
+                    None => {
+                        let s = fid_to_path
+                            .get(&def.fid)?
+                            .map(|v| v.value().to_string())
+                            .unwrap_or_default();
+                        fid_path_cache.insert(def.fid, s.clone());
+                        s
+                    }
+                };
+                entry.push(FoundSymbol {
+                    name: name.clone(),
+                    kind: def.kind,
+                    file: path,
+                    fid: def.fid,
+                    start_byte: def.start,
+                    end_byte: def.end,
+                    start_line: def.start_line,
+                    end_line: def.end_line,
+                    visibility: def.visibility,
+                });
+            }
+        }
+        Ok(out)
+    }
 }
 
 /// Surface struct for `Index.FindSymbol` consumers. Plain data; no redb
@@ -1156,6 +1217,95 @@ mod tests {
 
         let no_hits = store.find_symbol("does_not_exist").unwrap();
         assert!(no_hits.is_empty());
+    }
+
+    #[test]
+    fn find_symbols_batch_matches_per_name_find_symbol() {
+        // Same fixture as `commit_then_find_symbol_round_trips`, but
+        // ask via batch + compare against single-call. The two paths
+        // must produce identical FoundSymbol sets per name.
+        let (_tmp, store) = temp_store();
+        let h = blake3::hash(b"file v1").into();
+        let entry = FileBatchEntry {
+            path: std::path::PathBuf::from("src/lib.rs"),
+            meta: rust_meta(h),
+            defs: vec![
+                (
+                    "build_index".to_string(),
+                    DefSite {
+                        fid: 0,
+                        start: 100,
+                        end: 200,
+                        start_line: 5,
+                        end_line: 15,
+                        visibility: Visibility::Public,
+                        kind: SymbolKind::Function,
+                    },
+                    SymbolKind::Function,
+                ),
+                (
+                    "Index".to_string(),
+                    DefSite {
+                        fid: 0,
+                        start: 0,
+                        end: 50,
+                        start_line: 1,
+                        end_line: 3,
+                        visibility: Visibility::Public,
+                        kind: SymbolKind::Struct,
+                    },
+                    SymbolKind::Struct,
+                ),
+            ],
+            refs: Vec::new(),
+        };
+        store
+            .commit_batch(vec![entry], vec![], Durability::Immediate)
+            .unwrap();
+
+        let names = vec![
+            "build_index".to_string(),
+            "Index".to_string(),
+            "does_not_exist".to_string(),
+        ];
+        let batched = store.find_symbols_batch(&names).unwrap();
+        assert_eq!(batched.len(), 3);
+        // Present names return the same Vec contents as find_symbol.
+        for name in &["build_index", "Index"] {
+            let batch_hits = batched.get(*name).expect("name in batch result");
+            let single_hits = store.find_symbol(name).unwrap();
+            assert_eq!(
+                batch_hits.len(),
+                single_hits.len(),
+                "{name}: batch vs single-call hit count must match"
+            );
+            // The two paths produce identical FoundSymbol entries.
+            // (Order within a name is multimap-walk order; we don't
+            // pin it here — the closure walker sorts before picking
+            // the first match anyway.)
+            for (b, s) in batch_hits.iter().zip(single_hits.iter()) {
+                assert_eq!(b.name, s.name);
+                assert_eq!(b.file, s.file);
+                assert_eq!(b.kind, s.kind);
+                assert_eq!(b.start_byte, s.start_byte);
+                assert_eq!(b.end_byte, s.end_byte);
+            }
+        }
+        // Missing name returns an empty Vec at the key.
+        assert!(
+            batched
+                .get("does_not_exist")
+                .expect("key present")
+                .is_empty(),
+            "missing name should map to empty Vec, not be absent"
+        );
+    }
+
+    #[test]
+    fn find_symbols_batch_empty_input_returns_empty_map() {
+        let (_tmp, store) = temp_store();
+        let result = store.find_symbols_batch(&[]).unwrap();
+        assert!(result.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Profiling on the post-sync-closure baseline (PR #46) showed `find_symbol_resolve_loop` still spending **168 µs avg per closure walk** — N sequential `Store::find_symbol(name)` calls, each paying its own `db.begin_read()` + table-open cost. Across N≈5 candidates per call on `crates/rts-core`, that's ~30 µs of pure txn-setup overhead per dep.

## Change

New `Store::find_symbols_batch(&[String]) → HashMap<String, Vec<FoundSymbol>>`. Opens **one** read transaction, **one** shared `fid → path` cache, and walks each name's defs. `closure::compute` calls this once instead of `find_symbol` N times.

## Measured impact

`rts-bench latency --workspace crates/rts-core --queries 5000 --cold-count 500 --deps`:

| Metric | Pre-batch | Post-batch | Δ |
|---|---:|---:|---|
| `read_symbol` p50 | 2023 µs | **1720 µs** | **−15 %** |
| `read_symbol` p95 | 4618 µs | **3205 µs** | **−31 %** |
| `read_symbol` p99 | 8307 µs | **6663 µs** | **−20 %** |
| `find_symbol` p95 | 2446 µs | **1482 µs** | **−39 %** |

`find_symbol`'s own p95 also dropped — likely a side effect of reduced redb transaction contention on the shared read path; the bench interleaves find_symbol and read_symbol calls.

## Cumulative session progress (v0.3.0 release → now)

| Metric | v0.3.0 release | After all fixes | Δ |
|---|---:|---:|---|
| `read_symbol` p50 | 3207 µs | **1720 µs** | **−46 %** |
| `read_symbol` p95 | 7023 µs | **3205 µs** | **−54 %** |
| `read_symbol` p99 | 11877 µs | **6663 µs** | **−44 %** |

## Remaining gap to alpha.30

Alpha.30 read_symbol p95 = 974 µs. Post-fix v0.3 = 3205 µs. **Still 3.3× slower** (down from 7.2× pre-session, 4.7× post-sync-closure).

The remaining structural gap is the larger v0.3 response shape (rank_score, content_version, callers fields always plumbed) and tree-sitter signature renders on uncached deps.

## Test plan

- [x] `cargo build --workspace --release` clean
- [x] `cargo test -p rts-daemon` → 131 unit + 24 integration pass; +2 new tests
- [x] `cargo fmt --check` + `cargo clippy` clean
- [x] Bench reproduces stably across runs

The two new tests verify the batch path returns identical `FoundSymbol` entries to N single calls (modulo intra-name ordering, which neither path pins — both have a sort step in their callers).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: pure latency reduction with strict-equivalence semantics. The new method is a strict subset of `find_symbol` behavior batched across N names.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.5, 1M context, extended thinking) + Compound Engineering v2.49.0