### PR TITLE
feat(rts-daemon): include_signature — auto-default for small-result queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,36 @@ A `find_symbol --doc-contains "evict"` query against the indexed workspace retur
 #### Test coverage
 
 +1 unit test (`test_csharp_extraction`) covering class, method, record, and interface extraction with XML doc payload assertions.
+### `Index.FindSymbol.include_signature` — auto-default for small-result queries
+
+PR #81 shipped `include_signature` as opt-in (default `false`) to preserve the pre-v0.5.3 wire shape. v0.5.3+ flips the default *for browsing-shaped queries* — the cases where an agent's most likely next step is `read_symbol` on the top hit, and the round-trip is pure waste.
+
+The auto-default rule:
+
+| Query shape | New default |
+|---|---|
+| `name` exact lookup (any limit) | `true` (auto-render) |
+| `pattern` with `limit <= 10` | `true` (auto-render) |
+| `pattern` with default 256 (or any larger explicit limit) | `false` |
+| `include_signature` explicitly set | honored verbatim |
+
+Pre-v0.5.3 callers reading `signature: null` see strictly more populated data after this change — `null` becomes a real string for name lookups and small-pattern queries. Clients relying on the pre-v0.5.3 null can opt out per-call with `include_signature: false` (the existing escape hatch).
+
+#### Why these specific shapes
+
+- **Name lookups**: by-name queries are typically `name: "foo"` where the user already knows exactly what they want — 0-3 matches, signatures always wanted next. The cost is bounded.
+- **Pattern with limit ≤ 10**: user explicitly asked for a short list → browsing intent → signatures useful.
+- **Pattern with default 256**: bulk enumeration → 256 signatures is too much speculative parsing. Stay off unless asked.
+
+The existing per-daemon `SignatureCache` (keyed on `(path, byte_range, mtime)`) means repeat queries on the same workspace amortize to hashmap lookups — auto-on doesn't add per-query latency after the first warm pass.
+
+#### Test coverage
+
++1 integration test (`find_symbol_auto_signature_for_small_queries`) covering all four branches (name-default, limit-default, pattern-default-off, explicit-off). Updated `find_symbol_include_signature` to expect the new auto-on behavior on name lookups; explicit-false case unchanged.
+
+#### Protocol surface
+
+`docs/protocol-v0.md` §7.6 documents the heuristic and the explicit-off escape hatch. No new capability string — the field is still advertised under `find_symbol_signature_field` (v0.5.3+), the change is to its default-value resolution.
 
 ### Release workflow — drop hung Intel Mac target, unblock SHA256SUMS aggregator
 

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -535,7 +535,33 @@ pub async fn find_symbol(
     let kind_filter = p.kind.as_deref().map(SymbolKind::from_str_loose);
     let file_filter = p.file.as_deref();
     let sort_mode = SortMode::from_param(p.sort.as_deref());
-    let want_signatures = p.include_signature.unwrap_or(false);
+    // Auto-default for `include_signature` when not explicitly set.
+    //
+    // Heuristic: small-result queries are "browsing" queries where
+    // signatures are nearly always wanted next (the agent's natural
+    // follow-up is `read_symbol` for the top hit). Pre-v0.5.3 the
+    // default was always `false` — cheaper, but every browsing flow
+    // paid an extra round-trip.
+    //
+    // We auto-enable when:
+    //   - the user asked by exact `name` (lookups land 0-3 results)
+    //   - OR the user explicitly capped `limit` at 10 or less
+    //
+    // Pattern queries with the default 256 limit still default to
+    // `false` — pattern-of-the-day workflows like
+    // `find_symbol --pattern "*"` shouldn't auto-parse 256 symbols.
+    //
+    // Explicit `include_signature: false` always wins (escape hatch
+    // for clients that want the pre-v0.5.3 wire shape on small
+    // queries — useful for byte-count-tight clients).
+    let want_signatures = match p.include_signature {
+        Some(b) => b,
+        None => match (p.name.as_ref(), p.limit) {
+            (Some(_), _) => true,
+            (None, Some(n)) if n <= 10 => true,
+            _ => false,
+        },
+    };
 
     let (root, store_arc) = snapshot(state)?;
 

--- a/crates/rts-daemon/tests/find_symbol_round_trip.rs
+++ b/crates/rts-daemon/tests/find_symbol_round_trip.rs
@@ -627,7 +627,12 @@ async fn find_symbol_include_signature() -> anyhow::Result<()> {
         "rendered signature should strip the body: {sig:?}"
     );
 
-    // Case B: include_signature omitted → null (back-compat).
+    // Case B: include_signature omitted on a name lookup → auto-on
+    // (v0.5.3+). The pre-v0.5.3 default was null; the new heuristic
+    // recognises name-only queries as "browsing" and renders the
+    // signature without an extra round trip. Dedicated coverage of
+    // the full auto-default matrix lives in
+    // `find_symbol_auto_signature_for_small_queries` below.
     let no_sig = round_trip(
         &mut stream,
         "11",
@@ -635,12 +640,15 @@ async fn find_symbol_include_signature() -> anyhow::Result<()> {
         json!({ "name": "add" }),
     )
     .await?;
+    let auto_sig = no_sig["result"]["matches"][0]["signature"].as_str();
     assert!(
-        no_sig["result"]["matches"][0]["signature"].is_null(),
-        "signature should be null without include_signature: {no_sig:?}"
+        auto_sig.map(|s| s.contains("fn add")).unwrap_or(false),
+        "name-only query should auto-render signature (v0.5.3+ behavior): {no_sig:?}"
     );
 
-    // Case C: include_signature false explicitly → also null.
+    // Case C: include_signature false explicitly → null even on a
+    // name lookup. Explicit-off escape hatch for clients that need
+    // the pre-v0.5.3 wire shape (e.g. byte-count-tight callers).
     let false_sig = round_trip(
         &mut stream,
         "12",
@@ -651,6 +659,136 @@ async fn find_symbol_include_signature() -> anyhow::Result<()> {
     assert!(
         false_sig["result"]["matches"][0]["signature"].is_null(),
         "signature should be null when include_signature=false: {false_sig:?}"
+    );
+
+    Ok(())
+}
+
+/// v0.5.3: auto-enable `include_signature` for small-result queries.
+///
+/// Heuristic: when `include_signature` is omitted,
+/// - `name` lookups (likely 0-3 results) → auto-on
+/// - `pattern` with `limit <= 10` → auto-on
+/// - `pattern` with default/large limit → stay off (pre-v0.5.3 shape)
+/// - explicit `include_signature: false` always wins
+#[tokio::test(flavor = "current_thread")]
+async fn find_symbol_auto_signature_for_small_queries() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // Three functions so pattern queries have a result-set bigger than 1.
+    std::fs::write(
+        workspace.path().join("lib.rs"),
+        "pub fn alpha() {}\npub fn beta(x: u32) -> u32 { x }\npub fn gamma() {}\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+    let _ = poll_for_match(&mut stream, "beta", Duration::from_secs(5)).await?;
+
+    // Case A: name-only query → auto-on. `beta` should have a rendered signature.
+    let by_name = round_trip(
+        &mut stream,
+        "30",
+        "Index.FindSymbol",
+        json!({ "name": "beta" }),
+    )
+    .await?;
+    let sig_a = by_name["result"]["matches"][0]["signature"].as_str();
+    assert!(
+        sig_a.map(|s| s.contains("fn beta")).unwrap_or(false),
+        "name-only query should auto-render signature; got: {by_name:?}"
+    );
+
+    // Case B: pattern with small explicit limit → auto-on. All three
+    // alphabet fns should have rendered signatures.
+    let pattern_small = round_trip(
+        &mut stream,
+        "31",
+        "Index.FindSymbol",
+        json!({ "pattern": "*", "limit": 5 }),
+    )
+    .await?;
+    let matches_b = pattern_small["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !matches_b.is_empty(),
+        "pattern with limit=5 should return matches: {pattern_small:?}"
+    );
+    for m in &matches_b {
+        let sig = m["signature"].as_str();
+        assert!(
+            sig.is_some(),
+            "limit\u{2264}10 pattern query should auto-render every match's signature; \
+             got null for {:?}",
+            m["qualified_name"]
+        );
+    }
+
+    // Case C: pattern with default (no limit) → stay off. Signatures null.
+    let pattern_default = round_trip(
+        &mut stream,
+        "32",
+        "Index.FindSymbol",
+        json!({ "pattern": "*" }),
+    )
+    .await?;
+    let first = &pattern_default["result"]["matches"][0];
+    assert!(
+        first["signature"].is_null(),
+        "pattern with default limit should NOT auto-render (default 256 is too many): {pattern_default:?}"
+    );
+
+    // Case D: explicit false always wins, even for name lookups.
+    let explicit_off = round_trip(
+        &mut stream,
+        "33",
+        "Index.FindSymbol",
+        json!({ "name": "beta", "include_signature": false }),
+    )
+    .await?;
+    assert!(
+        explicit_off["result"]["matches"][0]["signature"].is_null(),
+        "explicit include_signature=false must win over auto-default: {explicit_off:?}"
     );
 
     Ok(())

--- a/docs/protocol-v0.md
+++ b/docs/protocol-v0.md
@@ -467,7 +467,18 @@ The glob matcher has **no character classes** and **no escapes** — `*` and `?`
 
 **Pre-filter count (v0.5.2+, capability `find_symbol_pre_filter_count`):** `result.pre_filter_count: Option<usize>` — present only when a filter (currently `doc_contains`) was active. Reports the candidate count before the filter ran. Lets agents distinguish `matches: []` because the pattern matched nothing from `matches: []` because the filter rejected every candidate. Omitted when no filter ran (back-compat).
 
-**Signature field (v0.5.3+, capability `find_symbol_signature_field`):** `params.include_signature: bool` (default `false`) — when true, each match's `signature` field is populated via the per-language `SignatureRenderer` (the same code path `Index.ReadSymbol shape=signature` uses). Renders are cached on the daemon per `(path, byte_range, mtime)`, so repeated pattern queries on the same workspace amortize the parse cost. Default `false` preserves the pre-v0.5.3 wire shape (`signature: null`); agents that want rendered signatures must opt in. Best for outline-style follow-ups where the agent wants per-match signatures without paying for `read_symbol` per result.
+**Signature field (v0.5.3+, capability `find_symbol_signature_field`):** `params.include_signature: bool` — when true, each match's `signature` field is populated via the per-language `SignatureRenderer` (the same code path `Index.ReadSymbol shape=signature` uses). Renders are cached on the daemon per `(path, byte_range, mtime)`, so repeated pattern queries on the same workspace amortize the parse cost.
+
+**Default-on heuristic (v0.5.3+):** when `include_signature` is omitted, the daemon auto-enables it for *small-result* queries — the cases where the agent's most likely next step is `read_symbol` on the top hit, and an extra round trip is pure waste. Specifically:
+
+| Query shape | Auto-default |
+|---|---|
+| `name` exact lookup (any limit) | `true` |
+| `pattern` with `limit <= 10` | `true` |
+| `pattern` with default 256 (or any larger explicit limit) | `false` |
+| `include_signature` explicitly set | honored verbatim |
+
+Pre-v0.5.3 clients reading `signature: null` see strictly more populated fields after this change — `null` becomes a real string for the affected query shapes. Clients relying on the pre-v0.5.3 null can opt out per-call with `include_signature: false`.
 
 **`result`**:
 ```jsonc


### PR DESCRIPTION
## Summary

PR #81 shipped `include_signature` as opt-in (default `false`). v0.5.3+ flips the default for **browsing-shaped queries** — the cases where the agent's natural follow-up is `read_symbol` on the top hit, and the extra round-trip is pure waste.

## Auto-default rule

| Query shape | New default |
|---|---|
| `name` exact lookup (any limit) | `true` (auto-render) |
| `pattern` with `limit <= 10` | `true` (auto-render) |
| `pattern` with default 256 (or any larger explicit limit) | `false` |
| `include_signature` explicitly set | honored verbatim |

## Why these specific shapes

- **`name` lookups**: by-name queries land 0-3 matches almost always — the user already knows what they want, signatures save a round trip every time. Cost is bounded.
- **`pattern` with small limit**: user explicitly asked for a short list → browsing intent → signatures useful.
- **`pattern` with default 256**: bulk enumeration → 256 signatures is too much speculative parsing.
- **Explicit set**: always honored — explicit `false` is the escape hatch for byte-count-tight clients.

The existing per-daemon `SignatureCache` (keyed on `(path, byte_range, mtime)`) means repeat queries on the same workspace amortize to hashmap lookups. Auto-on doesn't add per-query latency after the first warm pass.

## Wire compatibility

Pre-v0.5.3 callers reading `signature: null` see *strictly more populated data* — null becomes a real string for name lookups and small-pattern queries. Callers that depended on the pre-v0.5.3 null can opt out per-call with `include_signature: false`.

## Test plan

- [x] `cargo test -p rts-daemon --test find_symbol_round_trip` → 5 passed
  - `find_symbol_auto_signature_for_small_queries` (new — covers all 4 branches)
  - `find_symbol_include_signature` (updated — name-only now expects auto-on)
  - Existing 3 tests unchanged
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p rts-daemon` clean

## Post-Deploy Monitoring & Validation

\`No additional operational monitoring required:\` opt-out heuristic change. Cost is bounded by the existing SignatureCache; affected query shapes already have small result sets by definition. Pre-v0.5.3 wire shape preserved for clients that explicitly set `include_signature: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)