### PR TITLE
release: v0.5.4 — external-repo eval + per-workspace daemons + Index.Grep + 12-language parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-05-16
+
+**Theme: cross-codebase evaluation, daemon workspace-isolation, grep, and 12-language parity.**
+
+v0.5.3 declared "100% answerable coverage on rts-core" but only had self-eval to support it. v0.5.4 closes that loop by adding **six external-repo corpora** spanning Rust, Go, Python, JavaScript, and Java — and a battery of ranker improvements driven by the failure modes those corpora exposed.
+
+The marquee result: **ripgrep (50k LOC Rust)** went from **35.7% coverage / MRR 0.073** to **85.7% / 0.549** — a 7.5× MRR improvement from a single PR. The candidate-pool architecture (PageRank-only fetch was missing the type-level symbols on large workspaces) was the deeper issue hiding behind a scorer-tuning hypothesis.
+
+### Headline changes
+
+1. **C# language support** — 12-language doc-comment parity (#84).
+2. **Trait / type-alias / union / macro extraction** in `extract_rust_symbols` (part of #91). Pre-fix `pub trait Log` was invisible to `find_symbol`.
+3. **Per-workspace socket paths** (#88). `ws-<16hex>.sock` from `blake3(canonical_path)`. No more `pkill -f rts-daemon` to switch workspaces.
+4. **`Index.Grep` method** (#90). Literal-substring search across indexed file bytes. Capability `index_grep`.
+5. **`Index.FindSymbol.include_signature`** — opt-in (#81) then auto-default for small queries (#86).
+6. **`Index.FindSymbol.pre_filter_count`** extended to `kind` + `file` filters (#89).
+7. **Six external-repo corpora** (#87, #91): rust-log, ripgrep, cobra, requests, chalk (JS), gson (Java) + dogfood-v3.
+8. **Ranker improvements** (#91): trait extraction, CVC consonant-doubling lemma overrides, common-noun penalty, kind-hint multiplier, public-visibility boost, multi-pass kind-enriched candidate fetch, test-file/test-name penalty.
+
+### Quality-of-life
+
+- **Cold-mount UX** (#83): 30s recv timeout + diagnostic error.
+- **`rts-bench query` workspace auto-detection** (#85): no more `--workspace .`.
+- **Release workflow** (#82): dropped hung Intel Mac target; unblocked SHA256SUMS aggregator.
+
+### Final cross-corpus matrix
+
+| Corpus | Coverage | MRR |
+|---|---:|---:|
+| rust-log | **100%** | 0.736 |
+| ripgrep | 85.7% | 0.553 |
+| cobra | 76.9% | 0.573 |
+| requests | 84.6% | 0.545 |
+| chalk | 85.7% | 0.857 |
+| gson | 75.0% | 0.497 |
+| rts-core v1 (audited) | 100% answerable | 0.352 |
+| rts-core blind-v2 | 100% answerable | 0.312 |
+
+External-corpus avg: **84.6%**. rts-core invariants held.
+
+### Protocol surface
+
+New capabilities advertised in `Daemon.Ping`:
+- `find_symbol_signature_field` (v0.5.3+, opt-in `include_signature`)
+- `index_grep` (v0.5.4+, literal-substring search)
+
+Per-workspace socket path: `<runtime_root>/ws-<16hex>.sock` (`default.sock` retained as bootstrap fallback).
+
+### Out of scope (filed for follow-up)
+
+- cobra + requests past 76.9% / 84.6%
+- Promote external corpora to CI invariants
+- rts-core v1 MRR regression (-10%, generalisation cost)
+
 ### Semantic eval — dogfood-v3 corpus surfaces the real generalization gap
 
 Closes the v0.5.0-noted "out of scope" follow-up: *"Mining queries from real Claude Code transcripts (the most rigorous corpus addition)."* True transcript mining isn't possible yet because rts-mcp isn't wired into Claude Code sessions today — but the next-best thing is: **mine the developer's own dogfood lookups while building features against this very repo**, treating those natural-language intents as the corpus.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.4"
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yourusername/rust_tree_sitter"


### PR DESCRIPTION
## Summary

Rolls up 9 PRs since v0.5.2 into a feature-heavy release.

### Headline

External-corpus eval **average 84.6% answerable coverage** across 6 popular GitHub repos spanning Rust, Go, Python, JS, Java. ripgrep moved 35.7% → **85.7%** coverage (7.5× MRR). rts-core invariants held at 100%.

### PR roll-up

| # | Theme |
|---|---|
| #81 | `include_signature` opt-in |
| #82 | Release workflow fix (Intel Mac, SHA256SUMS) |
| #83 | Cold-mount UX (30s recv timeout) |
| #84 | C# language support — 12-language parity |
| #85 | `rts-bench query` workspace auto-detect |
| #86 | `include_signature` auto-default for small queries |
| #87 | dogfood-v3 corpus (71.4% honest baseline) |
| #88 | Per-workspace socket paths |
| #89 | `pre_filter_count` for kind + file filters |
| #90 | `Index.Grep` — literal-substring search |
| #91 | 6 external corpora + ranker fixes |

### New protocol surface

| Capability | Notes |
|---|---|
| `find_symbol_signature_field` | Opt-in `include_signature` param + auto-default for small queries |
| `index_grep` | New `Index.Grep` method |

### Per-workspace daemon isolation

`default.sock` → `ws-<16hex>.sock` (hashed from canonical workspace path). Two daemons on distinct workspaces now coexist on one UID.

### Final cross-corpus matrix

| Corpus | Coverage | MRR |
|---|---:|---:|
| rust-log | **100%** | 0.736 |
| ripgrep | 85.7% | 0.553 |
| cobra | 76.9% | 0.573 |
| requests | 84.6% | 0.545 |
| chalk | 85.7% | 0.857 |
| gson | 75.0% | 0.497 |
| rts-core v1 (audited) | 100% answerable | 0.352 |
| rts-core blind-v2 | 100% answerable | 0.312 |

### Test plan

- [x] \`cargo build --workspace --release\` clean
- [x] All three binaries report \`0.5.4\` via \`--version\`
- [x] \`cargo test --workspace --release\` green
- [x] All 6 external corpora ran end-to-end pre-tag

### Post-Deploy Monitoring & Validation

- **What to monitor**: tag-push release workflow (\`gh run list --workflow=release.yml --limit 1\`). The Intel Mac drop from #82 should let it complete cleanly with SHA256SUMS this time.
- **Expected**: 3 tarballs + per-asset .sha256 + consolidated SHA256SUMS
- **Validation**: \`curl -fsSL https://github.com/njfio/rs-agent-code-utility/releases/download/v0.5.4/SHA256SUMS\` returns content (previously 404 on v0.5.0/v0.5.1/v0.5.2)
- **Failure trigger**: workflow fails or SHA256SUMS still missing → diagnose the aggregator config

🤖 Generated with [Claude Code](https://claude.com/claude-code)