### PR TITLE
fix(daemon, mcp): per-workspace socket paths — closes the WORKSPACE_MISMATCH recovery dance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,40 @@ First-match-wins per directory level, so a nested `Cargo.toml` in a member crate
 #### Out of scope (filed for follow-up)
 
 The `resolve_bin` helper (which locates `rts-mcp` / `rts-daemon` binaries) still requires `$PWD` to be the cargo build root. Running `rts-bench query` from a deep subdirectory works for the `--workspace` flag but fails on binary resolution unless `RTS_MCP_BIN` and `RTS_DAEMON_BIN` are exported. A symmetric "walk upward to find `target/{release,debug}/`" fix is the obvious next iteration.
+### Per-workspace socket paths — closes the `WORKSPACE_MISMATCH` recovery dance
+
+Pre-v0.5.4 every daemon on a given UID bound `default.sock`. Switching workspaces in the same shell gave:
+
+```
+Error: WORKSPACE_MISMATCH — daemon is already pinned to a different workspace on this socket.
+```
+
+…and required `pkill -f rts-daemon && sleep 1` to recover. Hit this in real dogfooding multiple times.
+
+The error message itself claimed "the socket path is per-workspace-hash per protocol-v0 §5.3" — but that was aspirational; only the bootstrap `default.sock` path was ever implemented.
+
+This PR makes the claim true:
+
+#### What changed
+
+- New `rts_daemon::socket::socket_path_for_workspace(canonical_path)` and matching `rts_mcp::socket::workspace_socket_path` — both compute `<runtime_root>/ws-<16hex>.sock` where the hex is the first 8 bytes of `blake3(canonical_path_bytes)`.
+- When the daemon is started with `--workspace W`, it canonicalises `W` and binds the per-workspace socket. Without `--workspace`, it falls back to `default.sock` (bootstrap path preserved for tests and any client that started without a workspace).
+- When `rts-mcp`'s auto-spawn knows the workspace at startup (the production path: `rts-mcp --workspace W` from Claude Code / Cursor / etc.), it computes the same hash and routes to the per-workspace socket — connecting to a live daemon there, or auto-spawning one if absent.
+- `docs/protocol-v0.md` §5.3 updated with the new layout and the `default.sock` bootstrap rationale.
+
+#### Impact
+
+Two daemons on distinct workspaces can now coexist on the same UID. The `WORKSPACE_MISMATCH` error remains for the (now rare) case where a daemon's hard-locked workspace is queried with a different `Workspace.Mount` payload over its own socket — that's a real protocol violation, not the path-collision artifact.
+
+#### Test coverage
+
++1 integration test (`two_daemons_one_runtime_dir_distinct_workspaces`) explicitly exercising the pre-PR failure: spawn daemon A with `--workspace=tempA`, spawn daemon B with `--workspace=tempB` against the **same shared `XDG_RUNTIME_DIR` / HOME**, verify both bind successfully, mount succeeds on each socket, each daemon indexes its own workspace's symbols, and neither sees the other's. Pre-v0.5.4 this test would have failed at daemon B's `bind()` (lockfile collision on `default.sock`).
+
+#### Wire-compat
+
+- Post-v0.5.4 MCP + post-v0.5.4 daemon: per-workspace path on both sides → ✅
+- Post-v0.5.4 MCP + pre-v0.5.4 daemon: MCP looks for `ws-XXX.sock`, doesn't find it, auto-spawns a fresh daemon (which is post-v0.5.4 since both binaries ship together) → ✅
+- Pre-v0.5.4 MCP + post-v0.5.4 daemon: pre-v0.5.4 MCP looks for `default.sock`, post-v0.5.4 daemon-with-workspace doesn't bind there → mismatch. Practical impact: zero, since both binaries ship and update together. Documented for completeness.
 
 ### Release workflow — drop hung Intel Mac target, unblock SHA256SUMS aggregator
 

--- a/crates/rts-daemon/src/main.rs
+++ b/crates/rts-daemon/src/main.rs
@@ -136,7 +136,22 @@ async fn main() -> anyhow::Result<()> {
     lifecycle::preflight().context("daemon preflight failed")?;
 
     // Phase 2: socket path and lockfile.
-    let socket_path = socket::socket_path_for_default()?;
+    //
+    // v0.5.4+: when `--workspace <path>` is passed, bind a
+    // per-workspace socket (`ws-<16hex>.sock`) so multiple daemons
+    // can coexist — one per workspace. Without `--workspace` we
+    // bind `default.sock` for the bootstrap case (which still
+    // preserves the v0.5.3-and-earlier shape for callers that
+    // expect it).
+    let socket_path = match prewarm_workspace.as_deref() {
+        Some(p) => {
+            let canonical = p
+                .canonicalize()
+                .with_context(|| format!("canonicalize --workspace argument {}", p.display()))?;
+            socket::socket_path_for_workspace(&canonical)?
+        }
+        None => socket::socket_path_for_default()?,
+    };
     let _lock = lifecycle::acquire_lock(&socket_path).with_context(|| {
         format!(
             "could not acquire daemon lock for {}",

--- a/crates/rts-daemon/src/socket.rs
+++ b/crates/rts-daemon/src/socket.rs
@@ -21,11 +21,49 @@ use crate::state::DaemonState;
 /// Per-connection in-flight cap (protocol-v0 §9.4).
 const PER_CONNECTION_INFLIGHT_CAP: usize = 16;
 
-/// Fallback socket path used when no per-workspace hash is known yet —
-/// for v0's bootstrap "I haven't mounted yet" state. Once a workspace is
-/// mounted, future invocations would write to the per-workspace path; this
-/// fallback lets us boot a daemon without one.
+/// Fallback socket path used when no workspace is known yet — the
+/// bootstrap "started without `--workspace`" state. Once a daemon
+/// knows its workspace, future spawns hit the per-workspace path
+/// via [`socket_path_for_workspace`].
+///
+/// Pre-v0.5.4 this was the *only* socket path: every daemon on a
+/// given UID bound `default.sock` and switching workspaces required
+/// killing the daemon. v0.5.4+ adds per-workspace sockets so two
+/// daemons can coexist (one per workspace) without the
+/// `WORKSPACE_MISMATCH` error.
 pub fn socket_path_for_default() -> anyhow::Result<PathBuf> {
+    let dir = ensure_runtime_dir()?;
+    Ok(dir.join("default.sock"))
+}
+
+/// Per-workspace socket path. Two distinct workspaces produce
+/// distinct socket files, so an agent (or `rts-bench`) can switch
+/// between workspaces in the same shell without the second
+/// invocation seeing `WORKSPACE_MISMATCH` from a daemon pinned to
+/// the first one.
+///
+/// Hash input is `blake3(canonical_path.as_os_str_bytes())` —
+/// device/inode information would be slightly more robust against
+/// bind-mounts, but the canonical-path collision surface is
+/// effectively zero for real workspace roots, and a path-only hash
+/// keeps the algorithm deterministic across `Workspace.Mount`
+/// retries (`fstat` may race during cold-mount).
+///
+/// Socket file shape: `ws-<16hex>.sock` (first 8 bytes of blake3,
+/// 16 hex chars). 2^64 paths before a collision — plenty.
+pub fn socket_path_for_workspace(canonical_workspace: &Path) -> anyhow::Result<PathBuf> {
+    let dir = ensure_runtime_dir()?;
+    let bytes = canonical_workspace.as_os_str().as_encoded_bytes();
+    let hash = blake3::hash(bytes);
+    let short = hash.to_hex();
+    let short16 = &short.as_str()[..16];
+    Ok(dir.join(format!("ws-{short16}.sock")))
+}
+
+/// Shared helper: ensure `runtime_root()` exists with `0700` perms.
+/// Both `socket_path_for_default` and `socket_path_for_workspace`
+/// route through this so the parent dir invariant is one place.
+fn ensure_runtime_dir() -> anyhow::Result<PathBuf> {
     let dir = runtime_root()?;
     std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
     nix::sys::stat::fchmodat(
@@ -35,7 +73,7 @@ pub fn socket_path_for_default() -> anyhow::Result<PathBuf> {
         nix::sys::stat::FchmodatFlags::FollowSymlink,
     )
     .with_context(|| format!("chmod 0700 on {}", dir.display()))?;
-    Ok(dir.join("default.sock"))
+    Ok(dir)
 }
 
 fn runtime_root() -> anyhow::Result<PathBuf> {

--- a/crates/rts-daemon/tests/per_workspace_sockets.rs
+++ b/crates/rts-daemon/tests/per_workspace_sockets.rs
@@ -1,0 +1,267 @@
+//! End-to-end test: two daemons on **distinct workspaces** can coexist
+//! on the same UID's runtime dir simultaneously. Pre-v0.5.4 both
+//! daemons would race for `default.sock` and the second would fail
+//! with `WORKSPACE_MISMATCH`. v0.5.4+ uses per-workspace
+//! `ws-<16hex>.sock` files so they don't collide.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn poll_for_match(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<Value> {
+    let deadline = Instant::now() + timeout;
+    let mut next_id: u64 = 100;
+    loop {
+        next_id += 1;
+        let resp = round_trip(
+            stream,
+            &next_id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        let matches = resp["result"]["matches"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        if !matches.is_empty() {
+            return Ok(resp);
+        }
+        if Instant::now() >= deadline {
+            return Ok(resp);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+/// Compute the per-workspace socket path the way `rts-daemon::socket`
+/// does. Mirrors the production hash so the test verifies the actual
+/// binding, not a re-implementation.
+fn ws_socket_path(runtime_dir: &std::path::Path, canonical_workspace: &std::path::Path) -> PathBuf {
+    let bytes = canonical_workspace.as_os_str().as_encoded_bytes();
+    let hash = blake3::hash(bytes);
+    let short = hash.to_hex();
+    let short16 = &short.as_str()[..16];
+    runtime_dir.join(format!("ws-{short16}.sock"))
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn two_daemons_one_runtime_dir_distinct_workspaces() -> anyhow::Result<()> {
+    // ONE runtime dir / HOME / state dir shared across both daemons.
+    // The bug being tested: pre-v0.5.4 the second daemon would
+    // collide on `default.sock` regardless of its workspace.
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // Two distinct workspaces. Each gets its own daemon below.
+    let workspace_a = tempfile::tempdir()?;
+    let workspace_b = tempfile::tempdir()?;
+    std::fs::write(
+        workspace_a.path().join("a.rs"),
+        "pub fn workspace_a_marker() {}\n",
+    )?;
+    std::fs::write(
+        workspace_b.path().join("b.rs"),
+        "pub fn workspace_b_marker() {}\n",
+    )?;
+
+    // Canonical workspace paths — macOS `tempdir` returns `/var/...`
+    // but the daemon canonicalises to `/private/var/...`. Match.
+    let canon_a = workspace_a.path().canonicalize()?;
+    let canon_b = workspace_b.path().canonicalize()?;
+
+    // On macOS the daemon writes to `$HOME/Library/Caches/rts/`;
+    // on Linux to `$XDG_RUNTIME_DIR/rts/`. Compute the actual dir.
+    let daemon_runtime_dir = if cfg!(target_os = "macos") {
+        home_dir.path().join("Library").join("Caches").join("rts")
+    } else {
+        runtime_dir.path().join("rts")
+    };
+
+    let socket_a = ws_socket_path(&daemon_runtime_dir, &canon_a);
+    let socket_b = ws_socket_path(&daemon_runtime_dir, &canon_b);
+    assert_ne!(
+        socket_a, socket_b,
+        "distinct workspaces must hash to distinct sockets",
+    );
+
+    // Spawn daemon A.
+    let mut cmd_a = Command::new(daemon_bin());
+    cmd_a
+        .args(["--workspace"])
+        .arg(workspace_a.path())
+        .env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child_a = cmd_a.spawn()?;
+    let _kill_a = KillOnDrop(&mut child_a);
+    wait_for_socket(&socket_a, Duration::from_secs(5)).await?;
+
+    // Spawn daemon B *while A is still running* — the previously
+    // failing scenario.
+    let mut cmd_b = Command::new(daemon_bin());
+    cmd_b
+        .args(["--workspace"])
+        .arg(workspace_b.path())
+        .env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child_b = cmd_b.spawn()?;
+    let _kill_b = KillOnDrop(&mut child_b);
+    wait_for_socket(&socket_b, Duration::from_secs(5)).await?;
+
+    // Both sockets exist concurrently. Query each daemon and verify
+    // it returns its own workspace's symbol, not the other's.
+    let mut stream_a = UnixStream::connect(&socket_a).await?;
+    let mount_a = round_trip(
+        &mut stream_a,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace_a.path() }),
+    )
+    .await?;
+    assert!(mount_a["error"].is_null(), "mount A: {mount_a:?}");
+    let resp_a =
+        poll_for_match(&mut stream_a, "workspace_a_marker", Duration::from_secs(5)).await?;
+    let matches_a = resp_a["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        matches_a
+            .iter()
+            .any(|m| m["qualified_name"] == "workspace_a_marker"),
+        "daemon A should index workspace A: {resp_a:?}"
+    );
+
+    let mut stream_b = UnixStream::connect(&socket_b).await?;
+    let mount_b = round_trip(
+        &mut stream_b,
+        "2",
+        "Workspace.Mount",
+        json!({ "root": workspace_b.path() }),
+    )
+    .await?;
+    assert!(mount_b["error"].is_null(), "mount B: {mount_b:?}");
+    let resp_b =
+        poll_for_match(&mut stream_b, "workspace_b_marker", Duration::from_secs(5)).await?;
+    let matches_b = resp_b["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        matches_b
+            .iter()
+            .any(|m| m["qualified_name"] == "workspace_b_marker"),
+        "daemon B should index workspace B: {resp_b:?}"
+    );
+
+    // Critical assertion: A doesn't see B's symbols and vice-versa.
+    // Pre-v0.5.4 a single daemon would have one of them mounted and
+    // the other would 404 (or — worse — the second daemon would
+    // fail to bind entirely).
+    let cross_a = round_trip(
+        &mut stream_a,
+        "3",
+        "Index.FindSymbol",
+        json!({ "name": "workspace_b_marker" }),
+    )
+    .await?;
+    assert!(
+        cross_a["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(false),
+        "daemon A must NOT see workspace B's symbols: {cross_a:?}"
+    );
+
+    let cross_b = round_trip(
+        &mut stream_b,
+        "4",
+        "Index.FindSymbol",
+        json!({ "name": "workspace_a_marker" }),
+    )
+    .await?;
+    assert!(
+        cross_b["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(false),
+        "daemon B must NOT see workspace A's symbols: {cross_b:?}"
+    );
+
+    Ok(())
+}

--- a/crates/rts-mcp/src/socket.rs
+++ b/crates/rts-mcp/src/socket.rs
@@ -1,15 +1,21 @@
 //! Socket-path discovery + daemon auto-spawn.
 //!
-//! Mirrors `rts-daemon`'s `socket::socket_path_for_default` so the MCP server
-//! and the daemon agree on where the Unix socket lives:
+//! Mirrors `rts-daemon`'s `socket` module so the MCP server and the
+//! daemon agree on where the Unix socket lives:
 //!
-//!   Linux: `${XDG_RUNTIME_DIR}/rts/default.sock`
-//!   macOS: `$HOME/Library/Caches/rts/default.sock`
+//!   Linux: `${XDG_RUNTIME_DIR}/rts/`
+//!   macOS: `$HOME/Library/Caches/rts/`
 //!
-//! Per-workspace socket paths (the `blake3(dev_id || inode || canonical_path)`
-//! flavour from protocol-v0 §5.3) are a v1.1 refinement — v0 is workspace-pinned
-//! to one daemon per host, and the "default" socket is the agreed bootstrap
-//! location.
+//! Per-workspace socket paths (v0.5.4+): when the MCP server knows
+//! the workspace at startup (`--workspace`), we compute
+//! `ws-<16hex>.sock` (first 8 bytes of blake3 over the canonical
+//! path) and use that. Switching workspaces in the same UID no
+//! longer hits `WORKSPACE_MISMATCH` — each workspace gets its own
+//! daemon on its own socket.
+//!
+//! The `default.sock` path is kept as a bootstrap fallback for the
+//! "started without a workspace" case (mostly: pre-v0.5.4 daemons
+//! and tests that boot a bare daemon).
 //!
 //! The auto-spawn flow:
 //!   1. If the socket exists and accepts a connection, use it.
@@ -38,6 +44,17 @@ const MAX_POLL: Duration = Duration::from_millis(250);
 /// unset on Linux (matches the daemon's refusal to fall back to `/tmp`).
 pub fn default_socket_path() -> Result<PathBuf> {
     Ok(runtime_root()?.join("default.sock"))
+}
+
+/// Per-workspace socket path — mirrors
+/// `rts_daemon::socket::socket_path_for_workspace`. Two distinct
+/// workspaces produce distinct socket files. v0.5.4+.
+pub fn workspace_socket_path(canonical_workspace: &std::path::Path) -> Result<PathBuf> {
+    let bytes = canonical_workspace.as_os_str().as_encoded_bytes();
+    let hash = blake3::hash(bytes);
+    let short = hash.to_hex();
+    let short16 = &short.as_str()[..16];
+    Ok(runtime_root()?.join(format!("ws-{short16}.sock")))
 }
 
 fn runtime_root() -> Result<PathBuf> {
@@ -86,7 +103,25 @@ pub async fn connect_with_auto_spawn(
     daemon_bin: &std::path::Path,
     prewarm_workspace: Option<&std::path::Path>,
 ) -> Result<UnixStream> {
-    let socket_path = default_socket_path()?;
+    // v0.5.4+: pick a per-workspace socket when we know the workspace
+    // at spawn time. Falls back to `default.sock` only for the
+    // bootstrap path (no `--workspace` known yet).
+    let socket_path = match prewarm_workspace {
+        Some(p) => {
+            // Canonicalise so the same workspace always hashes to
+            // the same socket, regardless of how the caller spelled
+            // the path. Falls through to default on canonicalize
+            // failure (e.g. workspace doesn't exist yet) — the
+            // daemon's own canonicalization step would error
+            // identically, so deferring it preserves the error
+            // surface.
+            match p.canonicalize() {
+                Ok(canon) => workspace_socket_path(&canon)?,
+                Err(_) => default_socket_path()?,
+            }
+        }
+        None => default_socket_path()?,
+    };
     if let Some(s) = try_connect(&socket_path).await {
         return Ok(s);
     }

--- a/docs/protocol-v0.md
+++ b/docs/protocol-v0.md
@@ -252,10 +252,16 @@ On every `Workspace.Mount`, the daemon re-stats the path and verifies `(dev, ino
 ### 5.3 Socket path
 
 ```text
-Linux:   ${XDG_RUNTIME_DIR}/rts/${workspace_id_hex}.sock
-macOS:   ${HOME}/Library/Caches/rts/${workspace_id_hex}.sock
-Windows: \\.\pipe\rts.${user_sid}.${workspace_id_hex}        (v1.1)
+Linux:   ${XDG_RUNTIME_DIR}/rts/ws-${workspace_id_hex16}.sock   (v0.5.4+)
+         ${XDG_RUNTIME_DIR}/rts/default.sock                    (bootstrap)
+macOS:   ${HOME}/Library/Caches/rts/ws-${workspace_id_hex16}.sock   (v0.5.4+)
+         ${HOME}/Library/Caches/rts/default.sock                    (bootstrap)
+Windows: \\.\pipe\rts.${user_sid}.${workspace_id_hex16}        (v1.1)
 ```
+
+`${workspace_id_hex16}` is the first 8 bytes of `blake3(canonical_workspace_path_bytes)`, hex-encoded — 16 chars. Two distinct workspace roots produce distinct sockets, so concurrent daemons (one per workspace) coexist on the same UID without `WORKSPACE_MISMATCH`.
+
+The `default.sock` bootstrap path is kept for the no-workspace case (daemons started without `--workspace`, e.g. some test harnesses, and pre-v0.5.4 clients). Post-v0.5.4 production callers always know their workspace at spawn time and route to the per-workspace path.
 
 Linux MUST refuse to start if `XDG_RUNTIME_DIR` is unset. There is **no `/tmp/rts-$UID/` fallback** — the symlink-attack surface on `/tmp` is too large (security-review F2).
 


### PR DESCRIPTION
## Summary

Pre-v0.5.4 every daemon on a given UID bound `default.sock`. Switching workspaces in the same shell gave:

\`\`\`
Error: WORKSPACE_MISMATCH — daemon is already pinned to a different workspace on this socket.
\`\`\`

…and required `pkill -f rts-daemon && sleep 1` to recover. Hit this in real dogfooding multiple times across this session.

The error message itself claimed *"the socket path is per-workspace-hash per protocol-v0 §5.3"* — but that was aspirational; only the bootstrap `default.sock` path was ever implemented. This PR makes the claim true.

## What changed

- New `rts_daemon::socket::socket_path_for_workspace(canonical_path)` and matching `rts_mcp::socket::workspace_socket_path` — both compute `<runtime_root>/ws-<16hex>.sock` where the hex is the first 8 bytes of `blake3(canonical_path_bytes)`.
- **Daemon**: when started with `--workspace W`, canonicalise W and bind the per-workspace socket. Without `--workspace`, fall back to `default.sock` (bootstrap path preserved for tests + any pre-v0.5.4 client).
- **MCP**: when `connect_with_auto_spawn` knows the workspace at spawn time (the production path: `rts-mcp --workspace W` from Claude Code / Cursor / etc.), compute the hash and route to the per-workspace socket. Connect to a live daemon there or auto-spawn one if absent.
- `docs/protocol-v0.md` §5.3 updated with the new layout and the `default.sock` bootstrap rationale.

## Impact

Two daemons on distinct workspaces now coexist on the same UID. The `WORKSPACE_MISMATCH` error remains for the (now rare) case where a daemon's hard-locked workspace is queried with a different `Workspace.Mount` payload over its own socket — that's a real protocol violation, not the path-collision artifact.

**Dogfood-verified end-to-end**: from a single shell with no daemon killed between calls:

\`\`\`bash
rts-bench query find-symbol --workspace \$TMP_A --name workspace_a_marker  # ✅ matches
rts-bench query find-symbol --workspace \$TMP_B --name workspace_b_marker  # ✅ matches
\`\`\`

Pre-PR: the second invocation returned `WORKSPACE_MISMATCH` and the user had to manually `pkill -f rts-daemon`.

## Test plan

- [x] `cargo test -p rts-daemon --test per_workspace_sockets` → 1 passed
  - New test `two_daemons_one_runtime_dir_distinct_workspaces` spawns daemon A with `--workspace=tempA` and daemon B with `--workspace=tempB` against the SAME shared XDG_RUNTIME_DIR / HOME, verifies both bind, mounts each, and asserts cross-workspace queries return empty (A doesn't see B's symbols and vice-versa).
- [x] `cargo test --workspace --release` — full suite green
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p rts-daemon -p rts-mcp` clean
- [x] Manual dogfood (above)

## Wire compatibility

| MCP | Daemon | Result |
|---|---|---|
| post-v0.5.4 | post-v0.5.4 | ✅ both use per-workspace path |
| post-v0.5.4 | pre-v0.5.4 | ✅ MCP looks for `ws-XXX.sock`, doesn't find, auto-spawns post-v0.5.4 daemon |
| pre-v0.5.4 | post-v0.5.4 | ❌ pre-MCP looks for `default.sock`, post-daemon doesn't bind there — mismatch. Practical impact: zero, since both binaries ship and update together. |

## Post-Deploy Monitoring & Validation

\`No additional operational monitoring required:\` filesystem-path change, no wire-protocol or behavioral change for warm daemons. Verify any in-flight CI scripts that hardcode `default.sock` are updated (none in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)