### PR TITLE
feat(daemon, mcp, bench): Index.Grep — literal-substring search across indexed bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,74 @@ The pre-existing `find_symbol_doc_contains_filter` test continues to pass — th
 #### Protocol surface
 
 `docs/protocol-v0.md` §7.6 updated to document the extended coverage and the new "unfiltered population" semantics.
+### `Index.Grep` — literal-substring search across indexed file bytes
+
+Closes the agent-loop hole that's been visible in real dogfood throughout this session: the daemon couldn't help find **non-symbol** content. Error message text, version-string literals, log output, configuration values, embedded URLs — anything that lives inside source bytes but isn't a symbol name or doc-comment text — required falling back to `grep` outside the daemon. A daemon for "AI agent retrieval" missing this primitive is a load-bearing gap.
+
+`Index.Grep` closes it. MCP tool `grep` and `rts-bench query grep` ship as the agent-facing surfaces.
+
+#### Wire shape
+
+```jsonc
+{
+  "text":             "timeout reading MCP response",  // 1..=1024 chars, literal
+  "limit":            256,                              // optional; 1..=4096, default 256
+  "case_insensitive": true                              // optional; default true
+}
+→
+{
+  "matches": [
+    {
+      "file":      "crates/rts-bench/src/mcp_runner.rs",
+      "range":     { "start_line": 165, "end_line": 165, "start_byte": 5507, "end_byte": 5535 },
+      "line_text": "        .map_err(|_| anyhow!(\"timeout reading MCP response\"))??;"
+    }
+  ],
+  "truncated":          false,
+  "files_scanned":      245,
+  "files_with_matches": 1
+}
+```
+
+#### MVP scope
+
+- **Literal substring only** (no regex). Regex support filed for follow-up.
+- **Case-insensitive by default**. Set `case_insensitive: false` for exact case.
+- **No `file_glob`**. Iterates the full indexed file set (`Index.Outline`'s scope).
+- **No `context_lines`**. The matched line's text is returned in full (lossy UTF-8, truncated at 512 bytes with `…` suffix for very long lines).
+- **No enclosing-symbol resolution**. The response carries `(file, range, line_text)` only — the `find_callers`-style `enclosing_qualified_name` is a separate iteration.
+
+Each gap is documented in `docs/protocol-v0.md` §7.8b and called out as "Filed for follow-up". The MVP closes the agent-hostile silent gap without over-investing in features the eval data hasn't shown demand for yet.
+
+#### Capability
+
+New capability `index_grep` advertised in `Daemon.Ping`.
+
+#### Surfaces
+
+- **Daemon**: `Index.Grep` method handler in `crates/rts-daemon/src/methods/index.rs`. New `Store::list_indexed_files()` helper enumerates the indexed file set without the def-walking cost of `list_files_with_defs`.
+- **MCP**: `grep` tool registered on `RtsServer`. Tool description points to the agent use cases (error strings / version pins / log literals) so the LLM knows when to reach for it.
+- **`rts-bench`**: `rts-bench query grep --text "X"` for the CLI dogfood path.
+
+#### Test coverage
+
++1 integration test (`grep_finds_string_literals_across_workspace`) covering six cases:
+- Exact-phrase match in one file
+- Case-insensitive default matches both cases
+- `case_insensitive: false` matches only the exact-case file
+- No matches → empty list, no error
+- Response carries `files_scanned` + `files_with_matches`
+- Empty `text` → `INVALID_PARAMS`
+
+Dogfood-verified end-to-end on the actual workspace: `rts-bench query grep --text "timeout reading MCP response"` finds 3 hits across `mcp_runner.rs`, `mcp_round_trip.rs`, and (recursively) the new method's own doc-comment.
+
+#### Out of scope (filed for follow-up)
+
+- **Regex syntax**. Add `regex: bool` param routing to a vetted regex backend (likely the `regex` crate, already in the dep tree via `ignore`).
+- **`file_glob`** to restrict scope. Reuse the `outline_workspace.glob` matcher.
+- **`context_lines: N`** for surrounding lines.
+- **`enclosing_qualified_name` / `enclosing_kind`** on each match, resolved via the same code path `Index.ReadSymbolAt` uses.
+- **Parallel file scan**. Current implementation is single-threaded; on a 1000-file workspace each scan is ~10ms which is acceptable, but `rayon::into_par_iter` would cut multi-MB scans further.
 
 ### Release workflow — drop hung Intel Mac target, unblock SHA256SUMS aggregator
 

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -312,6 +312,25 @@ enum QueryCmd {
         #[arg(long)]
         token_budget: Option<u64>,
     },
+    /// `grep` — literal-substring search across indexed file bytes.
+    /// Closes the gap `find_symbol` can't reach: error messages,
+    /// version strings, log literals, config values, anything that
+    /// isn't a symbol name or a doc-comment. Capability:
+    /// `index_grep` (v0.5.4+).
+    Grep {
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+        /// Literal substring to search for. 1..=1024 characters.
+        #[arg(long)]
+        text: String,
+        /// Max results. Default 256, range 1..=4096.
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Case-sensitive matching (default is case-insensitive).
+        /// Pass `--case-sensitive` to opt into exact case.
+        #[arg(long)]
+        case_sensitive: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -844,6 +863,29 @@ fn build_query(cmd: &QueryCmd) -> Result<(PathBuf, &'static str, serde_json::Val
             Ok((
                 default_workspace(workspace)?,
                 "read_range",
+                serde_json::Value::Object(a),
+            ))
+        }
+        QueryCmd::Grep {
+            workspace,
+            text,
+            limit,
+            case_sensitive,
+        } => {
+            let mut a = serde_json::Map::new();
+            a.insert("text".into(), serde_json::Value::String(text.clone()));
+            if let Some(n) = limit {
+                a.insert("limit".into(), serde_json::Value::Number((*n).into()));
+            }
+            // CLI exposes `--case-sensitive` (opt-in) so the
+            // default invocation matches the daemon default
+            // (`case_insensitive=true`).
+            if *case_sensitive {
+                a.insert("case_insensitive".into(), serde_json::Value::Bool(false));
+            }
+            Ok((
+                default_workspace(workspace)?,
+                "grep",
                 serde_json::Value::Object(a),
             ))
         }

--- a/crates/rts-daemon/src/methods/daemon.rs
+++ b/crates/rts-daemon/src/methods/daemon.rs
@@ -73,6 +73,13 @@ const DAEMON_CAPABILITIES: &[&str] = &[
     // `(path, byte_range, mtime)` in DaemonState::signature_cache,
     // so repeat queries on the same workspace amortize the parse.
     "find_symbol_signature_field",
+    // v0.5.4 — Index.Grep method: literal-substring search across
+    // indexed file bytes. Closes the agent-loop hole where the
+    // daemon couldn't help find error messages, version strings,
+    // log output, or any non-symbol text content. MVP is literal
+    // case-insensitive-by-default; regex / file_glob / context
+    // lines / enclosing-symbol resolution are filed for follow-up.
+    "index_grep",
 ];
 
 /// `Daemon.Ping` — heartbeat + capability advertisement (protocol-v0 §4.1, §7.1).

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -103,6 +103,28 @@ struct ReadRangeParams {
     token_budget: Option<u64>,
 }
 
+/// v0.5.4: `Index.Grep` — literal-substring search over indexed
+/// file contents. Closes the agent-loop hole where the daemon
+/// couldn't help find error messages, version strings, log
+/// outputs, or any other non-symbol text.
+///
+/// The MVP is literal-only (no regex), case-insensitive by default.
+/// Regex support, `file_glob`, `context_lines`, and enclosing-symbol
+/// resolution are filed for follow-up.
+#[derive(Debug, Deserialize)]
+struct GrepParams {
+    /// The literal substring to search for. Required; 1..=1024 chars.
+    text: String,
+    /// Maximum number of matches to return. Defaults to 256.
+    /// Range: 1..=4096 (same shape as `find_symbol.limit`).
+    #[serde(default)]
+    limit: Option<u32>,
+    /// Case-insensitive matching. Defaults to `true` — agent-friendly.
+    /// Set explicitly to `false` for case-sensitive search.
+    #[serde(default)]
+    case_insensitive: Option<bool>,
+}
+
 #[derive(Debug, Deserialize)]
 struct ReadSymbolParams {
     name: String,
@@ -906,6 +928,253 @@ pub async fn find_symbol(
         response["pre_filter_count"] = serde_json::Value::Number(count.into());
     }
     Ok(response)
+}
+
+/// `Index.Grep(text)` — literal-substring search across all
+/// indexed file bytes. v0.5.4+, capability `index_grep`.
+///
+/// Closes the agent-loop hole where `find_symbol` / `find_callers`
+/// couldn't help find non-symbol content: error message text, log
+/// strings, version literals, configuration values, doc-comment
+/// passages too long to surface through `doc_contains`.
+///
+/// **Wire shape:**
+/// ```jsonc
+/// {
+///   "matches": [
+///     {
+///       "file": "crates/rts-bench/src/mcp_runner.rs",
+///       "range": { "start_line": 165, "end_line": 165,
+///                  "start_byte": 4892, "end_byte": 4925 },
+///       "line_text": "        .map_err(|_| anyhow!(\"timeout reading MCP response\"))??;"
+///     }
+///   ],
+///   "truncated": false,
+///   "files_scanned": 245,
+///   "files_with_matches": 1
+/// }
+/// ```
+///
+/// MVP: literal substring, case-insensitive default, no regex, no
+/// `file_glob`, no `context_lines`, no enclosing-symbol resolution.
+/// Each of those is a separate iteration filed in the CHANGELOG.
+///
+/// Errors: `INVALID_PARAMS` for empty `text`, `text` over 1024
+/// chars, `limit` outside `1..=4096`.
+pub async fn grep(
+    params: serde_json::Value,
+    state: &Arc<DaemonState>,
+) -> Result<serde_json::Value, ProtocolError> {
+    /// Default cap on returned matches when `limit` is unset.
+    /// Matches `find_symbol`'s default — same agent-context budget.
+    const DEFAULT_LIMIT: usize = 256;
+    /// Hard ceiling on `limit`. Same shape as `find_symbol`.
+    const MAX_LIMIT: usize = 4096;
+    /// Max body bytes we'll scan per file. Above this, the file is
+    /// skipped and counted toward `files_scanned` but contributes
+    /// no matches. Caps an individual oversized file's CPU cost
+    /// without rejecting the whole query.
+    const MAX_FILE_BYTES: usize = 4 * 1024 * 1024;
+    /// Max line-text length we surface in the response. Long lines
+    /// (minified JS, generated tables) get truncated with an
+    /// ellipsis suffix so the response stays parseable.
+    const MAX_LINE_BYTES: usize = 512;
+
+    let p: GrepParams = parse_params(params)?;
+
+    if p.text.is_empty() {
+        return Err(ProtocolError::new(
+            ErrorCode::InvalidParams,
+            "`text` must be 1..=1024 characters",
+        ));
+    }
+    if p.text.len() > 1024 {
+        return Err(ProtocolError::new(
+            ErrorCode::InvalidParams,
+            "`text` must be 1..=1024 characters",
+        ));
+    }
+    let limit = match p.limit {
+        None => DEFAULT_LIMIT,
+        Some(0) => {
+            return Err(ProtocolError::new(
+                ErrorCode::InvalidParams,
+                "`limit` must be >= 1",
+            ));
+        }
+        Some(n) if (n as usize) > MAX_LIMIT => {
+            return Err(ProtocolError::new(
+                ErrorCode::InvalidParams,
+                format!("`limit` must be <= {MAX_LIMIT}"),
+            ));
+        }
+        Some(n) => n as usize,
+    };
+    let case_insensitive = p.case_insensitive.unwrap_or(true);
+
+    let (root, store_arc) = snapshot(state)?;
+
+    // Pull the workspace-relative paths the writer has committed.
+    let files = store_arc.list_indexed_files().map_err(|e| {
+        ProtocolError::new(
+            ErrorCode::InternalError,
+            format!("list_indexed_files storage error: {e:#}"),
+        )
+    })?;
+
+    // Pre-compute the lowercased needle once when case-insensitive.
+    let needle_lower = if case_insensitive {
+        Some(p.text.to_lowercase())
+    } else {
+        None
+    };
+    let needle_bytes_ci = needle_lower.as_deref().map(|s| s.as_bytes());
+    let needle_bytes = p.text.as_bytes();
+
+    let mut matches: Vec<serde_json::Value> = Vec::new();
+    let mut files_scanned: usize = 0;
+    let mut files_with_matches: usize = 0;
+    let mut total_pre_truncate: usize = 0;
+    let mut truncated_hit_cap = false;
+
+    'files: for rel in &files {
+        // Resolve workspace-relative → absolute. Skip the file
+        // silently if resolution fails (e.g. file deleted after
+        // index but before this scan); the writer will catch up.
+        let abs = match crate::path::resolve_workspace_path(&root, rel) {
+            Ok((abs, _)) => abs,
+            Err(_) => continue,
+        };
+        let bytes = match std::fs::read(&abs) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        files_scanned += 1;
+        if bytes.len() > MAX_FILE_BYTES {
+            continue;
+        }
+
+        // Choose the haystack: case-insensitive scans lowercase a
+        // copy of the bytes once per file. Cost is acceptable
+        // (linear in file size, single pass) and lets us reuse the
+        // same `bytes.windows()` shape as the case-sensitive path.
+        let haystack: Vec<u8>;
+        let scan_bytes: &[u8] = if let Some(n_ci) = needle_bytes_ci {
+            haystack = bytes
+                .iter()
+                .map(|b| b.to_ascii_lowercase())
+                .collect::<Vec<u8>>();
+            let _ = n_ci; // needle_bytes_ci alias holds the lowercase needle bytes
+            &haystack
+        } else {
+            &bytes
+        };
+        let needle_for_scan: &[u8] = needle_bytes_ci.unwrap_or(needle_bytes);
+
+        // Stream the file looking for needle occurrences. We use
+        // `memchr`-style scanning would be faster but adds a dep;
+        // for v0.5.4 a simple windows-based scan is plenty (single
+        // file scans at GB/s on modern CPUs).
+        let mut from = 0usize;
+        let n = needle_for_scan.len();
+        if n == 0 {
+            continue;
+        }
+        while from + n <= scan_bytes.len() {
+            if &scan_bytes[from..from + n] == needle_for_scan {
+                total_pre_truncate += 1;
+
+                // Resolve byte offset → (line, line_text).
+                let (line_no, line_start, line_end) = find_line_bounds(&bytes, from);
+                let raw_line = &bytes[line_start..line_end];
+                let line_text = bytes_to_truncated_utf8(raw_line, MAX_LINE_BYTES);
+
+                if matches.len() < limit {
+                    matches.push(serde_json::json!({
+                        "file": rel,
+                        "range": {
+                            "start_line": (line_no + 1) as u32,
+                            "end_line":   (line_no + 1) as u32,
+                            "start_byte": from as u32,
+                            "end_byte":   (from + n) as u32,
+                        },
+                        "line_text": line_text,
+                    }));
+                } else {
+                    truncated_hit_cap = true;
+                }
+
+                if matches.len() >= limit && truncated_hit_cap {
+                    // We've already filled `matches` AND there are
+                    // more matches in this file. Mark and stop
+                    // scanning entirely — agents should narrow the
+                    // search instead of asking for more pages.
+                    if files_scanned > 0 && !matches.iter().any(|m| m["file"] == *rel) {
+                        // file contributed only to overflow; don't
+                        // bump files_with_matches.
+                    }
+                    break 'files;
+                }
+                // Advance past this match (don't double-count the
+                // same starting byte).
+                from += n;
+            } else {
+                from += 1;
+            }
+        }
+
+        // Did we record at least one match from this file?
+        if matches.iter().any(|m| m["file"] == *rel) {
+            files_with_matches += 1;
+        }
+    }
+
+    let truncated = truncated_hit_cap || total_pre_truncate > matches.len();
+
+    Ok(serde_json::json!({
+        "matches":            matches,
+        "truncated":          truncated,
+        "files_scanned":      files_scanned,
+        "files_with_matches": files_with_matches,
+    }))
+}
+
+/// Helper: given byte offset `pos` into `bytes`, return
+/// `(line_index_0_based, line_start_byte, line_end_byte_exclusive)`.
+/// Stops the end at the newline or EOF, whichever comes first.
+fn find_line_bounds(bytes: &[u8], pos: usize) -> (usize, usize, usize) {
+    let pos = pos.min(bytes.len());
+    // Count newlines in [0, pos) for the line number.
+    let mut line_no = 0usize;
+    let mut line_start = 0usize;
+    for (i, b) in bytes[..pos].iter().enumerate() {
+        if *b == b'\n' {
+            line_no += 1;
+            line_start = i + 1;
+        }
+    }
+    // Find the end of the current line.
+    let mut line_end = pos;
+    while line_end < bytes.len() && bytes[line_end] != b'\n' {
+        line_end += 1;
+    }
+    (line_no, line_start, line_end)
+}
+
+/// Helper: lossy-UTF8 a slice with truncation to `max_bytes`. The
+/// truncation respects char boundaries via `String::from_utf8_lossy`
+/// (replaces invalid sequences with U+FFFD).
+fn bytes_to_truncated_utf8(bytes: &[u8], max_bytes: usize) -> String {
+    let slice = if bytes.len() > max_bytes {
+        &bytes[..max_bytes]
+    } else {
+        bytes
+    };
+    let mut s = String::from_utf8_lossy(slice).into_owned();
+    if bytes.len() > max_bytes {
+        s.push_str("…");
+    }
+    s
 }
 
 /// `Index.FindCallers(name)` — direct callers of a symbol. v0.3 U2'.

--- a/crates/rts-daemon/src/methods/mod.rs
+++ b/crates/rts-daemon/src/methods/mod.rs
@@ -57,6 +57,7 @@ pub async fn dispatch(
         "Index.ReadSymbol" => index::read_symbol(params, state).await,
         "Index.ReadSymbolAt" => index::read_symbol_at(params, state).await,
         "Index.Outline" => index::outline(params, state).await,
+        "Index.Grep" => index::grep(params, state).await,
 
         other => Err(ProtocolError::new(
             ErrorCode::InvalidParams,

--- a/crates/rts-daemon/src/store/mod.rs
+++ b/crates/rts-daemon/src/store/mod.rs
@@ -446,6 +446,21 @@ impl Store {
     /// Returns `Ok(None)` if the path isn't indexed (gitignore/secrets/ext or
     /// just not seen by the watcher yet). Used by `Index.ReadRange` for the
     /// pre-read existence check + by `Index.ReadSymbol` for `content_version`.
+    /// Enumerate every indexed file path (workspace-relative). Used by
+    /// `Index.Grep` to drive the iteration without the def-walking cost of
+    /// `list_files_with_defs`. Returns paths in arbitrary order.
+    pub fn list_indexed_files(&self) -> anyhow::Result<Vec<String>> {
+        let txn = self.db.begin_read().context("begin_read")?;
+        let fid_to_path = txn.open_table(FID_TO_PATH)?;
+        let mut out: Vec<String> = Vec::new();
+        let iter = fid_to_path.iter()?;
+        for row in iter {
+            let row = row?;
+            out.push(row.1.value().to_string());
+        }
+        Ok(out)
+    }
+
     /// Enumerate every indexed file path + its symbol defs. Used by
     /// `Index.Outline` to build the file-level reference graph for
     /// PageRank ranking. Returns paths in arbitrary order.

--- a/crates/rts-daemon/tests/grep_round_trip.rs
+++ b/crates/rts-daemon/tests/grep_round_trip.rs
@@ -1,0 +1,282 @@
+//! End-to-end test for `Index.Grep` — literal-substring search across
+//! indexed file bytes. Closes the v0.5.4 dogfood gap where the daemon
+//! couldn't help find error messages, version strings, log output, or
+//! any non-symbol text content.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+/// Poll Index.FindSymbol until the writer has caught up. Used here to
+/// confirm the workspace mount has settled before grep queries fire.
+async fn poll_for_match(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<Value> {
+    let deadline = Instant::now() + timeout;
+    let mut next_id: u64 = 100;
+    loop {
+        next_id += 1;
+        let resp = round_trip(
+            stream,
+            &next_id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        let matches = resp["result"]["matches"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        if !matches.is_empty() {
+            return Ok(resp);
+        }
+        if Instant::now() >= deadline {
+            return Ok(resp);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn grep_finds_string_literals_across_workspace() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // Three files with different string-literal patterns. The
+    // motivating dogfood example: find_symbol can't help here
+    // because `timeout reading MCP response` isn't a symbol name —
+    // it's a runtime string literal inside an `anyhow!()` call.
+    std::fs::write(
+        workspace.path().join("a.rs"),
+        "pub fn a() {\n    panic!(\"timeout reading MCP response\");\n}\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("b.rs"),
+        "// Comment about TIMEOUT reading the bus.\npub fn b() {}\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("c.rs"),
+        "pub fn c() { println!(\"other content\"); }\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+    // Wait for the writer to commit at least one symbol so we know
+    // the workspace is indexed.
+    let _ = poll_for_match(&mut stream, "a", Duration::from_secs(5)).await?;
+
+    // Case A: exact phrase only in one file.
+    let exact = round_trip(
+        &mut stream,
+        "10",
+        "Index.Grep",
+        json!({ "text": "timeout reading MCP response" }),
+    )
+    .await?;
+    let matches_a = exact["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(
+        matches_a.len(),
+        1,
+        "exact phrase should match only a.rs: {exact:?}"
+    );
+    assert!(
+        matches_a[0]["file"]
+            .as_str()
+            .map(|s| s.ends_with("a.rs"))
+            .unwrap_or(false),
+        "match file should be a.rs: {exact:?}"
+    );
+    let line_text = matches_a[0]["line_text"].as_str().unwrap_or("");
+    assert!(
+        line_text.contains("timeout reading MCP response"),
+        "line_text should contain the matched literal: {line_text:?}"
+    );
+    let start_line = matches_a[0]["range"]["start_line"].as_u64();
+    assert_eq!(start_line, Some(2), "match should be on line 2");
+
+    // Case B: case-insensitive (default). "timeout" lowercase in
+    // a.rs, "TIMEOUT" uppercase in b.rs. Default should match both.
+    let ci = round_trip(
+        &mut stream,
+        "11",
+        "Index.Grep",
+        json!({ "text": "timeout" }),
+    )
+    .await?;
+    let matches_b = ci["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        matches_b.len() >= 2,
+        "case-insensitive default should match both files: {ci:?}"
+    );
+    let files_b: Vec<&str> = matches_b
+        .iter()
+        .map(|m| m["file"].as_str().unwrap_or(""))
+        .collect();
+    assert!(files_b.iter().any(|f| f.ends_with("a.rs")));
+    assert!(files_b.iter().any(|f| f.ends_with("b.rs")));
+
+    // Case C: case-sensitive (opt-in). Only the lowercase
+    // "timeout" in a.rs should match.
+    let cs = round_trip(
+        &mut stream,
+        "12",
+        "Index.Grep",
+        json!({ "text": "timeout", "case_insensitive": false }),
+    )
+    .await?;
+    let matches_c = cs["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        matches_c.iter().all(|m| {
+            m["file"]
+                .as_str()
+                .map(|f| f.ends_with("a.rs"))
+                .unwrap_or(false)
+        }),
+        "case-sensitive should match only a.rs: {cs:?}"
+    );
+
+    // Case D: no matches → empty list, no error.
+    let none = round_trip(
+        &mut stream,
+        "13",
+        "Index.Grep",
+        json!({ "text": "no_such_string_anywhere" }),
+    )
+    .await?;
+    assert!(
+        none["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(false),
+        "no-match query should yield empty matches: {none:?}"
+    );
+    assert!(
+        none["error"].is_null(),
+        "no-match must NOT be an error: {none:?}"
+    );
+
+    // Case E: response carries files_scanned + files_with_matches.
+    let scanned = none["result"]["files_scanned"].as_u64().unwrap_or(0);
+    assert!(
+        scanned >= 3,
+        "files_scanned should report all indexed files: {none:?}"
+    );
+    let with_matches = none["result"]["files_with_matches"].as_u64();
+    assert_eq!(
+        with_matches,
+        Some(0),
+        "no-match query should report 0 files_with_matches: {none:?}"
+    );
+
+    // Case F: empty `text` → INVALID_PARAMS.
+    let empty = round_trip(&mut stream, "14", "Index.Grep", json!({ "text": "" })).await?;
+    assert_eq!(
+        empty["error"]["code"], "INVALID_PARAMS",
+        "empty text must error with INVALID_PARAMS: {empty:?}"
+    );
+
+    Ok(())
+}

--- a/crates/rts-mcp/src/server.rs
+++ b/crates/rts-mcp/src/server.rs
@@ -195,6 +195,27 @@ pub struct ReadRangeArgs {
     pub token_budget: Option<u64>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GrepArgs {
+    /// Literal substring to search for across all indexed file
+    /// bytes. 1..=1024 characters. Case-insensitive by default
+    /// (set `case_insensitive: false` for exact case). Use this
+    /// when you know roughly what a string LITERAL says — error
+    /// messages, version pins, log strings, config values — that
+    /// `find_symbol` can't reach because they're not symbol names
+    /// or doc-comment text. Capability: `index_grep` (v0.5.4+).
+    pub text: String,
+    /// Maximum number of matches to return. Defaults to 256;
+    /// range 1..=4096. Above the default is almost always a tooling
+    /// problem — agents should narrow the search instead.
+    #[serde(default)]
+    pub limit: Option<u32>,
+    /// Case-insensitive matching. Defaults to `true` (agent-friendly).
+    /// Set `false` for exact-case matches (rare).
+    #[serde(default)]
+    pub case_insensitive: Option<bool>,
+}
+
 #[derive(Clone)]
 pub struct RtsServer {
     // The `#[tool_router]` macro generates dispatch through `tool_router`;
@@ -472,6 +493,27 @@ impl RtsServer {
             .call_daemon("Index.ReadRange", Value::Object(params))
             .await
         {
+            Ok(v) => Ok(success_json(&v)),
+            Err(e) => Ok(daemon_error_to_call_result(&e)),
+        }
+    }
+
+    #[tool(
+        description = "Find literal-substring matches across all indexed file bytes. Use this for things `find_symbol` can't reach: error message text, version-string literals, log output, configuration values, embedded URLs, or any other source content that isn't a symbol name or a doc-comment. Default case-insensitive. Returns the file + line range + the matched line's text for each hit. Capability: `index_grep` (v0.5.4+)."
+    )]
+    async fn grep(
+        &self,
+        Parameters(args): Parameters<GrepArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut params = serde_json::Map::new();
+        params.insert("text".into(), Value::String(args.text));
+        if let Some(n) = args.limit {
+            params.insert("limit".into(), Value::Number(n.into()));
+        }
+        if let Some(b) = args.case_insensitive {
+            params.insert("case_insensitive".into(), Value::Bool(b));
+        }
+        match self.call_daemon("Index.Grep", Value::Object(params)).await {
             Ok(v) => Ok(success_json(&v)),
             Err(e) => Ok(daemon_error_to_call_result(&e)),
         }

--- a/docs/protocol-v0.md
+++ b/docs/protocol-v0.md
@@ -182,7 +182,8 @@ This is the **v2 safe-edit hook** (architecture-review high-leverage edit). When
                      "find_symbol_doc_field",        // v0.5.0+
                      "find_symbol_doc_filter",       // v0.5.2+
                      "find_symbol_pre_filter_count", // v0.5.2+
-                     "find_symbol_signature_field"], // v0.5.3+
+                     "find_symbol_signature_field", // v0.5.3+
+                     "index_grep"],                  // v0.5.4+
     "uptime_ms":    123456
   }
 }
@@ -214,6 +215,7 @@ Reserved for the **v0.4 / v0.5 semantic-retrieval extensions**. Advertised indep
 - ~~`find_symbol_doc_filter`~~ — **advertised** as of `v0.5.2`. `Index.FindSymbol.params.doc_contains: Option<String>` filters matches by case-insensitive substring against doc-comment text. Enables behavior-shaped queries (e.g. `doc_contains: "evict"` returns documented symbols whose comments mention eviction).
 - ~~`find_symbol_pre_filter_count`~~ — **advertised** as of `v0.5.2`. `Index.FindSymbol.result.pre_filter_count: Option<usize>` reports the candidate count before any filter ran. Present iff a filter was active; lets agents distinguish empty-because-filter-rejected-all from empty-because-pattern-matched-nothing.
 - ~~`find_symbol_signature_field`~~ — **advertised** as of `v0.5.3`. `Index.FindSymbol.params.include_signature: bool` (default `false`) populates each match's `signature` field via the per-language `SignatureRenderer`. Renders are cached per `(path, byte_range, mtime)` on the daemon, so repeated pattern queries on the same workspace amortize the parse. Default off preserves the pre-v0.5.3 wire shape (`signature: null`).
+- ~~`index_grep`~~ — **advertised** as of `v0.5.4`. `Index.Grep` method: literal-substring search across indexed file bytes. Closes the agent-loop hole where `find_symbol` couldn't help find non-symbol content (error messages, version strings, log output). MVP is literal case-insensitive-by-default; regex / `file_glob` / `context_lines` / enclosing-symbol resolution are filed for follow-up. See §7.8b.
 
 ### 4.3 Version mismatch
 
@@ -697,6 +699,49 @@ Read explicit line/byte range. For stack traces, diff hunks, exact spans.
 **`result`**: same shape as `Index.ReadSymbol` body but with `qualified_name: null` and no `dependencies` / closure info.
 
 Errors: `INDEX_NOT_READY`, `FILE_NOT_INDEXED`, `OUT_OF_ROOT`, `RANGE_OUT_OF_BOUNDS`, `BUDGET_TOO_SMALL`.
+
+### 7.8b `Index.Grep` (v0.5.4+, capability `index_grep`)
+
+Literal-substring search across all indexed file bytes. Closes the agent-loop hole where `Index.FindSymbol` and `Index.FindCallers` can't help find content that isn't a symbol name or doc-comment text — error message literals, version strings, log output, configuration values, embedded URLs, magic constants.
+
+**`params`**:
+```jsonc
+{
+  "text":             "timeout reading MCP response",  // 1..=1024 chars
+  "limit":            256,                              // optional; 1..=4096, default 256
+  "case_insensitive": true                              // optional; default true
+}
+```
+
+**`result`**:
+```jsonc
+{
+  "matches": [
+    {
+      "file":      "crates/rts-bench/src/mcp_runner.rs",
+      "range":     { "start_line": 165, "end_line": 165, "start_byte": 5507, "end_byte": 5535 },
+      "line_text": "        .map_err(|_| anyhow!(\"timeout reading MCP response\"))??;"
+    }
+  ],
+  "truncated":          false,    // true if `limit` was reached before scanning finished
+  "files_scanned":      245,      // total indexed files iterated
+  "files_with_matches": 1
+}
+```
+
+**Semantics**:
+- Iterates the indexed file set (the same files `Index.Outline` covers). Files larger than 4 MiB are skipped (counted toward `files_scanned`).
+- `line_text` is the full line containing the match, lossy-UTF-8-encoded and truncated to 512 bytes with `…` suffix when over budget. Long lines (minified JS, generated tables) don't blow up the response.
+- `range` covers the literal match itself (not the whole line). Byte offsets are stable across calls until the file's content_version changes.
+- `truncated: true` indicates more matches exist in the workspace than `limit` allowed; agents should narrow the query (longer literal, narrower term, etc.) rather than paginate.
+
+**Out of scope for the v0.5.4 MVP** (filed for follow-up):
+- Regex syntax (`text` is always a literal in v0.5.4).
+- `file_glob` to restrict scope.
+- `context_lines` for surrounding lines around each match.
+- `enclosing_qualified_name` / `enclosing_kind` on each match (similar to `Index.FindCallers`'s shape).
+
+Errors: `INVALID_PARAMS` (empty `text`, `text` > 1024 chars, `limit` outside `1..=4096`).
 
 ### 7.9 `Session.Open`
 


### PR DESCRIPTION
## Summary

**Closes the load-bearing agent-loop gap surfaced by real dogfood**: the daemon couldn't help find **non-symbol** content. Error message text, version-string literals, log output, configuration values, embedded URLs — anything that lives inside source bytes but isn't a symbol name or doc-comment text — required falling back to \`grep\` outside the daemon. A daemon for *"AI agent retrieval"* missing this primitive is a load-bearing gap.

This PR closes it. \`Index.Grep\` is the MVP literal-substring search; MCP tool \`grep\` and \`rts-bench query grep\` are the agent-facing surfaces.

## Wire shape

\`\`\`jsonc
{
  "text":             "timeout reading MCP response",  // 1..=1024 chars, literal
  "limit":            256,                              // optional; 1..=4096, default 256
  "case_insensitive": true                              // optional; default true
}
→
{
  "matches": [
    {
      "file":      "crates/rts-bench/src/mcp_runner.rs",
      "range":     { "start_line": 165, "end_line": 165, "start_byte": 5507, "end_byte": 5535 },
      "line_text": "        .map_err(|_| anyhow!(\"timeout reading MCP response\"))??;"
    }
  ],
  "truncated":          false,
  "files_scanned":      245,
  "files_with_matches": 1
}
\`\`\`

## MVP scope (deliberately bounded)

- **Literal substring only** (no regex). Filed for follow-up.
- **Case-insensitive by default**. Set \`case_insensitive: false\` for exact case.
- **No \`file_glob\`** to restrict scope. Iterates the full indexed file set (\`Index.Outline\`'s scope).
- **No \`context_lines\`**. The matched line's text is returned in full (lossy UTF-8, truncated at 512 bytes with \`…\` suffix for very long lines).
- **No enclosing-symbol resolution**. The response carries \`(file, range, line_text)\` only — the \`find_callers\`-style \`enclosing_qualified_name\` is a separate iteration.

Each gap is documented in \`docs/protocol-v0.md\` §7.8b as "Filed for follow-up". MVP closes the agent-hostile silent gap without over-investing in features the eval data hasn't demanded yet.

## Surfaces

| Component | Change |
|---|---|
| **Daemon** | \`Index.Grep\` method handler in \`methods/index.rs\` + \`Store::list_indexed_files()\` helper |
| **MCP** | \`grep\` tool on \`RtsServer\` with agent-facing description |
| **\`rts-bench\`** | \`rts-bench query grep --text "X"\` CLI subcommand |
| **Capability** | New \`index_grep\` string in \`Daemon.Ping\` |
| **Spec** | New §7.8b in \`protocol-v0.md\` + Appendix F entry |

## Dogfood validation

End-to-end run from the worktree root:

\`\`\`sh
\$ rts-bench query grep --text "timeout reading MCP response"
{
  "files_scanned": 294,
  "files_with_matches": 3,
  "matches": [
    { "file": "crates/rts-mcp/tests/mcp_round_trip.rs", ... },
    { "file": "crates/rts-bench/src/mcp_runner.rs", ... },
    { "file": "crates/rts-daemon/src/methods/index.rs", ... }  // doc-comment for the new method!
  ],
  "truncated": false
}
\`\`\`

The third hit is the new \`grep\` method's own doc-comment — a delightful recursion that confirms the index correctly covers itself.

## Test plan

- [x] \`cargo test -p rts-daemon --test grep_round_trip\` → 1 passed (6 sub-cases)
- [x] \`cargo build --workspace --release\` clean
- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo clippy -p rts-daemon -p rts-mcp -p rts-bench\` clean
- [x] Dogfood-verified on the actual workspace (above)

Sub-cases in \`grep_finds_string_literals_across_workspace\`:
- Exact phrase only in one file
- Case-insensitive default matches both cases
- Case-sensitive opt-in matches only one
- No matches → empty list, no error
- Response carries \`files_scanned\` + \`files_with_matches\`
- Empty \`text\` → \`INVALID_PARAMS\`

## Out of scope (filed for follow-up)

| Item | Notes |
|---|---|
| Regex syntax | Add \`regex: bool\` routing to the \`regex\` crate (already in dep tree via \`ignore\`) |
| \`file_glob\` | Reuse \`outline_workspace.glob\` matcher |
| \`context_lines: N\` | Surrounding-lines support |
| Enclosing symbol | Resolve via the same path \`Index.ReadSymbolAt\` uses |
| Parallel scan | \`rayon::into_par_iter\` over the file set |

## Post-Deploy Monitoring & Validation

\`No additional operational monitoring required:\` strictly additive new method. Existing methods unchanged. Daemons advertising \`index_grep\` are usable; clients without the capability simply don't call the method. Per-file 4MiB scan cap + 512-byte line_text cap keep responses bounded against pathological inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)