### PR TITLE
feat(rts-core): extract Rust const and static — closes PR #76 dogfood gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Rust `const` and `static` extraction — closes the PR #76 dogfood gap
+
+PR #76's honest dogfood report flagged: **Rust `const` declarations
+don't surface via `find_symbol`** — they weren't extracted as symbols
+by `extract_rust_symbols`. Agents searching for constants by name
+had to fall back to grep.
+
+This PR closes the gap by adding `const_item` and `static_item`
+extraction to `extract_rust_symbols`. Both module-level constants
+and function-local consts now surface as symbols with their doc
+comments attached.
+
+#### Verification
+
+The exact lookup that failed during PR #76's dogfood now works:
+
+```text
+$ rts-bench query find-symbol --workspace . --name DAEMON_CAPABILITIES
+  DAEMON_CAPABILITIES (const)  @  crates/rts-daemon/src/methods/daemon.rs:18
+
+$ rts-bench query find-symbol --workspace . --name DEFAULT_LIMIT
+  { qualified_name: "DEFAULT_LIMIT", kind: "const",
+    doc: "Default cap when no `limit` is supplied. ...",
+    file: "crates/rts-daemon/src/methods/index.rs", line: 469 }
+```
+
+Pattern queries work too: `--pattern "DEFAULT_*"` returns 8+
+constants across rts-core / rts-bench / rts-daemon, all with their
+doc-strings populated (v0.5.0+).
+
+#### What changed
+
+`crates/rts-core/src/analyzer.rs`:
+- New extraction pass in `extract_rust_symbols` that walks
+  `const_item` and `static_item` nodes
+- Sets `kind: "const"` or `kind: "static"` accordingly
+- Visibility derived from presence of `visibility_modifier` child
+- Doc comments extracted via the existing `extract_rust_doc_comments`
+  path (so `///`-line blocks attach correctly)
+
+Function-local consts get extracted too — tree-sitter's recursive
+descent picks them up alongside module-level ones.
+
+#### Test coverage
+
++1 unit test (`test_rust_const_and_static_extraction`) covering:
+- `pub const` extracted with `kind: "const"`, `visibility: "public"`
+- Multiple consts in the same file
+- `static` extracted with `kind: "static"`
+- Doc-string flows through
+
+595 workspace tests pass.
+
 ### `Index.FindSymbol.doc_contains` — behavior-shaped queries via doc text
 
 Built while **dogfooding the daemon** as my primary navigation surface. Filter `Index.FindSymbol` matches by case-insensitive substring against doc text. Lets agents ask "find the cache eviction code" → matches any documented symbol whose comment mentions `evict`, regardless of identifier name.

--- a/crates/rts-core/src/analyzer.rs
+++ b/crates/rts-core/src/analyzer.rs
@@ -1112,6 +1112,53 @@ impl CodebaseAnalyzer {
             });
         }
 
+        // Extract `const` and `static` declarations.
+        //
+        // Surfaces module-level constants (e.g. `pub const DEFAULT_LIMIT:
+        // usize = 256;`) and statics (e.g. `static FOO: AtomicU32 = …`)
+        // via `find_symbol`. Without this, agents searching by constant
+        // name fall back to grep — a real dogfooding gap surfaced in
+        // PR #76's report.
+        //
+        // tree-sitter rust grammar: `const_item` and `static_item`. Both
+        // expose a `name` child field. Doc comments use the same
+        // `///`-line scan as fns / structs / enums.
+        for kind_name in ["const_item", "static_item"] {
+            let items = tree.find_nodes_by_kind(kind_name);
+            for item in items {
+                if let Some(name_node) = item.child_by_field_name("name") {
+                    if let Ok(name) = name_node.text() {
+                        let visibility = if item
+                            .children()
+                            .iter()
+                            .any(|child| child.kind() == "visibility_modifier")
+                        {
+                            "public"
+                        } else {
+                            "private"
+                        };
+                        let docs =
+                            self.extract_rust_doc_comments(content, item.start_position().row);
+                        let kind_label = if kind_name == "const_item" {
+                            "const"
+                        } else {
+                            "static"
+                        };
+                        symbols.push(Symbol {
+                            name: name.to_string(),
+                            kind: kind_label.to_string(),
+                            start_line: item.start_position().row + 1,
+                            end_line: item.end_position().row + 1,
+                            start_column: item.start_position().column,
+                            end_column: item.end_position().column,
+                            visibility: visibility.to_string(),
+                            documentation: docs,
+                        });
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -2431,6 +2478,57 @@ mod tests {
             counter_docs, "Single-line JSDoc.",
             "single-line JSDoc should strip leading `*`"
         );
+    }
+
+    #[test]
+    fn test_rust_const_and_static_extraction() {
+        // Module-level `const` and `static` declarations weren't
+        // surfaced as symbols pre-this-PR, forcing agents to fall
+        // back to grep for constant lookups (see PR #76 dogfood
+        // report).
+        let temp_dir = TempDir::new().unwrap();
+        let rs_file = temp_dir.path().join("constants.rs");
+        fs::write(
+            &rs_file,
+            "/// The default request limit.\npub const DEFAULT_LIMIT: usize = 256;\n\n/// Maximum supported.\npub const MAX_LIMIT: usize = 4096;\n\nstatic INTERNAL_FLAG: bool = false;\n",
+        )
+        .unwrap();
+
+        let mut analyzer = CodebaseAnalyzer::new().unwrap();
+        let result = analyzer.analyze_directory(temp_dir.path()).unwrap();
+        let info = result
+            .files
+            .iter()
+            .find(|f| f.path.extension().unwrap() == "rs")
+            .unwrap();
+
+        let default_limit = info
+            .symbols
+            .iter()
+            .find(|s| s.name == "DEFAULT_LIMIT")
+            .expect("DEFAULT_LIMIT should be extracted as a symbol");
+        assert_eq!(default_limit.kind, "const");
+        assert_eq!(default_limit.visibility, "public");
+        assert_eq!(
+            default_limit.documentation.as_deref(),
+            Some("The default request limit."),
+            "const doc should flow through"
+        );
+
+        let max_limit = info
+            .symbols
+            .iter()
+            .find(|s| s.name == "MAX_LIMIT")
+            .expect("MAX_LIMIT should be extracted");
+        assert_eq!(max_limit.kind, "const");
+
+        let internal_flag = info
+            .symbols
+            .iter()
+            .find(|s| s.name == "INTERNAL_FLAG")
+            .expect("static INTERNAL_FLAG should be extracted as a symbol");
+        assert_eq!(internal_flag.kind, "static");
+        assert_eq!(internal_flag.visibility, "private");
     }
 
     #[test]


### PR DESCRIPTION
PR #76's honest dogfood report flagged: **Rust `const` declarations don't surface via `find_symbol`**. Agents searching for constants by name had to fall back to grep. This closes the gap.

## What changed

`extract_rust_symbols` now walks `const_item` and `static_item` tree-sitter nodes:
- `kind: "const"` or `kind: "static"`
- `visibility`: derived from `visibility_modifier` child
- `documentation`: extracted via the existing `extract_rust_doc_comments` path so `///` blocks attach correctly

**Function-local consts get extracted too** — tree-sitter's recursive descent picks them up alongside module-level ones.

## Verification

The exact lookup that failed during PR #76's dogfood now works:

```
$ rts-bench query find-symbol --workspace . --name DAEMON_CAPABILITIES
  DAEMON_CAPABILITIES (const)  @  crates/rts-daemon/src/methods/daemon.rs:18

$ rts-bench query find-symbol --workspace . --name DEFAULT_LIMIT
  { kind: "const",
    doc: "Default cap when no `limit` is supplied. ...",
    file: "crates/rts-daemon/src/methods/index.rs", line: 469 }
```

Pattern queries: `--pattern "DEFAULT_*"` returns 8+ constants across rts-core, rts-bench, and rts-daemon, all with doc-strings populated (v0.5.0+).

## Tests

+1 unit test (`test_rust_const_and_static_extraction`) covering:
- `pub const` → `kind: "const"`, `visibility: "public"`
- Multiple consts in same file
- `static` → `kind: "static"`
- Doc-string flows through

**595 workspace tests pass.**

## Test plan

- [x] `cargo test --workspace` — 595/0 pass
- [x] `cargo fmt --check` clean
- [x] Manual: `DAEMON_CAPABILITIES`, `DEFAULT_LIMIT`, `MAX_LIMIT` all return real metadata via find_symbol
- [x] CI guard: no scoring change, eval coverage unaffected

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required:` extractor addition. Existing symbol indices will pick up consts on next re-index. No daemon API change, no schema change, no behavior removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>