### PR TITLE
fix(release): drop hung x86_64-apple-darwin target; unblock SHA256SUMS aggregator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,13 @@
 # Coverage:
 #   - x86_64-unknown-linux-gnu     (ubuntu-latest, native)
 #   - aarch64-unknown-linux-gnu    (ubuntu-24.04-arm, native)
-#   - x86_64-apple-darwin          (macos-13, native Intel)
-#   - aarch64-apple-darwin         (macos-latest, native M-series)
+#   - aarch64-apple-darwin         (macos-latest, native Apple Silicon)
+#
+# Intel Mac (x86_64-apple-darwin) is intentionally dropped. The
+# `macos-13` runner pool hung indefinitely on every release in this
+# series (v0.5.0, v0.5.1, v0.5.2) — see commit history. Intel Mac
+# users build from source via `cargo install` for now; a Rosetta-aware
+# universal binary lands when there's user demand.
 #
 # Windows is intentionally out — the daemon uses `std::os::unix` (Unix
 # sockets + permissions) and the watcher's fs path is inotify/fsevents.
@@ -66,9 +71,6 @@ jobs:
             archive_ext: tar.gz
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
-            archive_ext: tar.gz
-          - target: x86_64-apple-darwin
-            runner: macos-13
             archive_ext: tar.gz
           - target: aarch64-apple-darwin
             runner: macos-latest
@@ -190,7 +192,14 @@ jobs:
     # Run on tag push so the aggregated SHA256SUMS file lands in the
     # draft release alongside the individual sidecars. workflow_dispatch
     # skips this — it's only relevant for actual releases.
-    if: github.ref_type == 'tag'
+    #
+    # `success() || failure()` (not `always()`) — runs once the build
+    # matrix has finished, even if one entry failed, but skips when the
+    # job was cancelled. Pre-fix this job required ALL matrix entries
+    # to succeed; the broken Intel Mac entry meant SHA256SUMS never
+    # published on v0.5.0, v0.5.1, or v0.5.2. With Intel Mac dropped
+    # and this guard, the aggregator publishes from whatever survived.
+    if: github.ref_type == 'tag' && (success() || failure())
     runs-on: ubuntu-latest
     steps:
       - name: Download all checksums

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Release workflow — drop hung Intel Mac target, unblock SHA256SUMS aggregator
+
+Diagnosed while babysitting the v0.5.2 release: the `x86_64-apple-darwin` matrix entry on the `macos-13` runner pool has hung **on every release in this series** (v0.5.0, v0.5.1, v0.5.2 all show the job perpetually queued, never completing). The cascading consequence: `aggregate-checksums` has `needs: build` and waits on all 4 entries, so the consolidated `SHA256SUMS` file was never published — the README's verify snippet (`sha256sum -c SHA256SUMS --ignore-missing`) pointed at a file that didn't exist on any release.
+
+This PR does two things:
+
+1. **Drops `x86_64-apple-darwin` from the build matrix.** GitHub's `macos-13` runners have been flaky-to-broken since the macOS 14/15 transition. Intel Mac users build from source via `cargo install` (the Option B path in the README) — the user population is small and shrinking; the alternative is a universal-binary cross-compile from `macos-latest`, which we can add later if there's demand.
+2. **Loosens the `aggregate-checksums` gate** to `success() || failure()`. The aggregator now publishes whatever the surviving matrix entries managed to upload, even when a target fails. (`always()` would also fire on cancellation — we don't want that.)
+
+Net effect: v0.5.3+ releases will ship 3 tarballs + per-asset `.sha256` sidecars + the aggregated `SHA256SUMS` file, all checksum-verifiable end-to-end.
+
+README updated to drop the Intel Mac row and note the build-from-source path for that platform.
+
 ### `Index.FindSymbol.include_signature` — opt-in per-match signature rendering
 
 The `signature` field on `find_symbol` matches has shipped as `null` since v0 because the writer doesn't store rendered signatures — they're computed on demand by `Index.ReadSymbol shape=signature`. That's the right default for the common case (an agent calling `find_symbol` doesn't always need signatures), but the cost is that **outline-style follow-ups need a separate `read_symbol` call per match** to see signatures.

--- a/README.md
+++ b/README.md
@@ -104,11 +104,13 @@ license files, and this README. Available targets:
 |---|---|
 | `x86_64-unknown-linux-gnu` | most Linux distros (Ubuntu 20.04+, Debian 11+, RHEL 9+) |
 | `aarch64-unknown-linux-gnu` | ARM Linux (Raspberry Pi 64-bit, AWS Graviton) |
-| `x86_64-apple-darwin` | Intel Mac |
-| `aarch64-apple-darwin` | Apple Silicon Mac |
+| `aarch64-apple-darwin` | Apple Silicon Mac (M1/M2/M3/M4) |
 
 Windows is not yet supported — the daemon uses Unix sockets (a Windows
-port lands in v1.x).
+port lands in v1.x). Intel Mac (x86_64-apple-darwin) prebuilt tarballs
+were dropped after the `macos-13` GitHub runner pool started hanging
+indefinitely; Intel Mac users should build from source via Option B
+below.
 
 ```sh
 # Pick the right target for your platform


### PR DESCRIPTION
## Summary

Surfaced while babysitting the v0.5.2 release. The `x86_64-apple-darwin` matrix entry on `macos-13` runners has **hung indefinitely on every release in this series** (verified across v0.5.0, v0.5.1, v0.5.2 — same job perpetually queued, no logs, no completion). Two cascading consequences:

1. **Each release ships only 3 of 4 tarballs.** Intel Mac users get nothing prebuilt.
2. **`SHA256SUMS` is missing from every release.** The `aggregate-checksums` job had `needs: build` and required all 4 matrix entries to finish — Intel Mac never did, so the aggregator never ran. The README's verify snippet points to a file that doesn't exist on any release.

## Changes

| File | Change |
|---|---|
| `.github/workflows/release.yml` | Drop `x86_64-apple-darwin` matrix row; loosen `aggregate-checksums.if` to `success() || failure()` |
| `README.md` | Drop Intel Mac row from the install table; note the build-from-source path |
| `CHANGELOG.md` | Unreleased entry with the diagnosis + fix narrative |

## Why drop the target instead of fixing it?

`macos-13` runner pool has been flaky-to-broken since GitHub's macOS 14/15 transition. Apple Silicon is the dominant developer hardware; Intel Mac users have `cargo install` as a clean fallback (Option B in the README). A Rosetta-aware universal-binary cross-compile from `macos-latest` is a separate, lower-priority follow-up if real user demand surfaces.

## Why `success() \|\| failure()` not `always()`?

`always()` fires on cancellation too — we don't want a SHA256SUMS publish if the maintainer cancelled the run mid-flight. `success() || failure()` runs only after the matrix completes naturally.

## Verification (post-merge)

The next tag push (likely v0.5.3 after the `include_signature` work) will be the verification. Expected:
- 3 tarballs uploaded (`x86_64-linux`, `aarch64-linux`, `aarch64-apple-darwin`)
- 3 per-asset `.sha256` sidecars
- 1 consolidated `SHA256SUMS` (the file that's been missing)

## Test plan

- [x] YAML syntax check via `gh workflow view release.yml` (post-push)
- [x] README diff manually reviewed — no Markdown-table breakage
- [x] CHANGELOG entry follows existing prose style
- [ ] Run-time validation lands when v0.5.3 tag pushes

## Post-Deploy Monitoring & Validation

- **What to monitor**: `gh run list --workflow=release.yml --limit 1` after the next tag push — expect `conclusion: success`
- **Validation check**: `curl -fsSL https://github.com/njfio/rs-agent-code-utility/releases/download/vX.Y.Z/SHA256SUMS` should now return a file (previously 404)
- **Expected healthy behavior**: all 3 build jobs SUCCESS; `aggregate-checksums` SUCCESS; release draft has SHA256SUMS asset
- **Failure signal**: if `aggregate-checksums` doesn't run, the `if` condition needs another look
- **Validation window**: next tagged release (within days); owner: maintainer who merges this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)