### PR TITLE
feat(rts-bench): stemmer lemma overrides — closes last miss (100% answerable coverage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Stemmer lemma overrides — closes the last miss (100% answerable coverage)
+
+PR #59 closed the second-to-last gap on the rts-core corpus, leaving
+one query missing: "what does file analysis do?" — caused by the
+naive stemmer being unable to unify `analysis` (stems to `analysi`)
+with `analyze` (stems to `analyz`). Same word, totally different
+suffixes.
+
+This PR adds a tiny lemma-override table for the Greek-origin
+noun/verb pairs that suffix-strip stemmers can't reconcile. The
+table is intentionally short and well-justified — not a general
+synonym dictionary.
+
+```rust
+const LEMMA_OVERRIDES: &[(&str, &str)] = &[
+    ("analysis", "analyz"),    ("analyses", "analyz"),
+    ("analytic", "analyz"),    ("analytical", "analyz"),
+    ("synthesis", "synthesiz"),("syntheses", "synthesiz"),
+    ("hypothesis", "hypothesiz"), ("hypotheses", "hypothesiz"),
+    ("diagnosis", "diagnos"),  ("diagnoses", "diagnos"),
+];
+```
+
+The overrides are checked before the regular suffix/e logic; if a
+token matches, the override wins. `stem("analyze")` continues to go
+through the regular path (no suffix match, trailing-e strip → `analyz`),
+so the entries are tuned so the two forms meet there.
+
+#### Numbers on the audited corpus
+
+| Metric              | Pre-lemma (PR #59) | With lemma          | Δ          |
+|---------------------|--------------------|---------------------|------------|
+| MRR                 | 0.402              | 0.441               | +10%       |
+| Coverage (all 13 q) | 69.2%              | 76.9%               | +7.7pp     |
+| **Answerable cov.** | **90% (9/10)**     | **100% (10/10)**    | **+10pp**  |
+| Precision@10        | 0.185              | 0.200               | +8%        |
+
+"what does file analysis do?" — previously a miss — now hits at
+**rank 2** (`FileAnalyzer` at position 1, `analyze_file` at position
+7). Three of four expected names land in top-10.
+
+#### Cumulative answerable-coverage journey
+
+| Stage                          | Coverage        |
+|--------------------------------|-----------------|
+| PR #55 baseline (graph-only)   | 40%             |
+| PR #56 decompose+stem+dedupe   | 50%             |
+| PR #57 limit param             | 60%             |
+| PR #58 corpus audit            | 80%             |
+| PR #59 IDF weighting           | 90%             |
+| **This PR (lemma overrides)**  | **100%**        |
+
+From 4-of-10 to 10-of-10 on a verified corpus, all on the graph-only
+baseline — no embeddings, no LLM scoring, no external model.
+
+#### What this means for the embedding question
+
+The original brainstorm proposal hypothesized that embeddings would
+help close the "natural-language ↔ identifier" gap. We now have a
+concrete answer for rts-core: **the graph-only baseline reaches
+100% on the corpus we built**. Any future embedding work has to
+beat this on a *different*, harder corpus to justify its model
+dependency.
+
+Honest caveats:
+- 10 answerable queries is small. The numbers would compress on a
+  larger corpus with harder queries.
+- The corpus was hand-graded by the same author who built the
+  ranker. Confirmation bias is real; an externally-graded corpus
+  (or queries from real agent traces) is the next step.
+- Code-domain natural-language queries skew identifier-shaped.
+  Queries like "where does the migration roll back on failure?" —
+  which require reasoning about *behavior* rather than naming —
+  remain unanswerable by this approach.
+
+#### Test coverage
+
++1 unit test (`stem_lemma_overrides_unify_greek_origin_pairs`)
+covering analysis/analyses/analyze + synthesis/synthesize +
+diagnosis/diagnose. 13/13 semantic tests pass.
+
 ### IDF-weighted sub-token scoring (+10pp answerable coverage → 90% on rts-core)
 
 Adds inverse-document-frequency weighting to the semantic baseline

--- a/crates/rts-bench/src/semantic.rs
+++ b/crates/rts-bench/src/semantic.rs
@@ -292,18 +292,57 @@ pub fn decompose_name(name: &str) -> Vec<String> {
     out.into_iter().filter(|s| s.len() > 1).collect()
 }
 
+/// Greek-origin noun/verb pairs the naive suffix stemmer can't
+/// unify on its own. `analysis` and `analyze` look completely
+/// different to a rule-based stripper (one ends in `-is`, the
+/// other in `-ize`), but they share the same semantic root.
+///
+/// Each entry maps a token to the stem its sibling form would
+/// produce under the regular suffix/e logic. e.g. `stem("analyze")`
+/// naturally lands on `analyz` (no suffix match, trailing-e strip);
+/// we map `analysis` → `analyz` so they meet.
+///
+/// Keep this list small and well-justified — it's a workaround for
+/// stemmer limitations, not a synonym dictionary.
+const LEMMA_OVERRIDES: &[(&str, &str)] = &[
+    // analysis ↔ analyze ↔ analyser ↔ analytical
+    ("analysis", "analyz"),
+    ("analyses", "analyz"),
+    ("analytic", "analyz"),
+    ("analytical", "analyz"),
+    // synthesis ↔ synthesize
+    ("synthesis", "synthesiz"),
+    ("syntheses", "synthesiz"),
+    // hypothesis ↔ hypothesize
+    ("hypothesis", "hypothesiz"),
+    ("hypotheses", "hypothesiz"),
+    // diagnosis ↔ diagnose
+    ("diagnosis", "diagnos"),
+    ("diagnoses", "diagnos"),
+];
+
 /// Drop common English suffixes so different inflections collapse
 /// to the same root. Intentionally simple — not a Porter stemmer,
 /// just enough to map `parsing`/`parse`/`parsed`/`parses` →`pars` and
 /// `nodes`/`node` → `nod`.
 ///
-/// Two passes:
-/// 1. Strip the first matching suffix from a fixed list (if the
+/// Three passes:
+/// 1. Lemma override: a small table of noun/verb pairs the rule-
+///    based stripper can't unify (`analysis` ↔ `analyze`). Checked
+///    first; if the lowercased input matches an entry, return its
+///    override.
+/// 2. Strip the first matching suffix from a fixed list (if the
 ///    resulting stem is still ≥ 3 chars).
-/// 2. Drop a final trailing `e` (so `parse` after the no-suffix path
+/// 3. Drop a final trailing `e` (so `parse` after the no-suffix path
 ///    still lands on `pars`).
 pub fn stem(token: &str) -> String {
-    let mut t = token.to_string();
+    let lower = token.to_lowercase();
+    for (from, to) in LEMMA_OVERRIDES {
+        if lower == *from {
+            return (*to).to_string();
+        }
+    }
+    let mut t = lower;
     // Longest first so e.g. `connection` matches `tion` before `s`.
     let suffixes: &[&str] = &[
         "ations", "ization", "tions", "sions", "ation", "tion", "sion", "ings", "ers", "ies",
@@ -765,6 +804,26 @@ mod tests {
         );
         // 1-char fragments dropped.
         assert_eq!(decompose_name("a_useful_name"), vec!["useful", "name"]);
+    }
+
+    #[test]
+    fn stem_lemma_overrides_unify_greek_origin_pairs() {
+        // The classic case: `analysis` and `analyze` look totally
+        // different to a suffix-strip stemmer (one ends in -is, the
+        // other in -ize) but share a semantic root. The lemma table
+        // forces them to meet on `analyz`.
+        let analyze_stem = stem("analyze");
+        assert_eq!(stem("analysis"), analyze_stem);
+        assert_eq!(stem("analyses"), analyze_stem);
+        assert_eq!(stem("analyzes"), analyze_stem); // suffix-strip path
+        assert_eq!(stem("analyzed"), analyze_stem); // suffix-strip path
+        // Synthesis family.
+        assert_eq!(stem("synthesis"), stem("synthesize"));
+        // Diagnosis family — pre-stem comparison; `diagnose` runs
+        // through the trailing-e path to "diagnos" and `diagnosis`
+        // uses the override to land on the same root.
+        assert_eq!(stem("diagnosis"), "diagnos");
+        assert_eq!(stem("diagnose"), "diagnos");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR #59 left one query unsolved on the rts-core corpus: \"what does file analysis do?\" — caused by the naive stemmer being unable to unify `analysis` (stems to `analysi`) with `analyze` (stems to `analyz`). Same word, totally different Greek/Latin suffixes.

This PR adds a **tiny lemma-override table** for Greek-origin noun/verb pairs the suffix-strip stemmer can't reconcile. Checked before the regular suffix/e logic; if a token matches, the override wins.

```rust
const LEMMA_OVERRIDES: &[(&str, &str)] = &[
    (\"analysis\", \"analyz\"),     (\"analyses\", \"analyz\"),
    (\"analytic\", \"analyz\"),     (\"analytical\", \"analyz\"),
    (\"synthesis\", \"synthesiz\"), (\"syntheses\", \"synthesiz\"),
    (\"hypothesis\", \"hypothesiz\"), (\"hypotheses\", \"hypothesiz\"),
    (\"diagnosis\", \"diagnos\"),   (\"diagnoses\", \"diagnos\"),
];
```

Intentionally short and well-justified — **not** a general synonym dictionary. Each entry is a Greek-origin `-is`/`-ize` pair where the stemmer would otherwise produce two distinct stems for one root.

## Numbers on the audited corpus

| Metric              | Pre-lemma (PR #59) | With lemma          | Δ          |
|---------------------|--------------------|---------------------|------------|
| MRR                 | 0.402              | 0.441               | +10%       |
| Coverage (all 13 q) | 69.2%              | 76.9%               | +7.7pp     |
| **Answerable cov.** | **90% (9/10)**     | **100% (10/10)**    | **+10pp**  |
| Precision@10        | 0.185              | 0.200               | +8%        |

\"file analysis\" — previously a miss — now hits at **rank 2** (`FileAnalyzer` at position 1, `analyze_file` at position 7). Three of four expected names in top-10.

## Cumulative answerable-coverage journey

| Stage                          | Coverage        |
|--------------------------------|-----------------|
| PR #55 baseline (graph-only)   | 40%             |
| PR #56 decompose+stem+dedupe   | 50%             |
| PR #57 `limit` param           | 60%             |
| PR #58 corpus audit            | 80%             |
| PR #59 IDF weighting           | 90%             |
| **This PR (lemma overrides)**  | **100%**        |

From 4-of-10 to 10-of-10 on a verified corpus, all on the **graph-only baseline** — no embeddings, no LLM scoring, no external model.

## What this means for the embedding question

The original brainstorm proposal hypothesized embeddings would help close the natural-language ↔ identifier gap. We now have a concrete answer for this corpus: **the graph-only baseline reaches 100%**. Any future embedding work has to beat this on a *different, harder* corpus to justify its model dependency.

## Honest caveats

- 10 answerable queries is small. Numbers would compress on a larger corpus with harder queries.
- The corpus was hand-graded by the same author who built the ranker. Confirmation bias is real; an externally-graded corpus (or queries mined from real agent traces) is the next step.
- Code-domain natural-language queries skew identifier-shaped. Behavior queries (\"where does the migration roll back on failure?\") remain unanswerable by this approach.

## Tests

+1 unit test (`stem_lemma_overrides_unify_greek_origin_pairs`) covering:
- analysis / analyses / analyze / analyzed / analyzes all collapse to the same stem
- synthesis / synthesize collapse
- diagnosis / diagnose collapse

13/13 semantic tests pass.

## Test plan

- [x] `cargo test -p rts-bench semantic::` — 13/13 pass
- [x] `cargo fmt --check` clean
- [x] Manual: `rts-bench semantic` produces documented numbers (MRR=0.441, answerable_coverage=100.0%)

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required:` bench-only change. No daemon API change, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>