### PR TITLE
feat(rts-bench): IDF-weighted sub-token scoring (+10pp answerable coverage → 90%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,85 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### IDF-weighted sub-token scoring (+10pp answerable coverage → 90% on rts-core)
+
+Adds inverse-document-frequency weighting to the semantic baseline
+ranker. Sub-token matches against common workspace terms (`symbol`,
+`file`, `analysis` in a code-analysis crate) get less score; matches
+against rare terms (`public`, `cache`, `signature`) get more.
+
+#### Why
+
+The audited corpus (PR #58) exposed two scoring failure modes:
+
+1. **"track which symbols are public"** → top1 = `Symbol` (a single-
+   word type), expected `is_public`/`visibility`. `Symbol` matched
+   the stemmed query token "symbol" at +10 (exact full-name) and
+   beat `is_public`'s +6 sub-token match. But `symbol` is a *very*
+   common term in rts-core — almost every candidate's name contains
+   it. The exact match was inflating against a generic match.
+
+2. **"how does the analyzer count symbols by kind?"** → top1 =
+   `SymbolTableAnalyzer`. Same pattern: common terms (`symbol`,
+   `analyzer`) outweighing rarer ones (`kind`, `count`).
+
+IDF directly addresses both. The classic Salton-Wong information-
+retrieval formula: a term's weight is `log((N + 1) / (df + 1)) + 1`
+where `df` is the count of candidates containing it. Common terms
+get weights near 1.0; rare terms get weights of 4-7×.
+
+#### What
+
+- New `IdfWeights::from_candidates(&[Candidate])` pre-computes
+  weights over the full pool once per eval.
+- `score_candidate(..., &IdfWeights)` multiplies every match-tier
+  bonus by the matched token's IDF weight. Exact-name match against
+  a common term now scores around 10 × 1.0; against a rare term, up
+  to 10 × 6.0.
+- File-path substring also IDF-weighted.
+
+#### Numbers on the audited corpus
+
+| Metric              | Pre-IDF (PR #58) | With IDF      | Δ          |
+|---------------------|------------------|---------------|------------|
+| MRR                 | 0.336            | 0.402         | +20%       |
+| Coverage (all 13 q) | 61.5%            | 69.2%         | +7.7pp     |
+| **Answerable cov.** | **80% (8/10)**   | **90% (9/10)**| **+10pp**  |
+| Precision@10        | 0.169            | 0.185         | +10%       |
+
+9 of 10 answerable queries hit. "track which symbols are public"
+went from a miss to rank 9 (`MemoryTracker` and `Symbol` no longer
+crowd out `is_public`). "how does the analyzer count symbols by
+kind?" went from rank 3 to rank 0 (top1 = `kind`).
+
+Cumulative on the answerable-corpus journey: 40% (PR #55 baseline) →
+50% (PR #56 decompose+stem) → 60% (PR #57 limit param) → 80% (PR #58
+corpus audit) → **90% (this PR)**.
+
+#### The one remaining miss
+
+"what does file analysis do?" → top1 = `FileAnalysisTask`; expected
+`analyze_file`/`FileAnalyzer` aren't in top-10. Root cause: the
+naive stemmer can't unify `analysis` (stems to `analysi`) with
+`analyze` (stems to `analyz`). Real Porter handles this via specific
+-is/-ize rules; ours doesn't. Could be addressed via:
+- A small synonym/lemma table for code-domain word pairs
+- Real Porter stemmer (~150 lines)
+- Word vectors (out of scope for "graph-only baseline")
+
+Filed for the next iteration.
+
+#### Test coverage
+
++2 unit tests:
+- `idf_weights_down_weight_common_tokens` (raw IDF behavior)
+- `idf_breaks_single_word_vs_compound_match` (the `Symbol` vs
+  `is_public` failure mode directly reproduced)
+
+Existing tests updated to pass a flat-IDF (weight=1.0 everywhere)
+to isolate score-tier ordering from IDF noise. 581 workspace tests
+pass.
+
 ### Semantic eval corpus audit (+20pp answerable coverage)
 
 Audits `corpus/semantic-eval-rts-core.toml` against the actual symbols

--- a/crates/rts-bench/src/semantic.rs
+++ b/crates/rts-bench/src/semantic.rs
@@ -324,6 +324,62 @@ pub fn stem(token: &str) -> String {
     t
 }
 
+/// Inverse-document-frequency weights over stemmed sub-tokens for
+/// the candidate pool. Used by `score_candidate` to down-weight
+/// matches against very-common terms (`symbol` in a code-analysis
+/// crate, `file` in a filesystem-walker crate) and up-weight rare
+/// terms (`public`, `visibility`, `cache`).
+///
+/// Formula: `log((N + 1) / (df + 1)) + 1.0` — a smoothed IDF that
+/// stays positive for any term and avoids zero/negative weights.
+/// Pre-computed once per eval over the entire candidate pool.
+#[derive(Debug, Clone, Default)]
+pub struct IdfWeights {
+    /// Map: stemmed sub-token → IDF weight in [~0.5, ~ln(N)+1].
+    pub weights: std::collections::HashMap<String, f64>,
+    /// Default weight applied to any token absent from `weights`
+    /// (treated as maximally rare).
+    pub default: f64,
+}
+
+impl IdfWeights {
+    /// Compute IDF weights from a candidate pool. Each sub-token's
+    /// document frequency is the number of distinct candidates whose
+    /// decomposed-stemmed name contains it.
+    pub fn from_candidates(candidates: &[Candidate]) -> Self {
+        use std::collections::HashMap;
+        let n = candidates.len() as f64;
+        let mut df: HashMap<String, usize> = HashMap::new();
+        for c in candidates {
+            let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+            for t in decompose_name(&c.name) {
+                let s = stem(&t);
+                if seen.insert(s.clone()) {
+                    *df.entry(s).or_insert(0) += 1;
+                }
+            }
+        }
+        let weights = df
+            .into_iter()
+            .map(|(tok, dfc)| {
+                let idf = ((n + 1.0) / (dfc as f64 + 1.0)).ln() + 1.0;
+                (tok, idf)
+            })
+            .collect();
+        let default = ((n + 1.0) / 1.0_f64).ln() + 1.0;
+        IdfWeights { weights, default }
+    }
+
+    /// Look up the weight for a stemmed token; missing tokens get
+    /// `default` (treated as "never seen, maximally rare").
+    pub fn weight(&self, stemmed_token: &str) -> f64 {
+        self.weights
+            .get(stemmed_token)
+            .copied()
+            .unwrap_or(self.default)
+    }
+}
+
 /// Score one candidate symbol against a token set.
 ///
 /// The candidate's qualified_name is decomposed into sub-tokens and
@@ -331,11 +387,18 @@ pub fn stem(token: &str) -> String {
 /// against (a) the full name, (b) the stemmed full name, (c) the
 /// stemmed sub-token set, (d) raw substring fallback. File-path
 /// substring stays unchanged.
+///
+/// Sub-token matches are weighted by IDF — matching a rare term
+/// like `public` is worth more than matching a workspace-common term
+/// like `symbol` in a code-analysis crate. This is what breaks the
+/// "common single-word symbol dominates" failure mode (`Symbol`
+/// outranking `is_public` for "where are symbols public?").
 pub fn score_candidate(
     candidate_name: &str,
     candidate_file: &str,
     candidate_rank: f64,
     tokens: &[String],
+    idf: &IdfWeights,
 ) -> f64 {
     let name_lower = candidate_name.to_lowercase();
     let file_lower = candidate_file.to_lowercase();
@@ -348,18 +411,21 @@ pub fn score_candidate(
     let mut score = candidate_rank; // baseline: PageRank already 0..1
     for tok in tokens {
         let tok_stem = stem(tok);
+        let w = idf.weight(&tok_stem);
         if name_lower == *tok || name_stem == tok_stem {
             // Exact full-name match (raw or stemmed) dominates.
-            score += 10.0;
+            // Weighted by IDF so a query against `Symbol` in a
+            // symbol-heavy codebase doesn't crush more-specific hits.
+            score += 10.0 * w;
         } else if sub_stems.contains(&tok_stem) {
             // Exact stemmed sub-token match — bridges the natural-
             // language ↔ identifier gap (`parsing` ↔ `parse_file`).
-            score += 6.0;
+            score += 6.0 * w;
         } else if name_lower.contains(tok) {
-            score += 3.0;
+            score += 3.0 * w;
         }
         if file_lower.contains(tok) {
-            score += 1.0;
+            score += 1.0 * w;
         }
     }
     score
@@ -382,13 +448,16 @@ pub async fn run(
     // `calculate_cache_key`). Filed for a follow-up that pairs
     // expansion with name-specificity scoring.
     let candidates = fetch_candidates(session).await?;
+    // Pre-compute IDF over the full candidate pool — the same
+    // weights apply to every query.
+    let idf = IdfWeights::from_candidates(&candidates);
     let mut out: Vec<QueryResult> = Vec::with_capacity(corpus.queries.len());
     for q in &corpus.queries {
         let tokens = tokens_of(&q.text);
         let mut scored: Vec<(String, String, f64)> = candidates
             .iter()
             .map(|c| {
-                let score = score_candidate(&c.name, &c.file, c.rank, &tokens);
+                let score = score_candidate(&c.name, &c.file, c.rank, &tokens, &idf);
                 (c.name.clone(), c.file.clone(), score)
             })
             .collect();
@@ -590,21 +659,92 @@ mod tests {
         assert!(toks.contains(&"compute_symbol_ranks".to_string()));
     }
 
+    /// Default IDF for tests: every token gets weight 1.0. Test the
+    /// score-tier ordering without IDF noise.
+    fn flat_idf() -> IdfWeights {
+        IdfWeights {
+            weights: std::collections::HashMap::new(),
+            default: 1.0,
+        }
+    }
+
     #[test]
     fn score_candidate_exact_name_dominates_substring() {
         let toks = vec!["mount".to_string()];
-        let exact = score_candidate("mount", "src/lib.rs", 0.001, &toks);
-        let sub_token = score_candidate("workspace_mount", "src/lib.rs", 0.001, &toks);
+        let idf = flat_idf();
+        let exact = score_candidate("mount", "src/lib.rs", 0.001, &toks, &idf);
+        let sub_token = score_candidate("workspace_mount", "src/lib.rs", 0.001, &toks, &idf);
         assert!(
             exact > sub_token,
             "exact full-name match should outrank sub-token match (+10 vs +6)"
         );
         // And sub-token match should outrank mere substring (which
         // is what `workspacemount` would have been before decompose).
-        let raw_substring = score_candidate("workspacemount", "src/lib.rs", 0.001, &toks);
+        let raw_substring = score_candidate("workspacemount", "src/lib.rs", 0.001, &toks, &idf);
         assert!(
             sub_token > raw_substring,
             "stemmed sub-token match should outrank raw substring match (+6 vs +3)"
+        );
+    }
+
+    #[test]
+    fn idf_weights_down_weight_common_tokens() {
+        // 10 candidates; 9 contain "symbol", 1 contains "public".
+        // IDF for "symbol" should be much smaller than for "public".
+        let mut cands = Vec::new();
+        for i in 0..9 {
+            cands.push(Candidate {
+                name: format!("symbol_thing_{i}"),
+                file: String::new(),
+                rank: 0.0,
+            });
+        }
+        cands.push(Candidate {
+            name: "is_public".into(),
+            file: String::new(),
+            rank: 0.0,
+        });
+        let idf = IdfWeights::from_candidates(&cands);
+        let w_symbol = idf.weight(&stem("symbol"));
+        let w_public = idf.weight(&stem("public"));
+        assert!(
+            w_public > w_symbol,
+            "rare term should outweigh common term: public={w_public}, symbol={w_symbol}"
+        );
+    }
+
+    #[test]
+    fn idf_breaks_single_word_vs_compound_match() {
+        // The "symbols public" failure mode: `Symbol` (single-word
+        // exact match against common term) shouldn't beat `is_public`
+        // (sub-token match against rare term) when IDF is in play.
+        let mut cands = Vec::new();
+        for i in 0..15 {
+            cands.push(Candidate {
+                name: format!("symbol_var_{i}"),
+                file: String::new(),
+                rank: 0.0,
+            });
+        }
+        cands.push(Candidate {
+            name: "Symbol".into(),
+            file: "src/symbol_table.rs".into(),
+            rank: 0.001,
+        });
+        cands.push(Candidate {
+            name: "is_public".into(),
+            file: "src/symbol_table.rs".into(),
+            rank: 0.001,
+        });
+        let idf = IdfWeights::from_candidates(&cands);
+        let toks = vec!["symbols".to_string(), "public".to_string()];
+        let symbol_score = score_candidate("Symbol", "src/symbol_table.rs", 0.001, &toks, &idf);
+        let is_public_score =
+            score_candidate("is_public", "src/symbol_table.rs", 0.001, &toks, &idf);
+        assert!(
+            is_public_score > symbol_score,
+            "with IDF, sub-token match against rare term should outrank exact-name match against common term: \
+             is_public={is_public_score}, Symbol={symbol_score}"
         );
     }
 
@@ -654,8 +794,9 @@ mod tests {
         // "parsing" query should hit candidate `parse_file_content`
         // even though there's no substring/exact overlap.
         let toks = vec!["parsing".to_string()];
-        let hit = score_candidate("parse_file_content", "src/parser.rs", 0.001, &toks);
-        let miss = score_candidate("unrelated_function", "src/other.rs", 0.001, &toks);
+        let idf = flat_idf();
+        let hit = score_candidate("parse_file_content", "src/parser.rs", 0.001, &toks, &idf);
+        let miss = score_candidate("unrelated_function", "src/other.rs", 0.001, &toks, &idf);
         // Hit gets at least the +6 sub-token bonus plus a file-path
         // +1 (the file is "parser.rs" which contains "parsing"? no it
         // doesn't, but stemming isn't applied to the path). The
@@ -670,8 +811,9 @@ mod tests {
     #[test]
     fn score_candidate_pagerank_breaks_ties_on_no_keyword_match() {
         let toks = vec!["unrelated_keyword_xyz".to_string()];
-        let high = score_candidate("foo", "src/lib.rs", 0.5, &toks);
-        let low = score_candidate("bar", "src/lib.rs", 0.001, &toks);
+        let idf = flat_idf();
+        let high = score_candidate("foo", "src/lib.rs", 0.5, &toks, &idf);
+        let low = score_candidate("bar", "src/lib.rs", 0.001, &toks, &idf);
         assert!(
             high > low,
             "with no keyword hits, PageRank determines the order"


### PR DESCRIPTION
**⚠️ Stacked on top of #58 (corpus audit).** Merge that first; this PR's numbers assume the audited corpus.

## Summary

Adds inverse-document-frequency weighting to the semantic baseline ranker. Sub-token matches against common workspace terms (`symbol`, `file`, `analysis` in a code-analysis crate) get less score; matches against rare terms (`public`, `cache`, `signature`) get more.

## Why

PR #58's audited corpus exposed two scoring failure modes — both caused by common single-word symbols outranking compound names:

1. **\"track which symbols are public\"** → top1 = `Symbol` (a generic type) beat `is_public` on +10 exact match vs +6 sub-token. But `symbol` appears in nearly every name in rts-core — the exact match was inflating against a maximally-common term.
2. **\"how does the analyzer count symbols by kind?\"** → top1 = `SymbolTableAnalyzer` for the same reason.

IDF directly addresses both. Classic Salton-Wong formula: `weight(t) = ln((N+1)/(df(t)+1)) + 1`. Common terms get weights near 1.0; rare terms 4-7×. The exact-name bonus stays +10, but it's now `+10 × IDF` — a rare-term match scores 5-7× higher than a common-term one.

## What

- `IdfWeights::from_candidates()` pre-computes weights over the full pool once per eval.
- `score_candidate(..., &IdfWeights)` multiplies every match-tier bonus by the matched token's IDF weight (including file-path substring).

## Numbers on the audited corpus

| Metric              | Pre-IDF (PR #58) | With IDF      | Δ          |
|---------------------|------------------|---------------|------------|
| MRR                 | 0.336            | 0.402         | +20%       |
| Coverage (all 13 q) | 61.5%            | 69.2%         | +7.7pp     |
| **Answerable cov.** | **80% (8/10)**   | **90% (9/10)**| **+10pp**  |
| Precision@10        | 0.169            | 0.185         | +10%       |

\"track which symbols are public\" went from **miss → rank 9** (`is_public` now in top-10). \"count symbols by kind\" went from **rank 3 → rank 0** (top1 = `kind`). \"how does the analyzer walk nodes?\" went from **rank 2 → rank 0** (top1 = `walker`).

## Cumulative answerable-coverage journey

| Stage                          | Coverage |
|--------------------------------|----------|
| PR #55 baseline (graph-only)   | 40%      |
| PR #56 decompose+stem+dedupe   | 50%      |
| PR #57 limit param (retrieval) | 60%      |
| PR #58 corpus audit            | 80%      |
| **This PR (IDF weighting)**    | **90%**  |

## The one remaining miss

\"what does file analysis do?\" → top1 = `FileAnalysisTask`; expected `analyze_file`/`FileAnalyzer` aren't in top-10. Root cause: the naive stemmer can't unify `analysis` (stems to `analysi`) with `analyze` (stems to `analyz`). Real Porter handles this via -is/-ize rules; ours doesn't. Could be addressed via:
- A small synonym/lemma table for code-domain word pairs
- Real Porter stemmer (~150 lines)
- Word vectors (out of scope for \"graph-only baseline\")

Filed for the next iteration.

## Tests

+2 unit tests:
- `idf_weights_down_weight_common_tokens` — raw IDF behavior on a synthetic 10-candidate pool
- `idf_breaks_single_word_vs_compound_match` — reproduces the `Symbol` vs `is_public` failure mode directly

Existing tests updated to pass `flat_idf()` (weight=1.0 everywhere) to isolate score-tier ordering from IDF noise. 12/12 semantic tests pass. 38/38 workspace test files clean.

## Test plan

- [x] `cargo test -p rts-bench semantic::` — 12/12 pass
- [x] `cargo test --workspace` — all clean
- [x] `cargo fmt --check` clean
- [x] Manual: `rts-bench semantic --corpus corpus/semantic-eval-rts-core.toml --workspace crates/rts-core` produces documented numbers (MRR=0.402, answerable_coverage=90.0%)

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required:` bench-only change. No daemon API change, no runtime impact, no data migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>