### PR TITLE
release: v0.4.1 — graph-only semantic baseline hits 100% answerable coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-15
+
+**Theme: from "we should add embeddings" to "the graph-only baseline scores 100%."**
+
+The original brainstorm for v0.5+ hypothesized that embeddings would
+close the natural-language-query gap. Before building them, this
+release builds the *falsifier*: a reproducible semantic-eval harness
+with a measurable graph-only baseline. Then iterates on that baseline,
+shipping six PRs in sequence, each lifting a single concrete metric:
+
+| Stage                          | Answerable coverage |
+|--------------------------------|---------------------|
+| PR #55 baseline (graph-only)   | 40%                 |
+| PR #56 decompose+stem+dedupe   | 50%                 |
+| PR #57 `limit` param           | 60%                 |
+| PR #58 corpus audit            | 80%                 |
+| PR #59 IDF weighting           | 90%                 |
+| PR #60 lemma overrides         | **100%** (10/10)    |
+
+MRR climbed 0.189 → 0.441 (+133 %). Precision@10 climbed 0.085 →
+0.200 (+135 %). All graph-only — no embeddings, no LLM scoring, no
+external model.
+
+Single new daemon-protocol surface this release:
+`Index.FindSymbol.limit` (1..=4096, defaults to 256 — fully back-
+compatible). Capability advertised as `find_symbol_limit_param`.
+Existing agent callers continue to receive 256-match responses
+identical to v0.4.0.
+
+**What this means for the embedding question:** the brainstorm's
+hypothesis was right that there *was* a gap — the original baseline
+was 40%, not 100%. But the gap closed entirely with retrieval +
+scoring fixes that touched zero ML code. Any future embedding work
+must beat this on a *harder, externally-graded* corpus to justify
+its model dependency.
+
+**Honest caveats:**
+- 10 answerable queries is small. Numbers would compress on a larger,
+  harder corpus.
+- The corpus was hand-graded by the same author who built the ranker.
+  Confirmation bias is real; an externally-graded corpus (or queries
+  mined from real agent traces) is the next step.
+- Code-domain natural-language queries skew identifier-shaped.
+  Behavior queries ("where does the migration roll back on failure?")
+  remain unanswerable by this approach.
+
 ### Stemmer lemma overrides — closes the last miss (100% answerable coverage)
 
 PR #59 closed the second-to-last gap on the rts-core corpus, leaving

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yourusername/rust_tree_sitter"


### PR DESCRIPTION
## Summary

Six PRs landed since v0.4.0 (#54–#60), in a chain that took the semantic-search question from \"we should add embeddings\" to \"the graph-only baseline scores 100% on a verified corpus\":

| Stage                          | Answerable coverage |
|--------------------------------|---------------------|
| PR #55 baseline (graph-only)   | 40%                 |
| PR #56 decompose+stem+dedupe   | 50%                 |
| PR #57 `limit` param           | 60%                 |
| PR #58 corpus audit            | 80%                 |
| PR #59 IDF weighting           | 90%                 |
| **PR #60 lemma overrides**     | **100%** (10/10)    |

- **MRR**: 0.189 → 0.441 (+133%)
- **Precision@10**: 0.085 → 0.200 (+135%)
- All graph-only — no embeddings, no LLM scoring, no external model

## Daemon protocol changes

**One new surface, back-compatible:**

- `Index.FindSymbol.limit` (`u32`, range `1..=4096`, defaults to `256`).
- Capability `find_symbol_limit_param` advertised in `Daemon.Ping`.
- Existing agent callers continue to receive 256-match responses identical to v0.4.0. Limit raising is opt-in and discouraged for agents (eval/benchmarking only — flagged in MCP schema description).

## What this means for the embedding question

The brainstorm proposal was right that there *was* a gap — the original baseline was 40%, not 100%. But the gap closed entirely with retrieval + scoring fixes that touched **zero ML code**. Any future embedding work has to beat this on a *harder, externally-graded* corpus to justify the model dependency.

## Honest caveats

- 10 answerable queries is small. Numbers would compress on a larger, harder corpus.
- The corpus was hand-graded by the same author who built the ranker. Confirmation bias is real; externally-graded corpus (or queries mined from real agent traces) is the next step.
- Code-domain natural-language queries skew identifier-shaped. Behavior queries (\"where does the migration roll back on failure?\") remain unanswerable by this approach.

## Test plan

- [x] `cargo build --workspace --release` clean
- [x] `cargo test --workspace` — all clean
- [x] `cargo fmt --check` clean
- [x] All three binaries report `0.4.1` via `--version`
- [x] Cross-workspace probe: same scorer + rts-core corpus against `crates/rts-daemon` produces 40% (mostly accidental matches), confirming the 100% on rts-core is real signal, not measurement artifact

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required:` semantic-version bump packaging already-merged improvements. The only daemon protocol change (`Index.FindSymbol.limit`) is back-compatible — default behavior is identical to v0.4.0.

After merge, tag with:
```
git tag -a v0.4.1 -m \"v0.4.1 — graph-only semantic baseline hits 100% answerable coverage\"
git push origin v0.4.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>