### PR TITLE
feat(ci): rts-bench semantic --check-coverage flag + CI regression guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,22 @@ jobs:
 
       - name: Build all workspace binaries
         run: cargo build --workspace --bins
+
+      # Semantic-baseline regression guard. Runs the bench against the
+      # rts-core corpus and fails CI if `answerable_coverage` falls
+      # below 0.90 (the honest combined-corpus baseline from v0.4.1+
+      # blind-v2). Catches ranker / retrieval regressions on every PR.
+      #
+      # Cost: ~30-60s extra per CI run (cold-mount + indexing on a
+      # small workspace + 10 queries). Worth it — without this, the
+      # 100%/90% numbers in CHANGELOG are snapshots, not invariants.
+      - name: Semantic baseline (regression guard)
+        run: |
+          RTS_MCP_BIN=$PWD/target/debug/rts-mcp \
+          RTS_DAEMON_BIN=$PWD/target/debug/rts-daemon \
+          ./target/debug/rts-bench semantic \
+            --corpus corpus/semantic-eval-rts-core.toml \
+            --workspace crates/rts-core \
+            --top-k 10 \
+            --dry-run \
+            --check-coverage 0.95

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI semantic-baseline regression guard
+
+`rts-bench semantic` now accepts `--check-coverage <FLOAT>`. When
+set, the bench exits with code 2 if the observed
+`answerable_coverage` falls below the threshold; pass-case prints
+`check: answerable_coverage X.XXX ≥ required Y.YYY ✓` and exits 0.
+
+CI wired to run the bench on every PR / push against
+`corpus/semantic-eval-rts-core.toml` (the v1 verified corpus) with
+threshold `0.95`. Future ranker / retrieval changes that regress
+below this number will fail CI.
+
+Why
+---
+Without this, the 100% answerable-coverage claim in v0.4.1 is a
+snapshot, not an invariant. A future refactor of the daemon's
+`find_symbol`, the bench's scorer, the prelude filter, the
+PageRank weights, or even an upgrade to a tree-sitter grammar
+that changes which symbols get extracted, could silently regress
+the baseline. Now it can't slip past code review.
+
+Cost: ~30-60 seconds extra per CI run (cold-mount + small
+workspace + 10 queries). Worth it.
+
+Follow-up: now that the blind-v2 corpus has landed (#62), the CI
+guard should upgrade to the combined corpus with threshold 0.85
+(the honest combined-corpus baseline of 0.90 minus a 5pp regression
+buffer).
+
 ### Blind-v2 corpus — confirmation-bias correction on the v0.4.1 claim
 
 The v0.4.1 release claimed 100% answerable coverage on a 10-query

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -155,6 +155,12 @@ enum Cmd {
         /// Skip writing the report.
         #[arg(long)]
         dry_run: bool,
+        /// Regression guard: fail the process with exit code 2 if
+        /// `answerable_coverage` falls below this threshold (e.g.
+        /// `0.90` for 90%). Use in CI to catch ranker regressions.
+        /// Default: no check, exits 0 regardless of metrics.
+        #[arg(long)]
+        check_coverage: Option<f64>,
     },
 }
 
@@ -436,7 +442,8 @@ async fn main() -> Result<()> {
             top_k,
             out,
             dry_run,
-        } => run_semantic(corpus, workspace, top_k, out, dry_run).await,
+            check_coverage,
+        } => run_semantic(corpus, workspace, top_k, out, dry_run, check_coverage).await,
     }
 }
 
@@ -446,6 +453,7 @@ async fn run_semantic(
     top_k: usize,
     out: Option<PathBuf>,
     dry_run: bool,
+    check_coverage: Option<f64>,
 ) -> Result<()> {
     let workspace = workspace
         .canonicalize()
@@ -498,16 +506,33 @@ async fn run_semantic(
         );
     }
 
-    if dry_run {
-        return Ok(());
+    if !dry_run {
+        let out_path = out.unwrap_or_else(|| {
+            std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(format!("bench-semantic-{}.json", git_short_sha()))
+        });
+        semantic::write_report(&out_path, &report)?;
+        println!("wrote {}", out_path.display());
     }
-    let out_path = out.unwrap_or_else(|| {
-        std::env::current_dir()
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join(format!("bench-semantic-{}.json", git_short_sha()))
-    });
-    semantic::write_report(&out_path, &report)?;
-    println!("wrote {}", out_path.display());
+
+    // Regression guard: after writing the report, gate on coverage.
+    // Print on its own line so CI failure logs make the threshold
+    // and observed value easy to spot.
+    if let Some(min) = check_coverage {
+        if report.answerable_coverage + f64::EPSILON < min {
+            eprintln!(
+                "regression: answerable_coverage {:.3} < required {:.3}",
+                report.answerable_coverage, min
+            );
+            std::process::exit(2);
+        } else {
+            println!(
+                "check: answerable_coverage {:.3} ≥ required {:.3} ✓",
+                report.answerable_coverage, min
+            );
+        }
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Option #1 from the post-v0.4.1 menu. Adds `rts-bench semantic --check-coverage <FLOAT>` and wires it into the CI workflow.

After running the eval, the bench exits with code **2** if the observed `answerable_coverage` falls below the threshold; the pass-case prints `check: answerable_coverage X.XXX ≥ required Y.YYY ✓` and exits 0.

CI runs the bench on every PR / push against the v1 verified corpus (`corpus/semantic-eval-rts-core.toml`) with **threshold `0.95`**. Future changes that regress below 95% answerable coverage now fail CI.

## Why

Without this, the 100% answerable-coverage claim in v0.4.1 is a snapshot, not an invariant. A future refactor of the daemon's `find_symbol`, the bench's scorer, the prelude filter, the PageRank weights, or even a tree-sitter grammar upgrade that changes which symbols get extracted, could silently regress the baseline. **Now it can't slip past code review.**

Cost: ~30-60 seconds extra per CI run (cold-mount + small workspace + 10 queries). Worth it.

## Local validation

| Case                | Result   |
|---------------------|----------|
| `--check-coverage 0.95` against v1 corpus | exit **0** + `check: ... ≥ required 0.950 ✓` |
| `--check-coverage 1.5` against v1 corpus  | exit **2** + `regression: ... < required 1.500` |
| existing tests | all pass |

## Follow-up

Once the blind-v2 corpus lands (companion PR #62), the CI guard should upgrade to the combined corpus with threshold **0.85** (the honest combined-corpus baseline of 0.90 minus a 5pp regression buffer). That's a one-line YAML change as a follow-up after both this PR and #62 merge.

## Test plan

- [x] `cargo build -p rts-bench --release` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p rts-bench` — all pass
- [x] Local pass case: `--check-coverage 0.95` exits 0
- [x] Local fail case: `--check-coverage 1.5` exits 2
- [x] CI itself will validate (this PR exercises the guard against itself)

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required:` CI-only addition. No daemon API change, no runtime impact on existing users. The new flag defaults to None (no check), so adding `--check-coverage` to existing scripts is fully opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>