### PR TITLE
feat(rts-mcp): defer Workspace.Mount to first agent tool call (v0.4 prewarm payoff)

### DIFF
--- a/crates/rts-mcp/src/main.rs
+++ b/crates/rts-mcp/src/main.rs
@@ -12,7 +12,6 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use rmcp::service::ServiceExt;
-use serde_json::json;
 
 mod daemon_client;
 mod server;
@@ -96,29 +95,29 @@ async fn main() -> Result<()> {
 
     let daemon_bin = socket::resolve_daemon_bin()?;
     // v0.4: pass the workspace path to auto-spawn so the daemon
-    // prewarms (kicks off the initial walk) before the `Workspace.Mount`
-    // RPC arrives over the socket. By the time the agent's first
-    // `find_symbol` lands, the index is warm — the cold-mount tax
-    // (~6 s on 100k LOC) overlaps with the MCP handshake instead of
-    // blocking the first tool call.
+    // prewarms (kicks off the initial walk) before any RPC arrives.
+    // Combined with the deferred `Workspace.Mount` below, this hides
+    // the cold-mount tax entirely on long-lived agent sessions: the
+    // daemon walks in the background while the user types their
+    // first question, and the lazy Mount on first tool call hits the
+    // idempotent path instantly.
     let stream = socket::connect_with_auto_spawn(&daemon_bin, Some(&workspace))
         .await
         .context("connect to rts-daemon")?;
-    let mut daemon = DaemonClient::new(stream);
+    let daemon = DaemonClient::new(stream);
 
-    // Mount the workspace before we start accepting MCP traffic. If this
-    // fails the agent will see no tools listed because the server exits.
-    let mount_resp = daemon
-        .call("Workspace.Mount", json!({ "root": workspace }))
-        .await
-        .with_context(|| format!("Workspace.Mount on {}", workspace.display()))?;
-    let workspace_id = mount_resp["workspace_id"].as_str().unwrap_or("<unknown>");
-    tracing::info!(
-        target: "rts_mcp",
-        "mounted workspace {} as id={}",
-        workspace.display(),
-        workspace_id
-    );
+    // v0.4: Workspace.Mount is now deferred — see `RtsServer::call_daemon`.
+    // The first agent tool call (find_symbol / outline_workspace / etc.)
+    // triggers the Mount. Daemon prewarm overlaps with the seconds the
+    // user spends typing their first question, so Mount is effectively
+    // free.
+    //
+    // Pre-v0.4 behavior was to Mount synchronously here at startup,
+    // which paid the 6 s cold-walk tax during rts-mcp boot — before
+    // the agent's first tool call could even be served. The deferred
+    // approach lets Claude Code / Cursor / etc. show tools as
+    // available immediately and amortizes the walk into the user's
+    // typing time.
 
     let instructions = format!(
         "rts-mcp serves four read-only retrieval tools for the workspace at {}. \
@@ -126,7 +125,7 @@ async fn main() -> Result<()> {
          first for orientation, then `find_symbol`/`read_symbol` for targeted reads.",
         workspace.display()
     );
-    let server = RtsServer::new(daemon, instructions);
+    let server = RtsServer::new(daemon, workspace.clone(), instructions);
     let service = server
         .serve(rmcp::transport::stdio())
         .await

--- a/crates/rts-mcp/src/server.rs
+++ b/crates/rts-mcp/src/server.rs
@@ -177,21 +177,67 @@ pub struct RtsServer {
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
     daemon: Arc<Mutex<DaemonClient>>,
+    /// v0.4: workspace path needed for lazy `Workspace.Mount`.
+    /// rts-mcp used to call Mount immediately at startup; with the
+    /// daemon's prewarm-on-spawn (PR #51), deferring Mount until
+    /// the first agent tool call lets the daemon's background walk
+    /// overlap with the seconds-to-minutes between session start and
+    /// the user's first code question. By the time Mount fires, the
+    /// daemon's prewarm has already populated the index — Mount hits
+    /// the idempotent path and returns immediately.
+    workspace: std::path::PathBuf,
+    /// Whether `Workspace.Mount` has been called for this session.
+    /// `AtomicBool` so the (cheap) fast-path in `call_daemon` is a
+    /// single relaxed load. Synchronization for the slow-path
+    /// (do-the-mount) happens through the daemon `Mutex` we already
+    /// hold there — no double-mount race possible.
+    ///
+    /// Wrapped in `Arc` because `RtsServer: Clone` (rmcp requirement)
+    /// and `AtomicBool` itself is not `Clone`.
+    mounted: Arc<std::sync::atomic::AtomicBool>,
     instructions: String,
 }
 
 #[tool_router]
 impl RtsServer {
-    pub fn new(daemon: DaemonClient, instructions: String) -> Self {
+    pub fn new(daemon: DaemonClient, workspace: std::path::PathBuf, instructions: String) -> Self {
         Self {
             tool_router: Self::tool_router(),
             daemon: Arc::new(Mutex::new(daemon)),
+            workspace,
+            mounted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             instructions,
         }
     }
 
+    /// Forward a method to the daemon. On the FIRST call (or after
+    /// a prior `Workspace.Mount` failure), this also issues
+    /// `Workspace.Mount` so subsequent tool calls have a workspace
+    /// to read from.
+    ///
+    /// The `daemon` mutex serializes — concurrent tool calls don't
+    /// race on the mount; the first one in does the mount, the
+    /// others wait on the mutex and see `mounted == true` by the
+    /// time they get the lock.
     async fn call_daemon(&self, method: &str, params: Value) -> Result<Value, DaemonError> {
         let mut guard = self.daemon.lock().await;
+        if !self.mounted.load(std::sync::atomic::Ordering::Acquire) {
+            let mount_resp = guard
+                .call(
+                    "Workspace.Mount",
+                    serde_json::json!({ "root": self.workspace }),
+                )
+                .await?;
+            let workspace_id = mount_resp["workspace_id"].as_str().unwrap_or("<unknown>");
+            tracing::info!(
+                target: "rts_mcp",
+                "lazy-mounted workspace {} as id={} on first tool call",
+                self.workspace.display(),
+                workspace_id,
+            );
+            self.mounted
+                .store(true, std::sync::atomic::Ordering::Release);
+        }
         guard.call(method, params).await
     }
 


### PR DESCRIPTION
## The architectural win lands here

Pairs with PR #51's daemon prewarm scaffolding to deliver the user-visible win the original question was about: **cold-mount becomes invisible to the agent loop**.

### Before this PR

```
T=0       Agent harness launches rts-mcp
T=50ms    rts-mcp spawns daemon with --workspace (PR #51)
T=100ms   Daemon kicks off background prewarm walk
T=100ms   rts-mcp IMMEDIATELY calls Workspace.Mount (synchronous!)
T=100ms   Mount RPC waits for prewarm to complete
T=~6s     Prewarm done; Mount returns
T=~6s     rts-mcp serves MCP stdio — tools listed, agent ready
T=~6s     User has been waiting ~6 s before they can ask anything
```

The prewarm gives a *partial* win (overlap with rts-mcp boot work, ~100-300 ms), but the cold tax still blocks rts-mcp startup.

### After this PR

```
T=0       Agent harness launches rts-mcp
T=50ms    rts-mcp spawns daemon with --workspace
T=100ms   Daemon starts background prewarm walk
T=100ms   rts-mcp serves MCP stdio immediately — tools listed
T=100ms   Agent harness sees rts-mcp ready
T=100ms   User reading greeting / typing first question
T=~5s     Daemon prewarm completes (background)
T=8s      User asks code question; agent invokes first tool
T=8.001s  RtsServer.call_daemon sees mounted=false → Mount RPC
T=8.001s  Daemon's prewarm done → idempotent path → instant return
T=8.003s  Tool returns
```

**The cold-mount tax happens during the user's typing time, not during agent startup.**

## Implementation

- `RtsServer` gets two new fields:
  - `workspace: PathBuf` — where to Mount when first needed
  - `mounted: Arc<AtomicBool>` — have we mounted yet
- `call_daemon` checks `mounted` on every tool call. First call finds it false → issues `Workspace.Mount`, sets `mounted=true`. Subsequent calls fast-path through (single `Acquire` load).
- The pre-existing `daemon` Mutex serializes concurrent tool calls, so only one Mount fires even if N tools call concurrently.
- `main.rs` removes the eager Mount block. `RtsServer::new` now takes the workspace path.

## Failure modes considered

- **Mount failure** (e.g. permission denied) → first tool call propagates the error. `mounted=false` stays, next tool call retries Mount. Transient failures recover; permanent failures surface per-tool-call.
- **Two concurrent first-tool-calls** → daemon mutex serializes; only the first fires Mount.

## What this doesn't change

- Daemon protocol (no new RPCs, no version bump)
- Tool list / descriptions exposed to agent
- Wire shape of any tool response
- Behavior when `--workspace` is NOT passed to daemon (legacy flow: daemon idle, Mount on first tool call works normally — no prewarm to overlap with, but no regression either)

## Test plan

- [x] `cargo build --workspace --release` clean
- [x] `cargo test --workspace` → 563 pass, 0 fail
- [x] `cargo fmt --check` + `cargo clippy` clean
- [x] End-to-end: `rts-bench query find-symbol` returns valid result with `rank_score` populated (would be 0 if Mount hadn't fired)

## Closing the original question

You asked: **"why isn't this fixed so as soon as the daemon starts it does the indexing?"**

The answer needed two parts:

1. **Daemon side** (PR #51): accept `--workspace <path>` at spawn time, kick off background walk, accept loop runs concurrently, Mount RPCs wait via Notify.
2. **rts-mcp side** (this PR): don't call Mount at startup. Let the daemon prewarm while the user thinks; lazy-Mount on first tool call.

Together: the cold-mount tax is paid during session-startup time (model load, greeting, user typing) instead of as a wall against the first tool call.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. Backward-compatible: a daemon without `--workspace` still works fine with the lazy Mount path; the only behavioral change is **when** Mount fires (after first tool call instead of at startup).

If anyone wants to see it firing, set `RTS_LOG=info` and look for `lazy-mounted workspace ... on first tool call` in rts-mcp's stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.5, 1M context, extended thinking) + Compound Engineering v2.49.0