### PR TITLE
chore(corpus): blind-v2 exposes confirmation bias — honest coverage is 90%, not 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Blind-v2 corpus — confirmation-bias correction on the v0.4.1 claim
+
+The v0.4.1 release claimed 100% answerable coverage on a 10-query
+rts-core corpus. The release notes flagged the honest caveat: the
+corpus was hand-graded by the same author who built the ranker,
+which biases the measurement.
+
+This PR addresses that caveat directly. A second corpus,
+`corpus/semantic-eval-rts-core-blind-v2.toml`, was written
+*outside-in* — queries drafted from agent-coding-loop patterns
+(error/debugging, lifecycle, extension, performance, result-
+collection) without first inspecting the symbol table. Only after
+drafting did each query's `expected_top_k` get graded against the
+actual 4096-symbol pool. Queries with no plausible answer became
+negative controls.
+
+#### What the blind corpus says
+
+| Corpus           | Queries | Answerable | Coverage     | MRR   |
+|------------------|---------|------------|--------------|-------|
+| v1 (original)    | 13      | 10         | **100%**     | 0.441 |
+| **blind v2**     | 15      | 10         | **80%** (8/10) | 0.273 |
+| Combined         | 28      | 20         | **90%** (18/20) | 0.351 |
+
+**The honest generalization number is 90%, not 100%.** The 20pp gap
+between v1 and blind v2 is the real confirmation-bias correction
+on the original measurement.
+
+#### The two blind-corpus misses (filed)
+
+1. **"what cleans up after analysis?"** → top1 = `cleaned` (a noise
+   match). Expected `clear`/`clear_cache`/`reset` are in the pool
+   but not in top-10. Root cause: `clean*` and `clear*` are
+   synonyms only to humans — the stemmer treats them as unrelated
+   roots. A synonym table (similar to the Greek-origin lemma overrides)
+   could close this.
+
+2. **"where are language-specific queries defined?"** → top1 =
+   `get_language_specific_complexity`. Expected `LanguageParser`/
+   `QueryBuilder`/`Query` are in the pool. The miss is a real
+   trade-off: compound names with two matching sub-tokens
+   (`language` + `specific`) legitimately outscore single-match
+   names. This isn't strictly wrong — it's a corpus-grading
+   judgment call.
+
+Neither miss is a bug. Both are now-visible limits of the graph-
+only baseline against agent-natural queries.
+
+#### Implication for the embedding question
+
+The 100%→90% correction doesn't change the conclusion meaningfully:
+the graph-only baseline still covers nearly all natural-language
+queries that have an identifier-shaped answer. Any embedding work
+still needs to beat 90% on a *harder, externally-graded* corpus —
+ideally one mined from real agent transcripts — to justify the
+model dependency.
+
+The two specific miss patterns above are concrete targets that
+future ranker work (synonym tables, multi-token prioritization) or
+future capability work (doc-comment indexing) could close *without*
+needing embeddings.
+
 ## [0.4.1] - 2026-05-15
 
 **Theme: from "we should add embeddings" to "the graph-only baseline scores 100%."**

--- a/corpus/semantic-eval-rts-core-blind-v2.toml
+++ b/corpus/semantic-eval-rts-core-blind-v2.toml
@@ -1,0 +1,140 @@
+# Semantic-search evaluation corpus for `crates/rts-core` — blind v2.
+#
+# Companion to `semantic-eval-rts-core.toml`. Where v1 was authored
+# after building the ranker (hence the v0.4.1 honest caveat about
+# confirmation bias), v2 was written outside-in: queries phrased the
+# way a new agent landing in *any* code-analysis crate might ask,
+# without first peeking at the symbol table.
+#
+# Workflow used:
+# 1. Drafted 18 queries from agent-coding-loop patterns: error/debug,
+#    lifecycle, extension, performance, plus 5 fictional topics.
+# 2. THEN probed `find_symbol(pattern="*", limit=4096)` to see what
+#    realistic answers exist in the pool. Queries with no plausible
+#    answer became negative controls; others got hand-graded
+#    `expected_top_k` lists of real symbols.
+# 3. Dropped 3 queries where every type would match ("how does X
+#    initialize?" against a crate full of `*Analyzer`s with `new`).
+#
+# Categories covered (v1 corpus covered none of these):
+#   - Error/debugging queries (3)
+#   - Lifecycle/workflow queries (3)
+#   - Extension/integration queries (2)
+#   - Performance/optimization queries (1)
+#   - Result-collection query (1)
+#   - Negative controls (5)
+#
+# Purpose: stress-test the v0.4.1 100%-on-v1 baseline on queries that
+# weren't shaped by knowledge of the codebase. If coverage drops
+# meaningfully on v2, the v1 number was corpus-overfit. If it stays
+# high, the baseline generalizes.
+
+version = 1
+
+# ─── Error / debugging queries ───
+
+[[query]]
+text = "what raises errors when parsing fails?"
+expected_top_k = ["ParseErrorDetails", "Parser", "Error", "LanguageErrorDetails", "QueryErrorType"]
+
+[[query]]
+text = "how are tree-sitter parser errors reported?"
+expected_top_k = ["TreeErrorDetails", "ParseErrorDetails", "Parser", "LanguageErrorDetails"]
+
+[[query]]
+text = "what error types exist for the parser?"
+expected_top_k = [
+    "ParseErrorDetails",
+    "LanguageErrorDetails",
+    "QueryErrorDetails",
+    "TreeErrorDetails",
+    "QueryErrorType",
+    "Error",
+]
+
+# ─── Lifecycle / workflow queries ───
+
+[[query]]
+text = "what runs first when analysis starts?"
+expected_top_k = ["FileAnalyzer", "CodebaseAnalyzer", "analyze", "analyze_file"]
+
+[[query]]
+text = "how does the cache get populated?"
+expected_top_k = [
+    "FileCache",
+    "cache_tree",
+    "calculate_cache_key",
+    "cache_key",
+    "cache_capacity",
+]
+
+[[query]]
+text = "what cleans up after analysis?"
+expected_top_k = ["clear", "clear_cache", "reset", "reset_statistics"]
+
+# ─── Extension / integration queries ───
+
+[[query]]
+text = "where are language-specific queries defined?"
+expected_top_k = [
+    "LanguageParser",
+    "QueryBuilder",
+    "Query",
+    "JavaScriptSyntax",
+    "PythonSyntax",
+]
+
+[[query]]
+text = "where is the JavaScript-specific extractor?"
+expected_top_k = [
+    "JavaScriptSyntax",
+    "detect_js_allocations",
+    "calculate_js_npath",
+    "detect_js_memory_leaks",
+]
+
+# ─── Performance / optimization ───
+
+[[query]]
+text = "where are allocation patterns optimized?"
+expected_top_k = [
+    "AllocationHotspot",
+    "AllocationPattern",
+    "AsyncOptimization",
+    "MemoryHotspot",
+    "MemoryLeakCandidate",
+]
+
+# ─── Result-collection query ───
+
+[[query]]
+text = "where does the analyzer collect results?"
+expected_top_k = [
+    "AnalysisResult",
+    "ResultAggregator",
+    "collect_definitions",
+    "SymbolAnalysisResult",
+    "DependencyAnalysisResult",
+]
+
+# ─── Negative controls — confirmed absent from the 4096-pool ───
+
+[[query]]
+text = "where do file I/O failures get handled?"
+expected_top_k = []
+
+[[query]]
+text = "where is panic recovery wired up?"
+expected_top_k = []
+
+[[query]]
+text = "where is the WebSocket handler?"
+expected_top_k = []
+
+[[query]]
+text = "what's the OAuth flow implementation?"
+expected_top_k = []
+
+[[query]]
+text = "where is the Redis cache adapter?"
+expected_top_k = []


### PR DESCRIPTION
## Summary

The v0.4.1 release claimed **100% answerable coverage** on a 10-query rts-core corpus, with the honest caveat: the corpus was hand-graded by the same author who built the ranker.

This PR addresses that caveat directly. A second corpus (`corpus/semantic-eval-rts-core-blind-v2.toml`) was written **outside-in**:

1. Drafted 18 queries from agent-coding-loop patterns (error/debug, lifecycle, extension, performance, result-collection, plus fictional negative controls) — **without first inspecting the symbol table**.
2. Only *after* drafting did each query's `expected_top_k` get graded against the actual 4096-symbol pool.
3. Queries with no plausible answer became negative controls. Queries where every type would match (e.g. \"how does X initialize?\") were dropped.

## Result

| Corpus           | Queries | Answerable | Coverage          | MRR   |
|------------------|---------|------------|-------------------|-------|
| v1 (original)    | 13      | 10         | **100%** (10/10)  | 0.441 |
| **blind v2**     | 15      | 10         | **80%** (8/10)    | 0.273 |
| **Combined**     | 28      | 20         | **90%** (18/20)   | 0.351 |

**The honest generalization number is 90%, not 100%.** The 20pp gap between v1 and blind v2 is the real confirmation-bias correction.

## The two blind-corpus misses (filed)

1. **\"what cleans up after analysis?\"** → top1 = `cleaned`. Expected `clear`/`clear_cache`/`reset` are in the pool but not in top-10. Root cause: `clean*` and `clear*` are synonyms only to humans — the stemmer treats them as unrelated roots. A synonym table (similar to the Greek-origin lemma overrides from PR #60) could close this.
2. **\"where are language-specific queries defined?\"** → top1 = `get_language_specific_complexity`. Expected `LanguageParser`/`QueryBuilder`/`Query` are in the pool. The miss is a real trade-off: compound names with two matching sub-tokens (`language` + `specific`) legitimately outscore single-match names.

Neither miss is a bug. Both are now-visible limits of the graph-only baseline against agent-natural queries.

## Implication for the embedding question

The 100%→90% correction doesn't change the conclusion meaningfully: the graph-only baseline still covers nearly all natural-language queries that have an identifier-shaped answer.

Any embedding work still needs to beat **90%** on a *harder, externally-graded* corpus — ideally one mined from real agent transcripts — to justify the model dependency.

The two specific miss patterns above are concrete targets that future ranker work (synonym tables, multi-token prioritization) or future capability work (doc-comment indexing) could close *without* needing embeddings.

## Test plan

- [x] Every `expected_top_k` name verified present in the daemon's 4096-pool via probe
- [x] Manual: `rts-bench semantic --corpus corpus/semantic-eval-rts-core-blind-v2.toml --workspace crates/rts-core` produces documented numbers
- [x] Manual: combined v1+v2 corpus produces 90% answerable coverage
- [x] No code change; corpus-only addition

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required:` corpus addition. No code change, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>