### PR TITLE
chore(corpus): audit semantic eval against actual indexed symbols (+20pp answerable coverage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Semantic eval corpus audit (+20pp answerable coverage)
+
+Audits `corpus/semantic-eval-rts-core.toml` against the actual symbols
+indexed for `crates/rts-core`. The previous corpus included fictional
+names the author imagined but never verified — exposed once the v0.4.1
+`limit` parameter let the bench see the full 2096-symbol pool.
+
+#### What was wrong
+
+Six of the ten "answerable" queries had `expected_top_k` entries that
+don't exist anywhere in rts-core:
+
+- `detect_language`, `from_extension`, `info_for_path` (language detection)
+- `Visibility`, `Public` (visibility tracking)
+- `SymbolKind`, `count_symbols` (symbol counting)
+- `render_signature`, `signature_renderer`, `SignatureRenderer` (all three — that whole query was fully fictional)
+- `TreeCache`, `cached_tree` (cache)
+- `Tree`, `walk_tree` (syntax tree / walk)
+
+The three "negative controls" (`auth`, `database pool`, `http handler`)
+were ALSO wrong — rts-core is a code-analysis crate that detects
+authentication / thread-pool / handler patterns in *other* people's
+code, so it has `AuthenticationCheck`, `AdvancedThreadPool`, and
+`Handler` types. Hitting those was a real hit being counted as a
+"correctly handled negative control".
+
+#### What was fixed
+
+- Every fictional expected name replaced with a real symbol from the
+  4096-pool probe. `detect_language` → `detect_language_from_path` /
+  `detect_language_from_extension` / `detect_language_from_content`,
+  etc.
+- One query (`render_signature`) reworded to point at real code:
+  "what strips a symbol's body for display?" → `render_strip_body`,
+  `render_rust`, `render_python`, etc.
+- Negative controls swapped to topics genuinely absent: `JWT`,
+  `GraphQL`, `SMTP` — all probed and confirmed missing from rts-core.
+- Validation: every `expected_top_k` name is verified against the
+  daemon's pool before the corpus ships.
+
+#### Numbers on the audited corpus
+
+| Metric              | Pre-audit (PR #57) | Audited corpus | Δ          |
+|---------------------|--------------------|----------------|------------|
+| MRR                 | 0.192              | 0.336          | +75%       |
+| Coverage (all 13 q) | 46.2%              | 61.5%          | +15.3pp    |
+| **Answerable cov.** | **60.0% (6/10)**   | **80.0% (8/10)** | **+20pp**  |
+| Precision@10        | 0.092              | 0.169          | +84%       |
+
+Important: these gains are NOT from a smarter ranker. They're from
+giving the existing ranker a corpus it can actually answer. This is
+the honest baseline — what graph-only retrieval achieves against
+verified ground truth.
+
+#### The two remaining misses
+
+- "what does file analysis do?" — top1 = `FileAnalysisTask`; expected
+  `analyze_file`/`FileAnalyzer` are in the pool but ranked below
+  competing token-overlap candidates.
+- "where does the code track which symbols are public?" — top1 =
+  `Symbol`; expected `is_public`/`visibility` lose because query token
+  "symbols" stems to "symbol" and exact-name-matches the `Symbol` type
+  at +10, beating sub-token matches at +6.
+
+Both are scoring-tier quirks, not retrieval problems. Filed for the
+next ranker iteration.
+
 ### `Index.FindSymbol.limit` — explicit cap for the eval harness (+10pp answerable coverage)
 
 Adds an optional `limit` parameter to `Index.FindSymbol` (and the

--- a/corpus/semantic-eval-rts-core.toml
+++ b/corpus/semantic-eval-rts-core.toml
@@ -13,16 +13,19 @@
 # Run: `rts-bench semantic --corpus corpus/semantic-eval-rts-core.toml \
 #                          --workspace crates/rts-core`
 #
-# Grading notes:
-# - "Hand-graded" means I looked at the actual code and listed
-#   symbols I'd expect a useful answer to surface. Not an
-#   exhaustive list — just the obvious ones for a quick scan.
+# Grading methodology:
+# - All `expected_top_k` names must exist in the indexed workspace.
+#   The corpus is validated by probing the daemon with
+#   `find_symbol(pattern="*", limit=4096)` and confirming every name
+#   appears in the pool. Names known to be missing are flagged.
 # - Order doesn't matter; the scorer checks membership in top-K.
-# - Some queries deliberately have no expected matches in this
-#   workspace (e.g. "where's auth logic?" — there isn't any in
-#   rts-core). Those queries score 0 across the board, which is
-#   useful: a ranker should NOT invent symbols for queries with
-#   no actual answer.
+# - Negative-control queries (empty `expected_top_k`) target topics
+#   genuinely absent from rts-core. Confirmed absent via `rg` over
+#   the workspace: no JWT, GraphQL, or SMTP code anywhere.
+# - Audited 2026-05-15 after the v0.4.1 limit-param landing exposed
+#   the full ranked pool. Previous version included fictional names
+#   like `detect_language`, `count_symbols`, `render_signature` that
+#   the corpus author imagined but never verified.
 
 version = 1
 
@@ -34,11 +37,14 @@ expected_top_k = ["parse", "parse_file_content", "create_syntax_tree", "Parser"]
 
 [[query]]
 text = "where is the syntax tree wrapper defined?"
-expected_top_k = ["SyntaxTree", "tree", "Tree"]
+# `Tree` doesn't exist in rts-core; the wrapper is named `SyntaxTree`.
+# `TreeCursor` is the tree-sitter cursor type and a reasonable hit.
+expected_top_k = ["SyntaxTree", "tree", "syntax_tree", "TreeCursor"]
 
 [[query]]
 text = "how does the analyzer walk nodes?"
-expected_top_k = ["find_nodes_by_kind", "collect_nodes_by_kind", "walk_tree", "root_node"]
+# `walk_tree` doesn't exist; the actual walk types are `walk`/`walker`.
+expected_top_k = ["find_nodes_by_kind", "collect_nodes_by_kind", "walk", "walker", "root_node"]
 
 [[query]]
 text = "what does file analysis do?"
@@ -46,40 +52,80 @@ expected_top_k = ["analyze_file", "FileAnalyzer", "analyze", "analyze_directory"
 
 [[query]]
 text = "where is the cache implemented?"
-expected_top_k = ["calculate_cache_key", "cache_tree", "TreeCache", "cached_tree"]
+# `TreeCache` and `cached_tree` don't exist. The real cache types are
+# `FileCache`, `CacheStats`, plus the symbol-level cache helpers.
+expected_top_k = ["calculate_cache_key", "cache_tree", "FileCache", "CacheStats", "is_cached"]
 
 [[query]]
 text = "what's the entry point for language detection?"
-expected_top_k = ["detect_language", "Language", "from_extension", "info_for_path"]
+# `detect_language` doesn't exist; the real entry points are the
+# `detect_language_from_*` family. `from_extension` and `info_for_path`
+# don't exist either; `LanguageInfo` is the closest type.
+expected_top_k = [
+    "detect_language_from_path",
+    "detect_language_from_extension",
+    "detect_language_from_content",
+    "Language",
+    "LanguageInfo",
+]
 
 # ─── Conceptual questions that may need fuzzier matching ───
 
 [[query]]
 text = "where does the code track which symbols are public?"
-expected_top_k = ["Visibility", "visibility", "is_public", "Public"]
+# `Visibility` and `Public` types don't exist in rts-core. The real
+# visibility logic lives in `is_public*` predicates and the bare
+# `visibility` field/method.
+expected_top_k = [
+    "is_public",
+    "visibility",
+    "is_public_function",
+    "is_public_class",
+    "is_public_method",
+    "is_rust_item_public",
+]
 
 [[query]]
 text = "how does the analyzer count symbols by kind?"
-expected_top_k = ["SymbolKind", "kind", "count_symbols", "find_nodes_by_kind"]
+# `SymbolKind` and `count_symbols` don't exist. The actual symbol
+# inventory lives in `SymbolTable`/`SymbolStatistics`/`Symbol`,
+# enumerated via `find_nodes_by_kind`.
+expected_top_k = ["Symbol", "SymbolTable", "SymbolStatistics", "kind", "find_nodes_by_kind"]
 
 [[query]]
-text = "what generates a signature from source?"
-expected_top_k = ["render_signature", "signature_renderer", "SignatureRenderer"]
+text = "what strips a symbol's body for display?"
+# Replaces the previous fully-fictional "render_signature" query.
+# rts-core's signature-rendering layer is the `render_*` family per
+# language, plus the body-stripping helpers.
+expected_top_k = [
+    "render_strip_body",
+    "render_strip_body_with_recursive_body",
+    "render_rust",
+    "render_python",
+    "render_javascript",
+]
 
 [[query]]
 text = "what's central to the codebase?"
 expected_top_k = ["find_nodes_by_kind", "child_by_field_name", "contains", "children"]
 
-# ─── Negative controls — no real answer in rts-core ───
+# ─── Negative controls — topics genuinely absent from rts-core ───
+#
+# The previous corpus had `auth`, `database connection pool`, and
+# `http handler` as negative controls — but rts-core ACTUALLY has
+# `AuthenticationCheck`, `AdvancedThreadPool`, and `Handler` types
+# (it's a code-analysis crate that detects these patterns in *other*
+# people's code). Replaced with JWT / GraphQL / SMTP, which were
+# probed and confirmed to be absent from the full 4096-symbol pool.
 
 [[query]]
-text = "where's the authentication logic?"
+text = "where is JWT token validation?"
 expected_top_k = []
 
 [[query]]
-text = "how does the database connection pool work?"
+text = "what's the GraphQL schema definition?"
 expected_top_k = []
 
 [[query]]
-text = "where is the http handler?"
+text = "where is the SMTP email client implementation?"
 expected_top_k = []


### PR DESCRIPTION
## Summary

PR #57's larger candidate pool let me probe what's actually in `crates/rts-core`. The corpus had several fictional `expected_top_k` names the author (an earlier session) imagined but never verified.

## Fixes

Six of the ten \"answerable\" queries had at least one fictional name:

- `detect_language`, `from_extension`, `info_for_path` (language detection)
- `Visibility`, `Public` (visibility tracking)
- `SymbolKind`, `count_symbols` (symbol counting)
- `render_signature`, `signature_renderer`, `SignatureRenderer` (the *entire* query was fictional)
- `TreeCache`, `cached_tree` (cache)
- `Tree`, `walk_tree` (syntax tree / walk)

All three \"negative controls\" were ALSO wrong — rts-core IS a code-analysis crate that detects authentication, thread-pool, and handler patterns in *other* people's code, so it has real `AuthenticationCheck`, `AdvancedThreadPool`, and `Handler` types. Hitting those was a real hit being counted as a successful negative control.

## Replacements

- Every fictional name → real symbol probed from the 4096-pool:
  - `detect_language` → `detect_language_from_path`, `detect_language_from_extension`, `detect_language_from_content`
  - `Visibility` → `is_public_function`, `is_public_class`, `is_rust_item_public`
  - `SymbolKind` → `SymbolTable`, `SymbolStatistics`, `Symbol`
  - `TreeCache` → `FileCache`, `CacheStats`, `is_cached`
  - `Tree` → `TreeCursor`, `syntax_tree`, `SyntaxTree`
  - `walk_tree` → `walk`, `walker`
- One query (`render_signature`) reworded to point at real code: \"what strips a symbol's body for display?\" → `render_strip_body`, `render_rust`, `render_python`.
- Negative controls swapped to topics genuinely absent from the workspace: **JWT, GraphQL, SMTP** — all probed and confirmed missing.
- Validated every `expected_top_k` name against the daemon's pool before shipping.

## Numbers on the audited corpus

| Metric              | Pre-audit (PR #57) | Audited corpus    | Δ          |
|---------------------|--------------------|-------------------|------------|
| MRR                 | 0.192              | 0.336             | +75%       |
| Coverage (all 13 q) | 46.2%              | 61.5%             | +15.3pp    |
| **Answerable cov.** | **60.0% (6/10)**   | **80.0% (8/10)**  | **+20pp**  |
| Precision@10        | 0.092              | 0.169             | +84%       |

**These gains aren't from a smarter ranker.** They're from giving the existing ranker a corpus it can actually answer. This is the honest baseline: what graph-only retrieval achieves against verified ground truth.

## Remaining two misses

Both are scoring-tier quirks, not retrieval problems:

1. **\"what does file analysis do?\"** — top1 = `FileAnalysisTask`; expected `analyze_file`/`FileAnalyzer` are in the pool but ranked below competing token-overlap candidates.
2. **\"where does the code track which symbols are public?\"** — top1 = `Symbol`; expected `is_public`/`visibility` lose because query token `\"symbols\"` stems to `\"symbol\"` and exact-name-matches the `Symbol` type at +10, beating sub-token matches at +6.

Both filed for the next ranker iteration.

## Test plan

- [x] `python3` validation: every `expected_top_k` name verified present in the daemon's 2096-symbol pool
- [x] `rg` confirmation: JWT/GraphQL/SMTP absent from `crates/rts-core/`
- [x] `cargo test --workspace` — passes (no code changes)
- [x] Manual: `rts-bench semantic` produces the documented MRR/coverage improvements

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required:` corpus-data-only change. No runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>