### PR TITLE
feat(corpus): dogfood-v3 semantic eval — 71.4% honest baseline on agent-natural queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Semantic eval — dogfood-v3 corpus surfaces the real generalization gap
+
+Closes the v0.5.0-noted "out of scope" follow-up: *"Mining queries from real Claude Code transcripts (the most rigorous corpus addition)."* True transcript mining isn't possible yet because rts-mcp isn't wired into Claude Code sessions today — but the next-best thing is: **mine the developer's own dogfood lookups while building features against this very repo**, treating those natural-language intents as the corpus.
+
+#### What's in the corpus
+
+`corpus/semantic-eval-rts-core-dogfood-v3.toml` — 14 queries authored from the developer's actual lookups while building PRs #81 / #82 / #83 / #84 / #85 / #86. Categories deliberately distinct from v1/v2:
+
+- **Enumerate-by-family** (4): _"where are all the per-language signature renderers?"_ → expects `render_rust`, `render_python`, ... family
+- **Extension-point discovery** (3): _"how do I add a new language?"_ → expects `Language` enum + `tree_sitter_language` + `detect_language_from_extension`
+- **Cross-cutting horizontal slices** (3): _"where are doc comments handled across all languages?"_ → expects the family of `extract_*_doc_comments`
+- **Source-of-truth lookups** (2): _"what's the canonical Language enum definition?"_ → expects `Language` ranked #1
+- **Implementation-detail anchors** (2): _"what struct represents an extracted symbol?"_ → expects `Symbol`
+
+#### The honest result: **71.4% answerable coverage** (10/14)
+
+| Corpus | Answerable coverage | MRR | Precision@10 |
+|---|---:|---:|---:|
+| v1 audited (13q) | 100% | 0.387 | 0.215 |
+| blind-v2 (15q) | 100% | 0.273 | n/a |
+| Combined v1+v2 (28q) | 100% (20/20) | - | - |
+| **dogfood-v3 (14q)** | **71.4% (10/14)** | **0.512** | **0.164** |
+
+The v1+v2 100% was meaningfully corpus-overfit. v3 exposes three concrete ranker gaps:
+
+1. **Token-frequency noise**: common English nouns (`all`, `structs`, `enums`, `new`) appearing in doc comments rank above real symbol names.
+2. **Plural ↔ singular stems for family-words**: queries asking about "renderers" / "extractors" / "loaders" don't reliably hit `render_*` / `extract_*` families.
+3. **Enumerate-by-family weak spot**: the ranker is tuned to surface a single best match; family queries systematically underperform.
+
+#### What this corpus is and isn't
+
+- ✅ **Is**: a falsifier for the "ranker generalises across query-shape distributions" hypothesis. The 100%-on-v1+v2 number does not generalise; v3 shows the honest ceiling on agent-natural query shapes.
+- ✅ **Is**: an artifact of *real use* — every query has a concrete provenance in a developer lookup that happened during this session's work.
+- ❌ **Is not**: a CI guard yet. Ranker improvements are filed for follow-up.
+
 ### `rts-bench query` — cold-mount UX: 30s recv timeout + diagnostic error message
 
 The `rts-bench query` (one-shot CLI dogfooding path) used a hardcoded 10s timeout when reading MCP responses and surfaced timeouts as the bare message `Error: timeout reading MCP response`. Three pain points met in one error:

--- a/corpus/semantic-eval-rts-core-dogfood-v3.toml
+++ b/corpus/semantic-eval-rts-core-dogfood-v3.toml
@@ -1,0 +1,145 @@
+# Semantic-search evaluation corpus for `crates/rts-core` — dogfood v3.
+#
+# Companion to v1 (author-authored, hand-graded) and blind-v2
+# (outside-in, agent-coding-loop categories). v3 captures **actual
+# natural-language intents observed while dogfooding the daemon to
+# build features for this very repo** — the kind of vocabulary that
+# emerges from real use rather than retrospective synthesis.
+#
+# Workflow used to author this corpus:
+# 1. While building PRs #81, #82, #83, #84, #85, #86, the developer
+#    (using `rts-bench query find-symbol/read-symbol/outline` as
+#    primary navigation) made ~30 distinct lookups against rts-core
+#    over a single multi-hour session.
+# 2. The actual *intents* behind those lookups — phrased the way the
+#    developer would have asked them to a teammate — became the
+#    `text` field. The symbol names that resolved the lookup became
+#    `expected_top_k`.
+# 3. Three queries that crossed crate boundaries (e.g. resolving to
+#    `crates/rts-daemon/src/*`) were dropped, since this corpus is
+#    rts-core-scoped for consistency with v1/v2.
+#
+# Categories distinct from v1/v2:
+#   - Enumerate-by-family (4): "where are all the X for Y?"
+#   - Extension-point discovery (3): "how do I add a new <thing>?"
+#   - Cross-cutting horizontal slices (3): "where are doc comments
+#     handled across all languages?"
+#   - Source-of-truth lookups (2): "what's THE canonical table for X?"
+#   - Implementation-detail anchors (2): "find the recv timeout"
+#
+# Purpose: stress-test the ranker on query *shapes* the prior
+# corpora didn't cover. If the v1/v2 100% holds here, the baseline
+# generalises across multiple author-distribution patterns.
+
+version = 1
+
+# ─── Enumerate-by-family ───
+# Tests that the ranker handles "all the X for Y" patterns where the
+# user knows there's a family of related symbols and wants the full
+# set, not just one.
+
+[[query]]
+text = "where are all the per-language signature renderers?"
+expected_top_k = [
+    "render_rust",
+    "render_python",
+    "render_typescript",
+    "render_javascript",
+    "render_go",
+    "render_java",
+    "render_c",
+    "render_cpp",
+    "render_php",
+    "render_ruby",
+    "render_swift",
+]
+
+[[query]]
+text = "show me the per-language symbol extractors"
+expected_top_k = [
+    "extract_rust_symbols",
+    "extract_python_symbols",
+    "extract_javascript_symbols",
+    "extract_go_symbols",
+    "extract_java_symbols",
+    "extract_swift_symbols",
+    "extract_ruby_symbols",
+    "extract_php_symbols",
+    "extract_c_symbols",
+]
+
+[[query]]
+text = "what are all the doc-comment extractors?"
+expected_top_k = [
+    "extract_rust_doc_comments",
+    "extract_swift_doc_comments",
+    "extract_c_doc_comments",
+    "extract_ruby_doc_comments",
+    "extract_go_doc_comments",
+]
+
+[[query]]
+text = "find all the tree-sitter language loaders"
+expected_top_k = ["tree_sitter_language", "Language", "detect_language_from_extension", "detect_language_from_path"]
+
+# ─── Extension-point discovery ───
+# Tests that "how do I add a new <thing>?" questions land on the
+# right extension surfaces (enums, dispatch matches, registries).
+
+[[query]]
+text = "how do I add a new language?"
+expected_top_k = ["Language", "tree_sitter_language", "detect_language_from_extension", "file_extensions"]
+
+[[query]]
+text = "where do I register a new file extension?"
+expected_top_k = ["detect_language_from_extension", "file_extensions", "detect_language_from_path", "Language"]
+
+[[query]]
+text = "what's the extension table for languages?"
+expected_top_k = ["file_extensions", "detect_language_from_extension", "Language"]
+
+# ─── Cross-cutting horizontal slices ───
+# Tests that "where is X handled across the codebase?" questions
+# find the cross-cutting concern, not just one site.
+
+[[query]]
+text = "where are doc comments handled across all languages?"
+expected_top_k = [
+    "extract_rust_doc_comments",
+    "extract_swift_doc_comments",
+    "extract_c_doc_comments",
+    "extract_ruby_doc_comments",
+    "extract_go_doc_comments",
+]
+
+[[query]]
+text = "how does symbol visibility get determined?"
+expected_top_k = ["visibility", "Symbol", "extract_rust_symbols"]
+
+[[query]]
+text = "what handles tree-sitter parser construction?"
+expected_top_k = ["Parser", "SyntaxTree", "tree_sitter_language"]
+
+# ─── Source-of-truth lookups ───
+# Tests that THE canonical table or registry ranks #1, not a usage
+# site that happens to mention the concept.
+
+[[query]]
+text = "what's the canonical Language enum definition?"
+expected_top_k = ["Language", "name", "file_extensions"]
+
+[[query]]
+text = "where is the highlights query table?"
+expected_top_k = ["highlights_query", "supports_highlights", "Language"]
+
+# ─── Implementation-detail anchors ───
+# Tests recall on specific known-by-behavior code that the user can
+# describe in plain English but not name precisely.
+
+[[query]]
+text = "what struct represents an extracted symbol?"
+expected_top_k = ["Symbol", "SymbolDefinition", "FileInfo"]
+
+[[query]]
+text = "where does C# get its grammar?"
+expected_top_k = ["Language", "tree_sitter_language"]


### PR DESCRIPTION
## Summary

Closes the v0.5.0-noted "out of scope" follow-up: **"Mining queries from real Claude Code transcripts (the most rigorous corpus addition)."**

True transcript mining isn't possible yet — rts-mcp isn't wired into Claude Code sessions today, so there are no agent-issued `find_symbol` transcripts available. The substitute, which is the next-most-rigorous corpus addition we can make right now: **mine the developer's own dogfood lookups while building features against this very repo.**

## What's in the corpus

`corpus/semantic-eval-rts-core-dogfood-v3.toml` — 14 queries, each with concrete provenance in a developer lookup during this session's work (PRs #81 / #82 / #83 / #84 / #85 / #86).

Categories deliberately distinct from v1/v2:

- **Enumerate-by-family** (4): _"where are all the per-language signature renderers?"_
- **Extension-point discovery** (3): _"how do I add a new language?"_
- **Cross-cutting horizontal slices** (3): _"where are doc comments handled across all languages?"_
- **Source-of-truth lookups** (2): _"what's the canonical Language enum definition?"_
- **Implementation-detail anchors** (2): _"what struct represents an extracted symbol?"_

## The honest result: **71.4% answerable coverage** (10/14)

| Corpus | Answerable coverage | MRR | Precision@10 |
|---|---:|---:|---:|
| v1 audited (13q) | 100% | 0.387 | 0.215 |
| blind-v2 (15q) | 100% | 0.273 | n/a |
| Combined v1+v2 (28q) | **100%** (20/20) | - | - |
| **dogfood-v3 (14q)** | **71.4%** (10/14) | **0.512** | **0.164** |

The 100% on v1+v2 was meaningfully corpus-overfit. v3 exposes three concrete ranker gaps:

1. **Token-frequency noise**: common English nouns (`all`, `structs`, `enums`, `new`) appearing in doc comments rank above real symbol names. _"what struct represents an extracted symbol?"_ → top1=`structs`, `Symbol` not in top 10.
2. **Plural ↔ singular stems for family-words**: queries asking about "renderers" / "extractors" / "loaders" don't reliably hit `render_*` / `extract_*` families. PR #71 closed `-y/-ies` (`query↔queries`); the `-er/-ers` axis is open.
3. **Enumerate-by-family weak spot**: the ranker is tuned to surface a single best match; family queries (where the user wants the *set*) systematically underperform.

Concrete failure samples (run from `cargo run --release -p rts-bench -- semantic ...`):

```
[  ❌ miss] where are all the per-language signature renderers?  →  top1="all"
[  ❌ miss] show me the per-language symbol extractors           →  top1="test_language_properties"
[  ❌ miss] what struct represents an extracted symbol?          →  top1="structs"
[  ❌ miss] where does C# get its grammar?                        →  top1="get_statistics"
```

## What this corpus is and isn't

- ✅ **Is**: a falsifier for the "ranker generalises across query-shape distributions" hypothesis. The 100%-on-v1+v2 number does not generalise; v3 shows the honest ceiling on agent-natural query shapes.
- ✅ **Is**: an artifact of *real use* — every query has a concrete provenance in a developer lookup that happened during this session's work.
- ❌ **Is not**: a CI guard yet. The 71.4% is the baseline; ranker improvements are filed for follow-up. Once a focused ranker PR closes the family-query gap, this corpus becomes a third invariant in `.github/workflows/semantic-coverage.yml` alongside v1 (≥0.95) and blind-v2 (≥0.75).

## Filed for follow-up

- **Family-query ranker fix**: detect "renderers"-shaped queries and boost prefix-matched families (`render_*`).
- **Common-noun penalty**: down-weight matches where the sole signal is a common English noun in a doc comment.
- **`-er`/`-ers` lemma override**: add to the existing `query↔queries` table.

## Test plan

- [x] Corpus parses cleanly (TOML v1 schema matches v1/v2)
- [x] `cargo run --release -p rts-bench -- semantic --corpus corpus/semantic-eval-rts-core-dogfood-v3.toml --workspace crates/rts-core --dry-run` runs end-to-end
- [x] Reported numbers reproduce: coverage=71.4%, mrr=0.512, precision@10=0.164
- [x] CHANGELOG entry documents the baseline + the three identified gaps + the follow-up plan
- [x] No CI guard added (deliberate — the 71.4% is data, not yet an invariant)

## Post-Deploy Monitoring & Validation

\`No additional operational monitoring required:\` purely additive corpus file + CHANGELOG documentation. No runtime impact; no behavior change. CI workflows remain locked to v1/v2 invariants per their existing thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)