### PR TITLE
feat(rts-bench): doctor — first-run health check + Daemon.Stats v2

### DIFF
--- a/.claude/hooks/rts-nudge.sh
+++ b/.claude/hooks/rts-nudge.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# version: 0.5.5
 # rts-nudge.sh — Claude Code PreToolUse hook (v0.5.8+, this repo).
 #
 # Intercepts `Bash` tool calls containing grep/rg/egrep/fgrep/find on

--- a/changelog.d/xxx-feat-rts-bench-doctor.md
+++ b/changelog.d/xxx-feat-rts-bench-doctor.md
@@ -1,0 +1,120 @@
+### `rts-bench doctor` + `Daemon.Stats v2` — first-run health check, end the silent-install era
+
+The #1 first-run failure pattern for rts has always been silent: daemon not running, MCP not registered to the right scope, stale index, hook missing, wrong workspace. Users grep through the README, tail the daemon log, and eventually file an issue. Adoption ceiling = *"users patient enough to debug a silent install."*
+
+This PR ships the diagnostic surface that surfaces every failure mode with an inline copy-pasteable fix.
+
+#### What
+
+**New `rts-bench doctor` subcommand.** Five sections, normative order, snapshot-stable output:
+
+```
+$ rts-bench doctor
+rts-bench doctor (schema=doctor-v0)
+
+== binary ==
+  [OK]   binary:doctor_version — rts-bench doctor v0.6.0
+  [OK]   binary:rts_daemon — rts-daemon at /usr/local/bin/rts-daemon (v0.6.0)
+  [OK]   binary:rts_mcp — rts-mcp at /usr/local/bin/rts-mcp (v0.6.0)
+
+== daemon ==
+  [OK]   daemon:reachable — daemon v0.6.0 reachable, uptime 12345 ms (daemon_stats_v2)
+
+== mcp_registration ==
+  [OK]   claude_code:user_scope — registered at ~/.claude.json
+  [?]    aider — not detected (soft-detect)
+  …
+
+== hook ==
+  [OK]   hook:installed_current — hook installed and current (v0.6.0)
+
+== workspace_index ==
+  [OK]   workspace_index:state — index generation 1247, 4218 files (cold walk completed)
+
+exit class: ok
+```
+
+Three flags: `--output [human|json]` (default `human`; reconciled to the `rts-bench query` convention), `--no-color`, `--workspace <path>`.
+
+**Exit-code contract (public API):**
+- `0` — no FAIL rows (any WARN allowed)
+- `1` — at least one FAIL row
+- `2` — doctor itself failed (panic, JSON serialization error)
+- `>=3` — reserved; CI gates MUST NOT depend on specific values
+
+**Five sections, in order:**
+
+1. **`binary`** — doctor's own version; `rts-daemon` / `rts-mcp` discovery on `$PATH`; symlink resolution via `std::fs::canonicalize`; version-drift detection across binaries. Manual `$PATH` walk (no `which` crate dep). No shell-outs to `realpath -m` (BSD/Linux foot-gun, cf. #106).
+2. **`daemon`** — per-workspace socket probe; one round-trip to the new `Daemon.Stats v2`; graceful fallback to `Workspace.Status` on pre-v2 daemons; distinguishes "not running" (WARN + `rts-daemon --workspace $PWD &` fix) from "stale socket" (FAIL + `rm -f` fix).
+3. **`mcp_registration`** — reads canonical config-file paths for all 5 supported agent hosts:
+
+   | Host         | Class  | Paths probed |
+   |--------------|--------|--------------|
+   | Claude Code  | Hard   | `~/.claude.json` (user), project `.mcp.json`, settings.json hook block |
+   | Cursor       | Hard   | `~/.cursor/mcp.json` |
+   | Continue     | Hard   | `~/.continue/config.yaml` (YAML, not JSON — corrected from brainstorm) |
+   | Aider        | Soft   | `~/.config/aider/mcp.json`, `<workspace>/.aider/mcp.json`, `~/.aider.conf.yml` |
+   | Cline        | Soft   | VS Code extension global state (OS-specific paths) |
+
+   Cross-scope drift detection for Claude Code: multiple scopes registering rts at different binaries → `[WARN] multi-scope drift`.
+4. **`hook`** — `.claude/hooks/rts-nudge.sh` presence + executability + version-marker match. New `# version: <ver>` comment in the hook lets doctor flag drift between bundled and installed versions.
+5. **`workspace_index`** — pinned-workspace path match (FAIL on mismatch with `move_workspace` fix), cold-walk completion (WARN on indexing-in-progress), index generation, file count.
+
+**`--output json` produces a versioned schema** (`doctor-v0`) documented in [`docs/doctor-schema.md`](../docs/doctor-schema.md). Stable across patch releases; additive evolution via the top-level `capabilities[]` array. Pre-v1 consumers: the agent-bench harness's preflight (PR follow-up).
+
+#### Prerequisite: `Daemon.Stats v2`
+
+Doctor's `daemon` and `workspace_index` sections need workspace metadata the daemon didn't previously surface. PR adds:
+
+- `pinned_workspace_path: str` — the canonical path the daemon is pinned to
+- `workspace_id: str` — 32-char hex (blake3 truncation) workspace fingerprint
+- `index_generation: u64` — bumps on every committed write
+- `cold_walk_completed_at_ms: u64 | null` — Unix-epoch ms of the writer's `ColdWalkComplete` flush; `null` until cold walk completes
+
+Backward compatible: pre-mount `Daemon.Stats` calls keep the v1 shape exactly. New capability `daemon_stats_v2` advertises the v2 fields; doctor degrades gracefully against old daemons.
+
+#### Fix-snippet taxonomy
+
+Every WARN/FAIL row may carry an inline `fix` block with a closed `class` taxonomy (10 variants: `install_binary`, `start_daemon`, `remove_stale_socket`, `register_mcp`, `fix_mcp_binary_path`, `make_hook_executable`, `update_hook`, `move_workspace`, `reindex_needed`, `fix_config_syntax`) and a copy-pasteable `command`. Renders as the next line in human mode, structured JSON object in machine mode.
+
+#### Panic safety
+
+The entire `doctor::run` body is wrapped in `catch_unwind`. A panic in any section yields exit `2` with a structured `error` envelope in JSON mode — doctor itself stays alive and reports.
+
+#### Snapshot stability
+
+No wall-clock timestamps in default output. ANSI gated by stdout-is-TTY + `NO_COLOR` env + `--no-color` flag. Section order normative. Row order within a section deterministic. Snapshot tests can diff against goldens.
+
+#### Why this matters
+
+A new user with a broken install today runs `rts` and sees nothing — no error, no hint. They grep the README, tail logs, eventually open an issue. With this PR, the new flow is:
+
+```
+$ rts-bench doctor
+== mcp_registration ==
+  [FAIL] claude_code:user_scope — rts not registered
+    → claude mcp add rts -- $(which rts-mcp) --workspace "$PWD"
+…
+$ claude mcp add rts -- ...   # paste the fix
+$ rts-bench doctor
+…all OK.
+```
+
+One subcommand, one failure narrative, one fix. The agent-bench harness consumes the JSON output for preflight checks so failed installs abort *before* burning API credit on a doomed trajectory.
+
+#### Verification
+
+- Full plan: [`docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md`](../docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md)
+- Origin brainstorm: [`docs/brainstorms/2026-05-18-rts-doctor-requirements.md`](../docs/brainstorms/2026-05-18-rts-doctor-requirements.md)
+- Schema doc: [`docs/doctor-schema.md`](../docs/doctor-schema.md)
+- New integration test: `crates/rts-daemon/tests/daemon_stats_v2_round_trip.rs` — asserts the v2 capability is advertised, v1 shape preserved pre-mount, v2 fields populate post-mount with sane values.
+- Per-section unit tests across `crates/rts-bench/src/doctor/` cover every documented row outcome.
+- End-to-end smoke on the rts workspace: doctor reports all-OK after `claude mcp add rts ...`.
+
+#### Out of scope (filed for follow-up)
+
+- **`--fix` mode** that applies recommended actions. Doctor is read-only in v1; auto-fix touches user config files and is the wrong shape for v1's "first install" mission.
+- **Behavioral telemetry** (per-method call counts, nudge-fire log, recent error rate). Lives in `daemon-stats` (#104) and the auto-dump-on-shutdown (#105).
+- **Cross-version drift detection** beyond the binary section. The known "Claude Code spawned a pre-#104 rts-mcp at session start" foot-gun is acknowledged but stays a separate brainstorm.
+- **Windows support.** Unix sockets only.
+- **`--section <name>` flag** for partial runs. All-or-nothing in v1.

--- a/crates/rts-bench/Cargo.toml
+++ b/crates/rts-bench/Cargo.toml
@@ -59,3 +59,9 @@ tempfile = "3"
 
 # TOML parsing for the semantic-eval corpus format. Pure-Rust, small.
 toml = "0.8"
+
+# YAML parsing for Continue's `~/.continue/config.yaml` (and Aider's
+# `~/.aider.conf.yml`). Pulled in for the `doctor` subcommand's per-host
+# MCP-registration detectors (U7); same crate is already in use by
+# rts-core, so this does not introduce a new transitive dep.
+serde_yaml = "0.9"

--- a/crates/rts-bench/Cargo.toml
+++ b/crates/rts-bench/Cargo.toml
@@ -40,6 +40,13 @@ hex = "0.4"
 # CLI subcommands. `clap` is cheap to bring in for the bench-only surface.
 clap = { version = "4", features = ["derive"] }
 
+# XDG-aware home/config dir resolution. Used by `rts-bench doctor`
+# (U2+) for per-agent-host config file discovery (`~/.cursor/mcp.json`,
+# `~/.continue/config.yaml`, etc.). Same crate (`dirs = "5"`) is
+# already a transitive dep via rts-daemon; promote to direct here so
+# the doctor surface doesn't depend on it indirectly.
+dirs = "5"
+
 # Filesystem walking (mirrors rts-core's filter).
 ignore = "0.4"
 

--- a/crates/rts-bench/src/doctor/binary_section.rs
+++ b/crates/rts-bench/src/doctor/binary_section.rs
@@ -128,7 +128,9 @@ fn is_executable_file(path: &Path) -> bool {
     // On non-Unix, fall back to "is a file". rts doesn't ship
     // Windows tarballs today, so this branch exists only to keep
     // the crate building if someone tries `cargo check --target …`.
-    std::fs::metadata(path).map(|m| m.is_file()).unwrap_or(false)
+    std::fs::metadata(path)
+        .map(|m| m.is_file())
+        .unwrap_or(false)
 }
 
 /// Resolve symlinks via `std::fs::canonicalize`. Falls back to the

--- a/crates/rts-bench/src/doctor/binary_section.rs
+++ b/crates/rts-bench/src/doctor/binary_section.rs
@@ -1,19 +1,407 @@
 //! `binary` section — doctor's own version, rts-daemon / rts-mcp
-//! presence on PATH, symlink resolution. U4 implements; this file is
-//! a placeholder that returns a single info row so U2's wiring
-//! compiles end-to-end.
+//! presence on PATH, symlink resolution, and version-drift detection.
+//!
+//! Implementation notes:
+//! - PATH lookup is a manual walk over `std::env::var_os("PATH")`. We
+//!   deliberately avoid the `which` crate (no new dep) and we never
+//!   shell out to `realpath -m` / `readlink -f` because their flag
+//!   semantics differ between BSD/macOS and GNU/Linux (cf. #106).
+//! - Symlink resolution uses `std::fs::canonicalize`, which is the
+//!   portable Rust equivalent.
+//! - `--version` invocation uses `std::process::Command::new(bin)`;
+//!   stdout is parsed leniently (we look for a `v?<semver-ish>` token
+//!   anywhere on the first non-empty line).
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use super::ctx::Ctx;
-use super::report::{Row, SectionReport};
+use super::report::{FixClass, FixSnippet, Row, SectionReport};
+
+/// Binaries this section probes for. Order matters — it's the row
+/// emission order.
+const PROBED_BINARIES: &[&str] = &["rts-daemon", "rts-mcp"];
 
 pub fn run(ctx: &Ctx) -> SectionReport {
     let mut s = SectionReport::new("binary");
-    s.push(Row::info(
-        "binary:placeholder",
-        format!(
-            "binary section not yet implemented (doctor v{ver})",
-            ver = ctx.doctor_version
-        ),
+
+    // Row 1 — doctor's own version. Always present, always OK.
+    s.push(Row::ok(
+        "binary:doctor_version",
+        format!("rts-bench doctor v{}", ctx.doctor_version),
     ));
+
+    // Rows 2..N — per-binary discovery. Each binary either resolves to
+    // a path (OK row + optional drift WARN) or doesn't (FAIL row with
+    // install fix snippet).
+    let path_var = std::env::var_os("PATH");
+    let mut drift_rows: Vec<Row> = Vec::new();
+
+    for bin in PROBED_BINARIES {
+        let label = bin_label(bin);
+        match find_on_path(bin, path_var.as_deref()) {
+            Some(found) => {
+                let resolved = canonicalize_or(&found);
+                let version = probe_version(&found);
+                let msg = match &version {
+                    Some(v) => format!("{} at {} (v{})", bin, resolved.display(), v),
+                    None => format!("{} at {}", bin, resolved.display()),
+                };
+                s.push(Row::ok(label, msg));
+
+                // Drift check: if we got a version and it doesn't match
+                // doctor's, emit a peer WARN row. No fix snippet — the
+                // recovery is contextual (rebuild vs reinstall vs pin).
+                if let Some(v) = version {
+                    if !versions_match(&v, ctx.doctor_version) {
+                        drift_rows.push(Row::warn(
+                            "binary:version_drift",
+                            format!(
+                                "version drift: doctor=v{}, {}=v{}",
+                                ctx.doctor_version, bin, v
+                            ),
+                        ));
+                    }
+                }
+            }
+            None => {
+                s.push(
+                    Row::fail(label, format!("{} not found on $PATH", bin))
+                        .with_fix(install_fix(bin)),
+                );
+            }
+        }
+    }
+
+    for r in drift_rows {
+        s.push(r);
+    }
+
     s
+}
+
+/// Stable row label for a binary name. We can't use `format!` in a
+/// const context, so this small helper keeps the labels predictable
+/// and snake_cased.
+fn bin_label(bin: &str) -> String {
+    format!("binary:{}", bin.replace('-', "_"))
+}
+
+/// Walk `$PATH` manually and return the first entry that contains an
+/// executable file named `bin`. Returns `None` when `$PATH` is unset
+/// or empty, or when no entry contains an executable match.
+///
+/// "Executable" on Unix means at least one of the user/group/other
+/// execute bits is set on a regular file. We deliberately do not
+/// check ownership or ACLs — doctor's job is to mirror what the
+/// shell would actually find.
+fn find_on_path(bin: &str, path_var: Option<&std::ffi::OsStr>) -> Option<PathBuf> {
+    let path_var = path_var?;
+    for dir in std::env::split_paths(path_var) {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        let candidate = dir.join(bin);
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// True iff `path` is a regular file with at least one execute bit.
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    meta.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    // On non-Unix, fall back to "is a file". rts doesn't ship
+    // Windows tarballs today, so this branch exists only to keep
+    // the crate building if someone tries `cargo check --target …`.
+    std::fs::metadata(path).map(|m| m.is_file()).unwrap_or(false)
+}
+
+/// Resolve symlinks via `std::fs::canonicalize`. Falls back to the
+/// original path on any error — canonicalize fails on broken
+/// symlinks and on paths the user can't stat through, neither of
+/// which should block the row.
+fn canonicalize_or(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Invoke `<bin> --version` and extract a semver-ish token. Returns
+/// `None` when the subprocess fails, exits non-zero, or its output
+/// doesn't contain a recognizable version.
+///
+/// Output format we accept (very lenient — both crates' `--version`
+/// emit a single line like `rts-daemon 0.5.4` today):
+///   `<name> [v]?<digits>.<digits>.<digits>[-suffix]`
+///
+/// We strip a leading `v` if present so the returned string is
+/// directly comparable to `ctx.doctor_version`.
+fn probe_version(bin: &Path) -> Option<String> {
+    let output = Command::new(bin).arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_version_token(&stdout)
+}
+
+/// Extract the first semver-shaped token from a `--version` blob.
+/// Pure function; tested in isolation below.
+fn parse_version_token(s: &str) -> Option<String> {
+    for line in s.lines() {
+        for token in line.split_whitespace() {
+            let trimmed = token.trim_start_matches('v');
+            if looks_like_semver(trimmed) {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// "Does this look like `MAJOR.MINOR.PATCH[-extras]`?" Pragmatic
+/// check — we just need to discriminate version tokens from the
+/// surrounding `rts-daemon` / `rts-mcp` name tokens. Not a full
+/// semver parser.
+fn looks_like_semver(s: &str) -> bool {
+    let core = s.split('-').next().unwrap_or(s);
+    let mut parts = core.split('.');
+    let (a, b, c) = (parts.next(), parts.next(), parts.next());
+    if parts.next().is_some() {
+        return false;
+    }
+    match (a, b, c) {
+        (Some(a), Some(b), Some(c)) => {
+            !a.is_empty()
+                && !b.is_empty()
+                && !c.is_empty()
+                && a.bytes().all(|x| x.is_ascii_digit())
+                && b.bytes().all(|x| x.is_ascii_digit())
+                && c.bytes().all(|x| x.is_ascii_digit())
+        }
+        _ => false,
+    }
+}
+
+/// Equality on the core `MAJOR.MINOR.PATCH` triple. Pre-release
+/// suffixes (`-rc1`, `-dev`) are ignored — we only care about
+/// drift at the release level. Both inputs may carry a leading `v`.
+fn versions_match(a: &str, b: &str) -> bool {
+    fn core(s: &str) -> &str {
+        s.trim_start_matches('v').split('-').next().unwrap_or(s)
+    }
+    core(a) == core(b)
+}
+
+/// Fix snippet for a missing binary. We prefer the prebuilt-tarball
+/// install pattern from README.md because it works on a clean machine
+/// without a Rust toolchain; we add a `cargo install` fallback in the
+/// description for source-build environments.
+fn install_fix(bin: &str) -> FixSnippet {
+    // Concise one-liner: source the binaries from the matching release
+    // tarball. Users on the source build can read the description for
+    // the `cargo install --path …` alternative.
+    let command = format!(
+        "curl -fsSL https://github.com/njfio/rs-agent-code-utility/releases/latest/download/install.sh | sh   # or: see docs/install.md"
+    );
+    FixSnippet::new(FixClass::InstallBinary, command).with_description(format!(
+        "{} is missing from $PATH. Install from a release tarball (see docs/install.md) or run `cargo install --path crates/{}` from a source checkout.",
+        bin, bin
+    ))
+}
+
+// `OsString` is referenced via `std::env::var_os` (Option<OsString>)
+// — keep the import explicit so this file documents its own surface.
+#[allow(dead_code)]
+fn _osstring_marker(_: OsString) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::DoctorArgs;
+    use crate::doctor::DoctorOutput;
+    use crate::doctor::report::RowKind;
+
+    fn ctx_for_tests() -> Ctx {
+        Ctx::build(&DoctorArgs {
+            output: DoctorOutput::Json,
+            no_color: true,
+            workspace: None,
+        })
+        .expect("Ctx::build should not fail in tests")
+    }
+
+    #[test]
+    fn section_name_is_binary() {
+        let ctx = ctx_for_tests();
+        let report = run(&ctx);
+        assert_eq!(report.name, "binary");
+    }
+
+    #[test]
+    fn doctor_version_row_is_present_and_ok() {
+        let ctx = ctx_for_tests();
+        let report = run(&ctx);
+        let row = report
+            .rows
+            .iter()
+            .find(|r| r.label == "binary:doctor_version")
+            .expect("doctor_version row must always be emitted");
+        assert_eq!(row.kind, RowKind::Ok);
+        assert!(
+            row.message.contains(ctx.doctor_version),
+            "doctor_version row should embed CARGO_PKG_VERSION: {:?}",
+            row.message
+        );
+    }
+
+    #[test]
+    fn empty_path_yields_fail_rows_for_each_probed_binary() {
+        // Snapshot the current PATH, then probe with an empty PATH
+        // directly (no env mutation needed — `find_on_path` accepts a
+        // PATH override). This avoids the Rust 2024 `unsafe` env
+        // dance and keeps the test thread-safe.
+        let empty: std::ffi::OsString = std::ffi::OsString::new();
+        for bin in PROBED_BINARIES {
+            assert!(
+                find_on_path(bin, Some(&empty)).is_none(),
+                "empty PATH should never resolve {}",
+                bin
+            );
+        }
+    }
+
+    #[test]
+    fn find_on_path_resolves_existing_binary_in_tmpdir() {
+        // Build a tempdir with a single executable file and prove the
+        // walker finds it. This is a self-contained sanity check for
+        // the executable-bit gating.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin_path = dir.path().join("rts-doctor-test-stub");
+        std::fs::write(&bin_path, b"#!/bin/sh\necho stub 0.0.0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&bin_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&bin_path, perms).unwrap();
+        }
+
+        let path_var: std::ffi::OsString = dir.path().as_os_str().to_owned();
+        let found = find_on_path("rts-doctor-test-stub", Some(&path_var));
+        assert_eq!(found.as_deref(), Some(bin_path.as_path()));
+    }
+
+    #[test]
+    fn find_on_path_skips_non_executable_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin_path = dir.path().join("not-executable");
+        std::fs::write(&bin_path, b"plain file\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&bin_path).unwrap().permissions();
+            perms.set_mode(0o644);
+            std::fs::set_permissions(&bin_path, perms).unwrap();
+        }
+
+        let path_var: std::ffi::OsString = dir.path().as_os_str().to_owned();
+        assert!(
+            find_on_path("not-executable", Some(&path_var)).is_none(),
+            "find_on_path should skip non-executable regular files"
+        );
+    }
+
+    #[test]
+    fn parse_version_token_extracts_semver_from_typical_output() {
+        assert_eq!(
+            parse_version_token("rts-daemon 0.5.4\n").as_deref(),
+            Some("0.5.4")
+        );
+        assert_eq!(
+            parse_version_token("rts-mcp v1.2.3-rc1\n").as_deref(),
+            Some("1.2.3-rc1")
+        );
+    }
+
+    #[test]
+    fn parse_version_token_returns_none_when_no_semver_present() {
+        assert!(parse_version_token("hello world\n").is_none());
+        assert!(parse_version_token("").is_none());
+    }
+
+    #[test]
+    fn looks_like_semver_filters_name_tokens() {
+        assert!(looks_like_semver("0.5.4"));
+        assert!(looks_like_semver("1.2.3-rc1"));
+        assert!(!looks_like_semver("rts-daemon"));
+        assert!(!looks_like_semver("0.5"));
+        assert!(!looks_like_semver("0.5.4.5"));
+    }
+
+    #[test]
+    fn versions_match_ignores_pre_release_and_leading_v() {
+        assert!(versions_match("0.5.4", "0.5.4"));
+        assert!(versions_match("v0.5.4", "0.5.4"));
+        assert!(versions_match("0.5.4-rc1", "0.5.4-dev"));
+        assert!(!versions_match("0.5.4", "0.5.5"));
+        assert!(!versions_match("0.6.0", "0.5.5"));
+    }
+
+    #[test]
+    fn missing_binaries_produce_fail_rows_with_install_fix() {
+        // We can't reliably remove rts-daemon from the real PATH inside
+        // a test (it's not safe to mutate PATH from a unit test in
+        // parallel), but we *can* exercise the install_fix codepath
+        // directly and validate the snippet shape.
+        let fix = install_fix("rts-daemon");
+        assert_eq!(fix.class, FixClass::InstallBinary);
+        assert!(
+            !fix.command.is_empty(),
+            "install fix command must be non-empty"
+        );
+        assert!(
+            fix.description
+                .as_deref()
+                .is_some_and(|d| d.contains("rts-daemon")),
+            "fix description should name the missing binary"
+        );
+    }
+
+    #[test]
+    fn section_does_not_panic_with_real_environment() {
+        // Smoke: regardless of whether rts-daemon/rts-mcp are on $PATH
+        // in the test harness, `run` must produce a well-formed
+        // SectionReport with at least the doctor_version row.
+        let ctx = ctx_for_tests();
+        let report = run(&ctx);
+        assert!(report.rows.len() >= 1 + PROBED_BINARIES.len());
+        assert!(
+            report
+                .rows
+                .iter()
+                .any(|r| r.label == "binary:doctor_version")
+        );
+        for bin in PROBED_BINARIES {
+            let label = bin_label(bin);
+            assert!(
+                report.rows.iter().any(|r| r.label == label),
+                "per-binary row should be emitted for {}",
+                bin
+            );
+        }
+    }
 }

--- a/crates/rts-bench/src/doctor/binary_section.rs
+++ b/crates/rts-bench/src/doctor/binary_section.rs
@@ -214,9 +214,7 @@ fn install_fix(bin: &str) -> FixSnippet {
     // Concise one-liner: source the binaries from the matching release
     // tarball. Users on the source build can read the description for
     // the `cargo install --path …` alternative.
-    let command = format!(
-        "curl -fsSL https://github.com/njfio/rs-agent-code-utility/releases/latest/download/install.sh | sh   # or: see docs/install.md"
-    );
+    let command = "curl -fsSL https://github.com/njfio/rs-agent-code-utility/releases/latest/download/install.sh | sh   # or: see docs/install.md";
     FixSnippet::new(FixClass::InstallBinary, command).with_description(format!(
         "{} is missing from $PATH. Install from a release tarball (see docs/install.md) or run `cargo install --path crates/{}` from a source checkout.",
         bin, bin

--- a/crates/rts-bench/src/doctor/binary_section.rs
+++ b/crates/rts-bench/src/doctor/binary_section.rs
@@ -1,0 +1,19 @@
+//! `binary` section — doctor's own version, rts-daemon / rts-mcp
+//! presence on PATH, symlink resolution. U4 implements; this file is
+//! a placeholder that returns a single info row so U2's wiring
+//! compiles end-to-end.
+
+use super::ctx::Ctx;
+use super::report::{Row, SectionReport};
+
+pub fn run(ctx: &Ctx) -> SectionReport {
+    let mut s = SectionReport::new("binary");
+    s.push(Row::info(
+        "binary:placeholder",
+        format!(
+            "binary section not yet implemented (doctor v{ver})",
+            ver = ctx.doctor_version
+        ),
+    ));
+    s
+}

--- a/crates/rts-bench/src/doctor/ctx.rs
+++ b/crates/rts-bench/src/doctor/ctx.rs
@@ -15,6 +15,7 @@ use super::DoctorArgs;
 /// through each section. The `daemon_stats` field is populated by
 /// `daemon_section::run` and read by `workspace_section::run`.
 #[derive(Debug)]
+#[allow(dead_code)] // color_enabled / socket_path read by future sections + U9 wiring.
 pub struct Ctx {
     /// `$PWD` (or `--workspace <path>`) canonicalized when possible.
     /// `None` when neither resolves to an existing directory.
@@ -46,10 +47,7 @@ impl Ctx {
     /// "workspace doesn't exist" — that's a row, not an init error.
     pub fn build(args: &DoctorArgs) -> Result<Self> {
         let workspace_arg = args.workspace.clone().or_else(|| std::env::current_dir().ok());
-        let workspace_path = workspace_arg.and_then(|p| match p.canonicalize() {
-            Ok(canon) => Some(canon),
-            Err(_) => Some(p),
-        });
+        let workspace_path = workspace_arg.map(|p| p.canonicalize().unwrap_or(p));
 
         let home = dirs::home_dir();
 
@@ -79,6 +77,7 @@ impl Ctx {
     }
 
     /// Helper: workspace path as a string ref (for messages).
+    #[allow(dead_code)] // consumed by U9 fix-snippet renderers.
     pub fn workspace_str(&self) -> &str {
         self.workspace_path
             .as_deref()

--- a/crates/rts-bench/src/doctor/ctx.rs
+++ b/crates/rts-bench/src/doctor/ctx.rs
@@ -1,0 +1,88 @@
+//! Doctor's runtime context. Carries everything sections need to know
+//! about the user's environment (workspace path, home directory,
+//! TTY/color state, daemon stats snapshot) so each section function
+//! can stay a small, pure-ish read-and-emit-rows operation.
+
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde_json::Value as JsonValue;
+
+use super::DoctorArgs;
+
+/// Doctor's runtime context. Built once at `run()` entry; threaded
+/// through each section. The `daemon_stats` field is populated by
+/// `daemon_section::run` and read by `workspace_section::run`.
+#[derive(Debug)]
+pub struct Ctx {
+    /// `$PWD` (or `--workspace <path>`) canonicalized when possible.
+    /// `None` when neither resolves to an existing directory.
+    pub workspace_path: Option<PathBuf>,
+    /// User's home directory. Used by per-host detectors to look up
+    /// `~/.cursor/mcp.json`, `~/.continue/config.yaml`, etc.
+    pub home: Option<PathBuf>,
+    /// Doctor's own binary version, from `CARGO_PKG_VERSION`.
+    pub doctor_version: &'static str,
+    /// Should the human renderer emit ANSI? `true` iff stdout is a TTY
+    /// AND `--no-color` is unset AND `NO_COLOR` env var is unset.
+    pub color_enabled: bool,
+    /// Populated by `daemon_section::run`: the raw `Daemon.Stats v2`
+    /// response body (or the v1 fallback shape) once the section
+    /// completes a successful round-trip. `None` when the daemon was
+    /// unreachable. Read by `workspace_section::run`.
+    pub daemon_stats: Option<JsonValue>,
+    /// Resolved per-workspace socket path, computed from
+    /// `workspace_path`. Lets `daemon_section` and `workspace_section`
+    /// share one path computation; the `mcp_section` and `nudge_hook`
+    /// don't need it.
+    pub socket_path: Option<PathBuf>,
+}
+
+impl Ctx {
+    /// Build a fresh `Ctx` from clap-parsed `DoctorArgs`. Resolves
+    /// the workspace path (or falls back to `$PWD`); resolves the
+    /// home dir; computes color-enable state. Never fails on
+    /// "workspace doesn't exist" — that's a row, not an init error.
+    pub fn build(args: &DoctorArgs) -> Result<Self> {
+        let workspace_arg = args.workspace.clone().or_else(|| std::env::current_dir().ok());
+        let workspace_path = workspace_arg.and_then(|p| match p.canonicalize() {
+            Ok(canon) => Some(canon),
+            Err(_) => Some(p),
+        });
+
+        let home = dirs::home_dir();
+
+        // ANSI gating: respect both `--no-color` and NO_COLOR env var,
+        // and require stdout to be a TTY.
+        let color_enabled = !args.no_color
+            && std::env::var_os("NO_COLOR").is_none()
+            && std::io::stdout().is_terminal();
+
+        // Socket path follows the rts-daemon convention:
+        // `<state_dir>/rts/ws-<16hex>.sock` keyed off the workspace
+        // fingerprint. We can compute the fingerprint client-side
+        // because it's blake3(dev_id || inode || canonical_path) per
+        // protocol-v0 §5.2. For doctor v1 we punt on this — the
+        // daemon_section can probe known socket locations directly
+        // since the daemon writes a `default.sock` fallback too.
+        let socket_path = None;
+
+        Ok(Self {
+            workspace_path,
+            home,
+            doctor_version: env!("CARGO_PKG_VERSION"),
+            color_enabled,
+            daemon_stats: None,
+            socket_path,
+        })
+    }
+
+    /// Helper: workspace path as a string ref (for messages).
+    pub fn workspace_str(&self) -> &str {
+        self.workspace_path
+            .as_deref()
+            .and_then(Path::to_str)
+            .unwrap_or("<no workspace>")
+    }
+}

--- a/crates/rts-bench/src/doctor/ctx.rs
+++ b/crates/rts-bench/src/doctor/ctx.rs
@@ -46,7 +46,10 @@ impl Ctx {
     /// home dir; computes color-enable state. Never fails on
     /// "workspace doesn't exist" — that's a row, not an init error.
     pub fn build(args: &DoctorArgs) -> Result<Self> {
-        let workspace_arg = args.workspace.clone().or_else(|| std::env::current_dir().ok());
+        let workspace_arg = args
+            .workspace
+            .clone()
+            .or_else(|| std::env::current_dir().ok());
         let workspace_path = workspace_arg.map(|p| p.canonicalize().unwrap_or(p));
 
         let home = dirs::home_dir();

--- a/crates/rts-bench/src/doctor/daemon_section.rs
+++ b/crates/rts-bench/src/doctor/daemon_section.rs
@@ -5,24 +5,39 @@
 //! read the pinned-path / index_generation / cold_walk_completed_at_ms
 //! fields without a second round-trip.
 //!
-//! Probing strategy for v1 (intentionally conservative — see plan §U5):
+//! Probing strategy (post Codex PR #109 review):
 //!
-//! 1. Resolve the **default** socket path (`<runtime_root>/rts/default.sock`).
-//!    For v1, doctor does NOT replicate the daemon's per-workspace
-//!    `blake3(canonical_path)` hashing; that logic lives in
-//!    `crates/rts-daemon/src/socket.rs` and duplicating it would be a
-//!    maintenance hazard. The default socket covers the common
-//!    single-workspace install — the most common first-run case.
-//! 2. If the socket file is absent → `[WARN] daemon not running`
-//!    + fix `rts-daemon --workspace $PWD &`.
-//! 3. If present, attempt a `connect(2)` with a 1-second timeout. On
-//!    connection refused → `[FAIL] stale socket` + fix `rm -f <path>`.
+//! 1. Compute *both* candidate socket paths in priority order:
+//!    a. workspace-scoped (`<runtime_root>/rts/ws-<16hex>.sock`),
+//!       where `16hex` is the first 8 bytes of
+//!       `blake3(canonical_workspace_path)` — mirrors the daemon's
+//!       `socket_path_for_workspace` in
+//!       `crates/rts-daemon/src/socket.rs:54`. Present whenever
+//!       `ctx.workspace_path` is set.
+//!    b. default (`<runtime_root>/rts/default.sock`) — the bootstrap
+//!       socket for daemons spawned without `--workspace`.
+//!    Pick the first candidate whose socket file *exists*. The
+//!    workspace-scoped path wins by priority because it's the more
+//!    specific match.
+//! 2. If neither file exists → `[WARN] daemon not running` + fix
+//!    `rts-daemon --workspace $PWD &`. Report uses the *expected*
+//!    path (workspace-scoped if known) so the fix command matches
+//!    where the daemon would actually bind.
+//! 3. If a file is present, attempt a `connect(2)` with a 1-second
+//!    timeout. On connection refused → `[FAIL] stale socket` + fix
+//!    `rm -f <path>`.
 //! 4. If the handshake succeeds, send `Daemon.Stats` and read one
 //!    JSON-RPC line back (1-second total deadline). If the response
 //!    carries v2 fields, mark OK and populate `ctx.daemon_stats`. If
 //!    the response is v1-shape only, fall back to `Workspace.Status`
 //!    so `workspace_section` still has `index_generation` data, and
 //!    emit a `[WARN] daemon predates daemon_stats_v2`.
+//!
+//! Replicating the daemon's blake3 hash here (rather than depending
+//! on the daemon crate) keeps doctor independent of the daemon's
+//! internal surface; drift risk is bounded because the hash function
+//! is deterministic and the daemon-side comment marks it stable.
+//! `workspace_socket_path_*` tests pin the file-shape contract.
 //!
 //! Synchronous `std::os::unix::net::UnixStream` is used here (no
 //! tokio); a single round-trip per section run, called from within
@@ -45,6 +60,28 @@ use super::report::{FixClass, FixSnippet, Row, SectionReport};
 /// diagnostic; a slow daemon is itself a diagnosis ("daemon hung").
 const ROUND_TRIP_TIMEOUT: Duration = Duration::from_secs(1);
 
+/// Compute the runtime-root directory the same way rts-daemon does.
+/// Returns `None` on unsupported OS or unset XDG_RUNTIME_DIR (Linux).
+fn runtime_root() -> Option<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        let xdg = std::env::var("XDG_RUNTIME_DIR").ok()?;
+        if xdg.is_empty() {
+            return None;
+        }
+        Some(PathBuf::from(xdg).join("rts"))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let home = dirs::home_dir()?;
+        Some(home.join("Library").join("Caches").join("rts"))
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}
+
 /// Compute the default-socket path the same way rts-daemon does for the
 /// no-`--workspace` case. Mirrors `crates/rts-daemon/src/socket.rs`.
 ///
@@ -53,41 +90,96 @@ const ROUND_TRIP_TIMEOUT: Duration = Duration::from_secs(1);
 ///
 /// macOS: `$HOME/Library/Caches/rts/default.sock`.
 pub(crate) fn default_socket_path() -> Option<PathBuf> {
-    #[cfg(target_os = "linux")]
-    {
-        let xdg = std::env::var("XDG_RUNTIME_DIR").ok()?;
-        if xdg.is_empty() {
-            return None;
-        }
-        Some(PathBuf::from(xdg).join("rts").join("default.sock"))
-    }
-    #[cfg(target_os = "macos")]
-    {
-        let home = dirs::home_dir()?;
-        Some(
-            home.join("Library")
-                .join("Caches")
-                .join("rts")
-                .join("default.sock"),
-        )
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    {
-        None
-    }
+    Some(runtime_root()?.join("default.sock"))
+}
+
+/// Compute the per-workspace socket path the same way rts-daemon does
+/// for the `--workspace <path>` case. Mirrors
+/// `socket_path_for_workspace` in `crates/rts-daemon/src/socket.rs:54`:
+/// `<runtime_root>/ws-<16hex>.sock` where `16hex` is the first 8 bytes
+/// of `blake3(canonical_path.as_os_str_bytes())`.
+///
+/// Replicating the daemon's hash logic here (instead of depending on
+/// the daemon crate) keeps doctor independent of the daemon's internal
+/// surface. Drift risk is real but bounded — the hash is deterministic
+/// and the daemon-side comment marks it as stable.
+///
+/// Returns `None` when the runtime root can't be resolved (Linux with
+/// unset `XDG_RUNTIME_DIR`, or an unsupported OS).
+pub(crate) fn workspace_socket_path(canonical_workspace: &Path) -> Option<PathBuf> {
+    let dir = runtime_root()?;
+    let bytes = canonical_workspace.as_os_str().as_encoded_bytes();
+    let hash = blake3::hash(bytes);
+    let short = hash.to_hex();
+    let short16 = &short.as_str()[..16];
+    Some(dir.join(format!("ws-{short16}.sock")))
 }
 
 pub fn run(ctx: &mut Ctx) -> SectionReport {
     let mut s = SectionReport::new("daemon");
 
-    // 1. Resolve the socket path. Without one we can only WARN.
-    let socket_path = match default_socket_path() {
-        Some(p) => p,
+    // 1. Build the candidate socket path list. When the user is
+    //    running in a workspace (the common case after #109),
+    //    `rts-daemon --workspace $PWD` binds the per-workspace
+    //    `ws-<16hex>.sock` instead of `default.sock` — so we have to
+    //    probe both. The workspace-scoped path takes precedence
+    //    because it's the more specific match; default.sock is the
+    //    fallback for daemons spawned without `--workspace`.
+    //
+    //    Codex review on PR #109 (P1) caught the original code's
+    //    blind spot: probing only `default.sock` reported `not
+    //    running` for any user running a workspace-scoped daemon,
+    //    masking the actual index state.
+    let workspace_socket = ctx
+        .workspace_path
+        .as_deref()
+        .and_then(workspace_socket_path);
+    let default_socket = default_socket_path();
+
+    let candidates: Vec<PathBuf> = [workspace_socket.clone(), default_socket.clone()]
+        .into_iter()
+        .flatten()
+        .collect();
+
+    if candidates.is_empty() {
+        s.push(Row::warn(
+            "daemon:socket_path_unresolved",
+            "could not resolve any socket path (unsupported OS or XDG_RUNTIME_DIR unset)",
+        ));
+        return s;
+    }
+
+    // 2. Pick the first candidate whose socket file *exists*. We
+    //    don't try to connect yet — that's step 3. Probing presence
+    //    first lets us report `not running` with the *expected*
+    //    workspace-scoped path in the fix snippet, instead of
+    //    nudging the user toward `default.sock`.
+    let socket_path = match candidates.iter().find(|p| std::fs::metadata(p).is_ok()) {
+        Some(p) => p.clone(),
         None => {
-            s.push(Row::warn(
-                "daemon:socket_path_unresolved",
-                "could not resolve default socket path (unsupported OS or XDG_RUNTIME_DIR unset)",
-            ));
+            // No socket exists at any candidate path. Report
+            // `not_running` using the workspace-scoped path (or
+            // default if no workspace was set) so the fix command
+            // matches the path the daemon would bind.
+            let preferred = workspace_socket
+                .clone()
+                .or(default_socket.clone())
+                .expect("candidates was non-empty");
+            s.push(
+                Row::warn(
+                    "daemon:not_running",
+                    format!(
+                        "no daemon socket at {} — daemon not running for this workspace",
+                        preferred.display()
+                    ),
+                )
+                .with_fix(
+                    FixSnippet::new(FixClass::StartDaemon, "rts-daemon --workspace $PWD &")
+                        .with_description(
+                            "start rts-daemon as a background process for this workspace",
+                        ),
+                ),
+            );
             return s;
         }
     };
@@ -96,36 +188,10 @@ pub fn run(ctx: &mut Ctx) -> SectionReport {
     // the path is informative for future debug/diagnostics).
     ctx.socket_path = Some(socket_path.clone());
 
-    // 2. Socket file present?
-    let exists = match std::fs::metadata(&socket_path) {
-        Ok(_) => true,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
-        Err(_) => {
-            // Permission denied or other I/O — treat as "absent" for
-            // doctor purposes since we can't probe it anyway.
-            false
-        }
-    };
-    if !exists {
-        s.push(
-            Row::warn(
-                "daemon:not_running",
-                format!(
-                    "no daemon socket at {} — daemon not running for this workspace",
-                    socket_path.display()
-                ),
-            )
-            .with_fix(
-                FixSnippet::new(FixClass::StartDaemon, "rts-daemon --workspace $PWD &")
-                    .with_description(
-                        "start rts-daemon as a background process for this workspace",
-                    ),
-            ),
-        );
-        return s;
-    }
-
     // 3. Connect with a short deadline. EREFUSED → stale socket.
+    // (The candidate-resolution above already established the socket
+    // file exists, so the original `if !exists` early-out has moved
+    // up there.)
     let stream = match UnixStream::connect(&socket_path) {
         Ok(s) => s,
         Err(e) => {
@@ -280,6 +346,67 @@ mod tests {
     use std::os::unix::net::UnixListener;
     use std::thread;
     use tempfile::TempDir;
+
+    #[test]
+    fn workspace_socket_path_mirrors_daemon_naming() {
+        // Pinning the expected shape: `ws-<16hex>.sock`. The 16hex is
+        // the first 8 bytes of `blake3(canonical_path.as_os_str_bytes())`
+        // — same algorithm the daemon's
+        // `crates/rts-daemon/src/socket.rs::socket_path_for_workspace`
+        // uses. Drift here would silently route doctor away from the
+        // socket the daemon actually binds.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = workspace_socket_path(tmp.path());
+        let Some(p) = path else {
+            // Linux test env without XDG_RUNTIME_DIR is a real possibility
+            // in CI; just confirm the absent path doesn't panic.
+            return;
+        };
+        let file = p
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("filename")
+            .to_string();
+        assert!(file.starts_with("ws-"), "expected `ws-` prefix; got {file}");
+        assert!(
+            file.ends_with(".sock"),
+            "expected `.sock` suffix; got {file}"
+        );
+        // 3 ("ws-") + 16 hex + 5 (".sock") = 24 chars total
+        assert_eq!(file.len(), 24, "expected 24-char filename; got `{file}`");
+        let hex = &file["ws-".len()..file.len() - ".sock".len()];
+        assert!(
+            hex.chars().all(|c| c.is_ascii_hexdigit()),
+            "expected lowercase-hex middle segment; got `{hex}`"
+        );
+    }
+
+    #[test]
+    fn workspace_socket_path_is_deterministic() {
+        // Same path → same hash. The fingerprint must be stable across
+        // process restarts so doctor and daemon agree.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let a = workspace_socket_path(tmp.path());
+        let b = workspace_socket_path(tmp.path());
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn workspace_socket_path_differs_per_workspace() {
+        // Two different paths must hash to different sockets, else the
+        // daemon's bind-per-workspace invariant breaks.
+        let a_tmp = tempfile::tempdir().expect("tempdir a");
+        let b_tmp = tempfile::tempdir().expect("tempdir b");
+        let a = workspace_socket_path(a_tmp.path());
+        let b = workspace_socket_path(b_tmp.path());
+        if let (Some(a), Some(b)) = (a, b) {
+            assert_ne!(
+                a.file_name(),
+                b.file_name(),
+                "distinct workspaces must hash to distinct sockets"
+            );
+        }
+    }
 
     fn make_ctx(socket_override: Option<PathBuf>) -> (TempDir, Ctx) {
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/rts-bench/src/doctor/daemon_section.rs
+++ b/crates/rts-bench/src/doctor/daemon_section.rs
@@ -1,0 +1,18 @@
+//! `daemon` section — per-workspace socket probe, `Daemon.Stats v2`
+//! round-trip with pre-v2 fallback. U5 implements.
+//!
+//! On success, populates `ctx.daemon_stats` so `workspace_section` can
+//! read the pinned-path / index_generation / cold_walk_completed_at_ms
+//! fields without a second round-trip.
+
+use super::ctx::Ctx;
+use super::report::{Row, SectionReport};
+
+pub fn run(_ctx: &mut Ctx) -> SectionReport {
+    let mut s = SectionReport::new("daemon");
+    s.push(Row::info(
+        "daemon:placeholder",
+        "daemon section not yet implemented",
+    ));
+    s
+}

--- a/crates/rts-bench/src/doctor/daemon_section.rs
+++ b/crates/rts-bench/src/doctor/daemon_section.rs
@@ -154,8 +154,8 @@ pub fn run(ctx: &mut Ctx) -> SectionReport {
     };
 
     let result = stats.get("result").cloned().unwrap_or(JsonValue::Null);
-    let has_v2 = result.get("pinned_workspace_path").is_some()
-        && result.get("index_generation").is_some();
+    let has_v2 =
+        result.get("pinned_workspace_path").is_some() && result.get("index_generation").is_some();
 
     if has_v2 {
         // Happy path. One round-trip, all the data we need.
@@ -313,9 +313,10 @@ mod tests {
                         socket_path.display()
                     ),
                 )
-                .with_fix(
-                    FixSnippet::new(FixClass::StartDaemon, "rts-daemon --workspace $PWD &"),
-                ),
+                .with_fix(FixSnippet::new(
+                    FixClass::StartDaemon,
+                    "rts-daemon --workspace $PWD &",
+                )),
             );
             return s;
         }

--- a/crates/rts-bench/src/doctor/daemon_section.rs
+++ b/crates/rts-bench/src/doctor/daemon_section.rs
@@ -1,18 +1,420 @@
 //! `daemon` section — per-workspace socket probe, `Daemon.Stats v2`
-//! round-trip with pre-v2 fallback. U5 implements.
+//! round-trip with pre-v2 fallback. U5.
 //!
 //! On success, populates `ctx.daemon_stats` so `workspace_section` can
 //! read the pinned-path / index_generation / cold_walk_completed_at_ms
 //! fields without a second round-trip.
+//!
+//! Probing strategy for v1 (intentionally conservative — see plan §U5):
+//!
+//! 1. Resolve the **default** socket path (`<runtime_root>/rts/default.sock`).
+//!    For v1, doctor does NOT replicate the daemon's per-workspace
+//!    `blake3(canonical_path)` hashing; that logic lives in
+//!    `crates/rts-daemon/src/socket.rs` and duplicating it would be a
+//!    maintenance hazard. The default socket covers the common
+//!    single-workspace install — the most common first-run case.
+//! 2. If the socket file is absent → `[WARN] daemon not running`
+//!    + fix `rts-daemon --workspace $PWD &`.
+//! 3. If present, attempt a `connect(2)` with a 1-second timeout. On
+//!    connection refused → `[FAIL] stale socket` + fix `rm -f <path>`.
+//! 4. If the handshake succeeds, send `Daemon.Stats` and read one
+//!    JSON-RPC line back (1-second total deadline). If the response
+//!    carries v2 fields, mark OK and populate `ctx.daemon_stats`. If
+//!    the response is v1-shape only, fall back to `Workspace.Status`
+//!    so `workspace_section` still has `index_generation` data, and
+//!    emit a `[WARN] daemon predates daemon_stats_v2`.
+//!
+//! Synchronous `std::os::unix::net::UnixStream` is used here (no
+//! tokio); a single round-trip per section run, called from within
+//! the existing `#[tokio::main]` runtime via the `spawn_blocking`-
+//! equivalent of just calling sync code from an async fn. This avoids
+//! `Handle::current().block_on(...)` which would deadlock on
+//! `current_thread` runtimes.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde_json::Value as JsonValue;
 
 use super::ctx::Ctx;
-use super::report::{Row, SectionReport};
+use super::report::{FixClass, FixSnippet, Row, SectionReport};
 
-pub fn run(_ctx: &mut Ctx) -> SectionReport {
+/// 1-second hard cap on the daemon round-trip. Doctor is a fast
+/// diagnostic; a slow daemon is itself a diagnosis ("daemon hung").
+const ROUND_TRIP_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Compute the default-socket path the same way rts-daemon does for the
+/// no-`--workspace` case. Mirrors `crates/rts-daemon/src/socket.rs`.
+///
+/// Linux: `$XDG_RUNTIME_DIR/rts/default.sock` (refuses to fall back to
+/// `/tmp` for security parity with the daemon).
+///
+/// macOS: `$HOME/Library/Caches/rts/default.sock`.
+pub(crate) fn default_socket_path() -> Option<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        let xdg = std::env::var("XDG_RUNTIME_DIR").ok()?;
+        if xdg.is_empty() {
+            return None;
+        }
+        Some(PathBuf::from(xdg).join("rts").join("default.sock"))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let home = dirs::home_dir()?;
+        Some(
+            home.join("Library")
+                .join("Caches")
+                .join("rts")
+                .join("default.sock"),
+        )
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}
+
+pub fn run(ctx: &mut Ctx) -> SectionReport {
     let mut s = SectionReport::new("daemon");
-    s.push(Row::info(
-        "daemon:placeholder",
-        "daemon section not yet implemented",
-    ));
+
+    // 1. Resolve the socket path. Without one we can only WARN.
+    let socket_path = match default_socket_path() {
+        Some(p) => p,
+        None => {
+            s.push(Row::warn(
+                "daemon:socket_path_unresolved",
+                "could not resolve default socket path (unsupported OS or XDG_RUNTIME_DIR unset)",
+            ));
+            return s;
+        }
+    };
+    // Make the resolved path available to peers (workspace_section
+    // reads `ctx.daemon_stats` rather than the socket directly, but
+    // the path is informative for future debug/diagnostics).
+    ctx.socket_path = Some(socket_path.clone());
+
+    // 2. Socket file present?
+    let exists = match std::fs::metadata(&socket_path) {
+        Ok(_) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => {
+            // Permission denied or other I/O — treat as "absent" for
+            // doctor purposes since we can't probe it anyway.
+            false
+        }
+    };
+    if !exists {
+        s.push(
+            Row::warn(
+                "daemon:not_running",
+                format!(
+                    "no daemon socket at {} — daemon not running for this workspace",
+                    socket_path.display()
+                ),
+            )
+            .with_fix(
+                FixSnippet::new(FixClass::StartDaemon, "rts-daemon --workspace $PWD &")
+                    .with_description(
+                        "start rts-daemon as a background process for this workspace",
+                    ),
+            ),
+        );
+        return s;
+    }
+
+    // 3. Connect with a short deadline. EREFUSED → stale socket.
+    let stream = match UnixStream::connect(&socket_path) {
+        Ok(s) => s,
+        Err(e) => {
+            // ECONNREFUSED means the socket file exists but no daemon
+            // is listening — the classic stale-socket case. ENOENT was
+            // ruled out by the metadata check above; any other error
+            // we report as FAIL with the same `rm -f` hint, since the
+            // user's recovery action is the same regardless of errno.
+            s.push(stale_socket_row(&socket_path, e));
+            return s;
+        }
+    };
+
+    // 4. Round-trip `Daemon.Stats` once. v2 fields are gated by the
+    //    daemon-side `daemon_stats_v2` capability; their absence is a
+    //    WARN (not FAIL) — the daemon is reachable, just old.
+    let stats = match do_round_trip(stream, "Daemon.Stats") {
+        Ok(v) => v,
+        Err(e) => {
+            s.push(Row::fail(
+                "daemon:stats_round_trip",
+                format!("Daemon.Stats round-trip failed: {e}"),
+            ));
+            return s;
+        }
+    };
+
+    let result = stats.get("result").cloned().unwrap_or(JsonValue::Null);
+    let has_v2 = result.get("pinned_workspace_path").is_some()
+        && result.get("index_generation").is_some();
+
+    if has_v2 {
+        // Happy path. One round-trip, all the data we need.
+        let version = result
+            .get("version")
+            .and_then(JsonValue::as_str)
+            .unwrap_or("?");
+        let uptime_ms = result
+            .get("uptime_ms")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
+        s.push(Row::ok(
+            "daemon:reachable",
+            format!(
+                "daemon v{version} reachable, uptime {} ms (daemon_stats_v2 capability present)",
+                uptime_ms
+            ),
+        ));
+        ctx.daemon_stats = Some(result);
+    } else {
+        // Pre-v2 daemon. Emit a WARN about version, then attempt a
+        // fallback `Workspace.Status` so workspace_section can still
+        // surface index_generation.
+        s.push(Row::warn(
+            "daemon:predates_v2",
+            "daemon reachable but predates daemon_stats_v2 — fields missing; please upgrade",
+        ));
+
+        match UnixStream::connect(&socket_path)
+            .map_err(anyhow_io)
+            .and_then(|s| do_round_trip(s, "Workspace.Status"))
+        {
+            Ok(status) => {
+                ctx.daemon_stats = Some(status.get("result").cloned().unwrap_or(JsonValue::Null));
+            }
+            Err(e) => {
+                // Non-fatal — workspace_section will surface a row about
+                // missing data. Annotate the partial failure here so
+                // the section's footnote line tells the operator why.
+                s.push_partial_failure(
+                    "daemon:fallback_status",
+                    format!("Workspace.Status fallback failed: {e}"),
+                );
+            }
+        }
+    }
+
     s
+}
+
+/// Build the FAIL row for the stale-socket case. Pulled out for clarity
+/// and because future error-kind classification (e.g. EACCES vs
+/// ECONNREFUSED) might split into multiple rows.
+fn stale_socket_row(socket_path: &Path, e: std::io::Error) -> Row {
+    Row::fail(
+        "daemon:stale_socket",
+        format!(
+            "socket file at {} exists but no daemon is listening ({e})",
+            socket_path.display()
+        ),
+    )
+    .with_fix(
+        FixSnippet::new(
+            FixClass::RemoveStaleSocket,
+            format!("rm -f {}", socket_path.display()),
+        )
+        .with_description("remove the stale socket file; then start rts-daemon"),
+    )
+}
+
+/// Synchronous one-shot JSON-RPC round-trip on a `UnixStream`. Writes a
+/// single newline-terminated request, reads one newline-terminated
+/// response back, parses it as JSON. All wrapped in a 1-second deadline
+/// via socket-level read/write timeouts.
+fn do_round_trip(stream: UnixStream, method: &str) -> Result<JsonValue, anyhow::Error> {
+    stream.set_read_timeout(Some(ROUND_TRIP_TIMEOUT))?;
+    stream.set_write_timeout(Some(ROUND_TRIP_TIMEOUT))?;
+
+    // Build the request line. id="doctor-1" so logs are diagnosable;
+    // params={} since both Daemon.Stats and Workspace.Status accept
+    // an empty object.
+    let req = serde_json::json!({
+        "id": "doctor-1",
+        "method": method,
+        "params": {}
+    });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+
+    let mut writer = &stream;
+    writer.write_all(&bytes)?;
+    writer.flush()?;
+
+    let mut reader = BufReader::new(&stream);
+    let mut line = Vec::with_capacity(4096);
+    let n = reader.read_until(b'\n', &mut line)?;
+    if n == 0 {
+        return Err(anyhow::anyhow!("EOF before response"));
+    }
+    // Trim trailing newline.
+    if line.ends_with(b"\n") {
+        line.pop();
+    }
+    let parsed: JsonValue = serde_json::from_slice(&line)?;
+    Ok(parsed)
+}
+
+fn anyhow_io(e: std::io::Error) -> anyhow::Error {
+    anyhow::Error::new(e)
+}
+
+// Silence unused-import warnings on platforms where the `Read` trait is
+// only used indirectly through `BufReader`. The use is real (BufReader
+// requires `R: Read`); keep the import to satisfy clippy in case it
+// later expands.
+#[allow(dead_code)]
+fn _force_read_import<R: Read>(_: R) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::net::UnixListener;
+    use std::thread;
+    use tempfile::TempDir;
+
+    fn make_ctx(socket_override: Option<PathBuf>) -> (TempDir, Ctx) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ctx = Ctx {
+            workspace_path: Some(tmp.path().to_path_buf()),
+            home: None,
+            doctor_version: "0.0.0-test",
+            color_enabled: false,
+            daemon_stats: None,
+            socket_path: socket_override,
+        };
+        (tmp, ctx)
+    }
+
+    /// Override the daemon-section probe to talk to an explicit
+    /// socket path rather than the real default-socket location.
+    /// We can't change `default_socket_path()` per-test (it reads
+    /// env vars set by the test harness, which races other tests),
+    /// so this helper reproduces the section's probe logic against
+    /// a known socket path. It mirrors the production code closely
+    /// so the tests still exercise the meaningful branches.
+    fn probe_with_socket(socket_path: &Path) -> SectionReport {
+        let mut s = SectionReport::new("daemon");
+        let exists = socket_path.exists();
+        if !exists {
+            s.push(
+                Row::warn(
+                    "daemon:not_running",
+                    format!(
+                        "no daemon socket at {} — daemon not running for this workspace",
+                        socket_path.display()
+                    ),
+                )
+                .with_fix(
+                    FixSnippet::new(FixClass::StartDaemon, "rts-daemon --workspace $PWD &"),
+                ),
+            );
+            return s;
+        }
+        match UnixStream::connect(socket_path) {
+            Ok(_) => s.push(Row::ok("daemon:reachable", "connected")),
+            Err(e) => s.push(stale_socket_row(socket_path, e)),
+        }
+        s
+    }
+
+    #[test]
+    fn daemon_section_reports_warn_when_socket_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let socket = tmp.path().join("no-such.sock");
+        let report = probe_with_socket(&socket);
+        assert_eq!(report.rows.len(), 1);
+        let row = &report.rows[0];
+        assert_eq!(row.kind, super::super::report::RowKind::Warn);
+        assert!(row.message.contains("daemon not running"));
+        let fix = row.fix.as_ref().expect("warn must have a fix");
+        assert_eq!(fix.class, FixClass::StartDaemon);
+        assert!(fix.command.contains("rts-daemon"));
+    }
+
+    #[test]
+    fn daemon_section_reports_fail_when_socket_stale() {
+        // Create a regular file at the socket path. connect(2) will
+        // return ENOTSOCK / ECONNREFUSED — both classified as "stale".
+        let tmp = tempfile::tempdir().unwrap();
+        let socket = tmp.path().join("stale.sock");
+        std::fs::write(&socket, b"").expect("create stale file");
+        let report = probe_with_socket(&socket);
+        assert_eq!(report.rows.len(), 1);
+        let row = &report.rows[0];
+        assert_eq!(row.kind, super::super::report::RowKind::Fail);
+        assert!(row.message.contains("no daemon is listening"));
+        let fix = row.fix.as_ref().expect("fail must have a fix");
+        assert_eq!(fix.class, FixClass::RemoveStaleSocket);
+        assert!(fix.command.starts_with("rm -f "));
+    }
+
+    #[test]
+    fn daemon_section_round_trip_with_listener_returns_response() {
+        // Spin up a tiny echo-style UnixListener on a temp path, hand
+        // the client a connected stream, and assert `do_round_trip`
+        // sends/receives a single JSON-RPC line. This exercises the
+        // wire path without depending on the real rts-daemon binary.
+        let tmp = tempfile::tempdir().unwrap();
+        let socket = tmp.path().join("echo.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+
+        let server = thread::spawn(move || {
+            let (mut conn, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(conn.try_clone().unwrap());
+            let mut line = Vec::new();
+            reader.read_until(b'\n', &mut line).unwrap();
+            // Verify the request shape briefly.
+            let req: JsonValue = serde_json::from_slice(line.trim_ascii_end()).unwrap();
+            assert_eq!(req["method"], "Daemon.Stats");
+            // Respond with a synthetic v2 payload.
+            let resp = serde_json::json!({
+                "id": req["id"],
+                "result": {
+                    "uptime_ms": 1234u64,
+                    "version": "0.6.0",
+                    "total_calls": 0u64,
+                    "calls": {},
+                    "pinned_workspace_path": "/tmp/ws",
+                    "workspace_id": "deadbeef".repeat(4),
+                    "index_generation": 1u64,
+                    "cold_walk_completed_at_ms": 100u64,
+                }
+            });
+            let mut bytes = serde_json::to_vec(&resp).unwrap();
+            bytes.push(b'\n');
+            conn.write_all(&bytes).unwrap();
+        });
+
+        let stream = UnixStream::connect(&socket).unwrap();
+        let resp = do_round_trip(stream, "Daemon.Stats").expect("round-trip");
+        let result = &resp["result"];
+        assert_eq!(result["version"], "0.6.0");
+        assert_eq!(result["index_generation"], 1u64);
+        assert_eq!(result["pinned_workspace_path"], "/tmp/ws");
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn daemon_section_writes_socket_path_into_ctx() {
+        // Smoke: even when the socket is missing, run() should
+        // populate ctx.socket_path with the resolved default path
+        // so peers (and future debug snapshots) can see it.
+        let (_tmp, mut ctx) = make_ctx(None);
+        // Note: run() reads the real env at default_socket_path(); we
+        // only assert that *some* path got written, or that None is
+        // returned on unsupported OS — both branches are valid.
+        let _ = run(&mut ctx);
+        // If default_socket_path() returned None, we WARN and bail
+        // before writing ctx.socket_path. That's fine — the assertion
+        // here is only that the section completes without panicking.
+    }
 }

--- a/crates/rts-bench/src/doctor/hosts/aider.rs
+++ b/crates/rts-bench/src/doctor/hosts/aider.rs
@@ -1,9 +1,18 @@
 //! Aider MCP-registration detector. Soft-detect at
-//! `~/.config/aider/mcp.json`, `./.aider/mcp.json`, or
-//! `~/.aider.conf.yml`. U7 implements.
+//! `~/.config/aider/mcp.json`, `<workspace>/.aider/mcp.json`, or
+//! `~/.aider.conf.yml`.
+//!
+//! Aider's MCP support is still alpha and the canonical wire-up uses
+//! the JSON `mcpServers` block; the YAML `.aider.conf.yml` is
+//! Aider's general config file (no formal MCP slot yet). We probe all
+//! three and emit a `[?]` info row when none are present.
 
+use std::path::{Path, PathBuf};
+
+use super::{DetectionClass, HostDetector, HostFinding, RegistrationDetail};
 use crate::doctor::ctx::Ctx;
-use super::{DetectionClass, HostDetector, HostFinding};
+use crate::doctor::hosts::claude_code::binary_resolves;
+use crate::doctor::report::{FixClass, FixSnippet, Row};
 
 pub struct Aider;
 
@@ -14,11 +23,253 @@ impl HostDetector for Aider {
     fn detection_class(&self) -> DetectionClass {
         DetectionClass::Soft
     }
-    fn detect(&self, _ctx: &Ctx) -> HostFinding {
-        HostFinding::skipped(
-            self.host_name(),
-            self.detection_class(),
-            "not yet implemented (U7)",
+    fn detect(&self, ctx: &Ctx) -> HostFinding {
+        detect_impl(ctx, ctx.home.as_deref(), ctx.workspace_path.as_deref())
+    }
+}
+
+pub(crate) fn detect_impl(
+    _ctx: &Ctx,
+    home: Option<&Path>,
+    workspace: Option<&Path>,
+) -> HostFinding {
+    let mut finding = HostFinding {
+        host_name: "aider",
+        detection_class: DetectionClass::Soft,
+        rows: Vec::new(),
+        rts_registered: None,
+        skipped_reason: None,
+    };
+
+    let mut candidates: Vec<(&'static str, PathBuf, ConfigKind)> = Vec::new();
+    if let Some(h) = home {
+        candidates.push((
+            "user_scope",
+            h.join(".config").join("aider").join("mcp.json"),
+            ConfigKind::Json,
+        ));
+    }
+    if let Some(ws) = workspace {
+        candidates.push((
+            "project_scope",
+            ws.join(".aider").join("mcp.json"),
+            ConfigKind::Json,
+        ));
+    }
+    if let Some(h) = home {
+        // The general aider conf — only relevant if/when Aider adds a
+        // proper MCP block. For now we just acknowledge its presence as
+        // an info row.
+        candidates.push((
+            "aider_conf",
+            h.join(".aider.conf.yml"),
+            ConfigKind::AiderConfYaml,
+        ));
+    }
+
+    let mut any_seen = false;
+    for (scope, path, kind) in candidates {
+        if !path.exists() {
+            continue;
+        }
+        any_seen = true;
+        let label = format!("aider:{}", scope);
+
+        match kind {
+            ConfigKind::Json => match read_and_parse_json(&path) {
+                Ok(v) => {
+                    let entry = v.get("mcpServers").and_then(|m| m.get("rts"));
+                    if let Some(entry) = entry {
+                        let cmd = entry
+                            .get("command")
+                            .and_then(|c| c.as_str())
+                            .map(str::to_string);
+                        match cmd {
+                            Some(c) if binary_resolves(&c) => {
+                                finding.rows.push(Row::ok(
+                                    label.clone(),
+                                    format!("rts registered ({}) in {}", c, path.display()),
+                                ));
+                                if finding.rts_registered.is_none() {
+                                    finding.rts_registered = Some(RegistrationDetail {
+                                        scope: scope.to_string(),
+                                        binary_path: Some(PathBuf::from(c)),
+                                        config_path: path.clone(),
+                                    });
+                                }
+                            }
+                            Some(c) => {
+                                finding.rows.push(
+                                    Row::fail(
+                                        label,
+                                        format!(
+                                            "rts registered in {} but binary {} not found",
+                                            path.display(),
+                                            c
+                                        ),
+                                    )
+                                    .with_fix(
+                                        FixSnippet::new(
+                                            FixClass::FixMcpBinaryPath,
+                                            format!(
+                                                "$EDITOR {}  # update mcpServers.rts.command",
+                                                path.display()
+                                            ),
+                                        )
+                                        .with_description(
+                                            "point Aider's rts entry at an existing binary",
+                                        ),
+                                    ),
+                                );
+                            }
+                            None => {
+                                finding.rows.push(Row::warn(
+                                    label,
+                                    format!(
+                                        "rts entry in {} has no `command`",
+                                        path.display()
+                                    ),
+                                ));
+                            }
+                        }
+                    } else {
+                        finding.rows.push(Row::info(
+                            label,
+                            format!("rts not registered in {}", path.display()),
+                        ));
+                    }
+                }
+                Err(msg) => {
+                    finding.rows.push(
+                        Row::warn(
+                            label,
+                            format!("could not parse {}: {}", path.display(), msg),
+                        )
+                        .with_fix(
+                            FixSnippet::new(
+                                FixClass::FixConfigSyntax,
+                                format!("$EDITOR {}", path.display()),
+                            )
+                            .with_description("fix JSON syntax in Aider mcp.json"),
+                        ),
+                    );
+                }
+            },
+            ConfigKind::AiderConfYaml => {
+                // ~/.aider.conf.yml exists. No formal MCP slot yet —
+                // emit an info row so the user knows we noticed.
+                finding.rows.push(Row::info(
+                    label,
+                    format!(
+                        "{} present; Aider's MCP support is alpha — see docs/install.md",
+                        path.display()
+                    ),
+                ));
+            }
+        }
+    }
+
+    if !any_seen {
+        // Soft-detect: emit a `[?]` rather than a skipped_reason so the
+        // operator sees that we tried but found nothing.
+        finding.rows.push(Row::info(
+            "aider:detect",
+            "no Aider MCP config found (soft-detect)",
+        ));
+        finding.skipped_reason = Some("not installed".to_string());
+    }
+
+    finding
+}
+
+enum ConfigKind {
+    Json,
+    AiderConfYaml,
+}
+
+fn read_and_parse_json(path: &Path) -> Result<serde_json::Value, String> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            format!("permission denied reading {}", path.display())
+        } else {
+            format!("read error: {e}")
+        }
+    })?;
+    serde_json::from_slice(&bytes).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::report::RowKind;
+    use crate::doctor::{DoctorArgs, DoctorOutput};
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn mk_ctx() -> Ctx {
+        Ctx::build(&DoctorArgs {
+            output: DoctorOutput::Json,
+            no_color: true,
+            workspace: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn absent_emits_info_soft_detect() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        let f = detect_impl(&mk_ctx(), Some(home.path()), Some(ws.path()));
+        // Soft-detect: rows non-empty with a `[?]`, skipped_reason set.
+        assert!(f.rows.iter().any(|r| r.kind == RowKind::Info));
+        assert!(f.skipped_reason.is_some());
+    }
+
+    #[test]
+    fn registered_json_is_ok() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        let bin = home.path().join("rts-mcp");
+        fs::write(&bin, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let cfg = home.path().join(".config").join("aider").join("mcp.json");
+        fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        fs::write(
+            &cfg,
+            format!(
+                r#"{{ "mcpServers": {{ "rts": {{ "command": "{}" }} }} }}"#,
+                bin.display()
+            ),
         )
+        .unwrap();
+        let f = detect_impl(&mk_ctx(), Some(home.path()), Some(ws.path()));
+        assert!(f.rows.iter().any(|r| r.kind == RowKind::Ok));
+        assert!(f.rts_registered.is_some());
+        assert!(f.skipped_reason.is_none());
+    }
+
+    #[test]
+    fn missing_binary_is_fail() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        let cfg = home.path().join(".config").join("aider").join("mcp.json");
+        fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        fs::write(
+            &cfg,
+            r#"{ "mcpServers": { "rts": { "command": "/nope/rts-mcp" } } }"#,
+        )
+        .unwrap();
+        let f = detect_impl(&mk_ctx(), Some(home.path()), Some(ws.path()));
+        let row = f
+            .rows
+            .iter()
+            .find(|r| r.label == "aider:user_scope")
+            .expect("user_scope row");
+        assert_eq!(row.kind, RowKind::Fail);
+        assert_eq!(row.fix.as_ref().unwrap().class, FixClass::FixMcpBinaryPath);
     }
 }

--- a/crates/rts-bench/src/doctor/hosts/aider.rs
+++ b/crates/rts-bench/src/doctor/hosts/aider.rs
@@ -1,0 +1,24 @@
+//! Aider MCP-registration detector. Soft-detect at
+//! `~/.config/aider/mcp.json`, `./.aider/mcp.json`, or
+//! `~/.aider.conf.yml`. U7 implements.
+
+use crate::doctor::ctx::Ctx;
+use super::{DetectionClass, HostDetector, HostFinding};
+
+pub struct Aider;
+
+impl HostDetector for Aider {
+    fn host_name(&self) -> &'static str {
+        "aider"
+    }
+    fn detection_class(&self) -> DetectionClass {
+        DetectionClass::Soft
+    }
+    fn detect(&self, _ctx: &Ctx) -> HostFinding {
+        HostFinding::skipped(
+            self.host_name(),
+            self.detection_class(),
+            "not yet implemented (U7)",
+        )
+    }
+}

--- a/crates/rts-bench/src/doctor/hosts/aider.rs
+++ b/crates/rts-bench/src/doctor/hosts/aider.rs
@@ -125,10 +125,7 @@ pub(crate) fn detect_impl(
                             None => {
                                 finding.rows.push(Row::warn(
                                     label,
-                                    format!(
-                                        "rts entry in {} has no `command`",
-                                        path.display()
-                                    ),
+                                    format!("rts entry in {} has no `command`", path.display()),
                                 ));
                             }
                         }

--- a/crates/rts-bench/src/doctor/hosts/claude_code.rs
+++ b/crates/rts-bench/src/doctor/hosts/claude_code.rs
@@ -1,0 +1,31 @@
+//! Claude Code MCP-registration detector. Hard-detect.
+//!
+//! Scopes (per `docs/install.md`):
+//! - user scope: `~/.claude.json`
+//! - project scope: `<workspace>/.mcp.json`
+//! - settings.json hook block: `<workspace>/.claude/settings.json`
+//!
+//! U7 implements. Multi-scope drift (user + project register
+//! different binaries) is the load-bearing foot-gun this detector
+//! catches.
+
+use crate::doctor::ctx::Ctx;
+use super::{DetectionClass, HostDetector, HostFinding};
+
+pub struct ClaudeCode;
+
+impl HostDetector for ClaudeCode {
+    fn host_name(&self) -> &'static str {
+        "claude_code"
+    }
+    fn detection_class(&self) -> DetectionClass {
+        DetectionClass::Hard
+    }
+    fn detect(&self, _ctx: &Ctx) -> HostFinding {
+        HostFinding::skipped(
+            self.host_name(),
+            self.detection_class(),
+            "not yet implemented (U7)",
+        )
+    }
+}

--- a/crates/rts-bench/src/doctor/hosts/claude_code.rs
+++ b/crates/rts-bench/src/doctor/hosts/claude_code.rs
@@ -5,12 +5,16 @@
 //! - project scope: `<workspace>/.mcp.json`
 //! - settings.json hook block: `<workspace>/.claude/settings.json`
 //!
-//! U7 implements. Multi-scope drift (user + project register
-//! different binaries) is the load-bearing foot-gun this detector
-//! catches.
+//! Multi-scope drift (user + project register different binaries) is the
+//! load-bearing foot-gun this detector catches and surfaces as a WARN.
 
+use std::path::{Path, PathBuf};
+
+use serde_json::Value as JsonValue;
+
+use super::{DetectionClass, HostDetector, HostFinding, RegistrationDetail};
 use crate::doctor::ctx::Ctx;
-use super::{DetectionClass, HostDetector, HostFinding};
+use crate::doctor::report::{FixClass, FixSnippet, Row};
 
 pub struct ClaudeCode;
 
@@ -21,11 +25,461 @@ impl HostDetector for ClaudeCode {
     fn detection_class(&self) -> DetectionClass {
         DetectionClass::Hard
     }
-    fn detect(&self, _ctx: &Ctx) -> HostFinding {
-        HostFinding::skipped(
-            self.host_name(),
-            self.detection_class(),
-            "not yet implemented (U7)",
-        )
+    fn detect(&self, ctx: &Ctx) -> HostFinding {
+        detect_impl(ctx, ctx.home.as_deref(), ctx.workspace_path.as_deref())
+    }
+}
+
+/// Internal entry point — broken out so tests can pass synthetic
+/// `home` / `workspace` paths without constructing a full `Ctx`.
+pub(crate) fn detect_impl(
+    _ctx: &Ctx,
+    home: Option<&Path>,
+    workspace: Option<&Path>,
+) -> HostFinding {
+    let mut finding = HostFinding {
+        host_name: "claude_code",
+        detection_class: DetectionClass::Hard,
+        rows: Vec::new(),
+        rts_registered: None,
+        skipped_reason: None,
+    };
+
+    let mut registrations: Vec<RegistrationDetail> = Vec::new();
+    let mut any_config_seen = false;
+
+    // -- User scope: `~/.claude.json`
+    if let Some(h) = home {
+        let path = h.join(".claude.json");
+        if path.exists() {
+            any_config_seen = true;
+            match read_and_parse_json(&path) {
+                Ok(v) => match find_mcp_entry(&v, "rts") {
+                    Some(entry) => {
+                        let detail = RegistrationDetail {
+                            scope: "user_scope".to_string(),
+                            binary_path: entry.command.clone().map(PathBuf::from),
+                            config_path: path.clone(),
+                        };
+                        emit_entry_row(
+                            &mut finding,
+                            "claude_code:user_scope",
+                            &entry,
+                            &path,
+                        );
+                        registrations.push(detail);
+                    }
+                    None => {
+                        // Config present but no rts entry — info row.
+                        finding.rows.push(Row::info(
+                            "claude_code:user_scope",
+                            format!("rts not registered in {}", path.display()),
+                        ));
+                    }
+                },
+                Err(msg) => {
+                    finding.rows.push(
+                        Row::warn(
+                            "claude_code:user_scope",
+                            format!("could not parse {}: {}", path.display(), msg),
+                        )
+                        .with_fix(
+                            FixSnippet::new(
+                                FixClass::FixConfigSyntax,
+                                format!("$EDITOR {}", path.display()),
+                            )
+                            .with_description("fix JSON syntax in user-scope config"),
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    // -- Project scope: `<workspace>/.mcp.json`
+    if let Some(ws) = workspace {
+        let path = ws.join(".mcp.json");
+        if path.exists() {
+            any_config_seen = true;
+            match read_and_parse_json(&path) {
+                Ok(v) => {
+                    if let Some(entry) = find_mcp_entry(&v, "rts") {
+                        let detail = RegistrationDetail {
+                            scope: "project_scope".to_string(),
+                            binary_path: entry.command.clone().map(PathBuf::from),
+                            config_path: path.clone(),
+                        };
+                        emit_entry_row(
+                            &mut finding,
+                            "claude_code:project_scope",
+                            &entry,
+                            &path,
+                        );
+                        registrations.push(detail);
+                    } else {
+                        finding.rows.push(Row::info(
+                            "claude_code:project_scope",
+                            format!("rts not registered in {}", path.display()),
+                        ));
+                    }
+                }
+                Err(msg) => {
+                    finding.rows.push(
+                        Row::warn(
+                            "claude_code:project_scope",
+                            format!("could not parse {}: {}", path.display(), msg),
+                        )
+                        .with_fix(
+                            FixSnippet::new(
+                                FixClass::FixConfigSyntax,
+                                format!("$EDITOR {}", path.display()),
+                            )
+                            .with_description("fix JSON syntax in project-scope config"),
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    // -- Hook block scope: `<workspace>/.claude/settings.json` — we look
+    //    for a PreToolUse entry that references `rts-nudge.sh`. The hook
+    //    section (U8) handles the hook *file* itself; here we only note
+    //    that the settings.json wires it in.
+    if let Some(ws) = workspace {
+        let path = ws.join(".claude").join("settings.json");
+        if path.exists() {
+            any_config_seen = true;
+            match read_and_parse_json(&path) {
+                Ok(v) => {
+                    if has_rts_nudge_hook(&v) {
+                        finding.rows.push(Row::ok(
+                            "claude_code:hook_block",
+                            format!("rts-nudge.sh wired in {}", path.display()),
+                        ));
+                    } else {
+                        finding.rows.push(Row::info(
+                            "claude_code:hook_block",
+                            format!("no rts-nudge hook entry in {}", path.display()),
+                        ));
+                    }
+                }
+                Err(msg) => {
+                    finding.rows.push(
+                        Row::warn(
+                            "claude_code:hook_block",
+                            format!("could not parse {}: {}", path.display(), msg),
+                        )
+                        .with_fix(
+                            FixSnippet::new(
+                                FixClass::FixConfigSyntax,
+                                format!("$EDITOR {}", path.display()),
+                            )
+                            .with_description("fix JSON syntax in settings.json"),
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    if !any_config_seen {
+        // No Claude Code config files at all — soft skip.
+        return HostFinding::skipped(
+            "claude_code",
+            DetectionClass::Hard,
+            "not installed (no ~/.claude.json or project .mcp.json found)",
+        );
+    }
+
+    // Store first registration for the orchestrator's drift check.
+    finding.rts_registered = registrations.into_iter().next();
+    finding
+}
+
+/// Parsed view of a single host's `mcpServers.<name>` entry.
+#[derive(Clone, Debug)]
+pub(crate) struct McpEntry {
+    pub command: Option<String>,
+}
+
+/// Look up `mcpServers.<name>` at either the document root (Cursor,
+/// project .mcp.json) or nested inside a `projects.<workspace>` object
+/// (the shape `~/.claude.json` uses for per-project servers). Returns
+/// the first match.
+fn find_mcp_entry(root: &JsonValue, name: &str) -> Option<McpEntry> {
+    if let Some(entry) = root
+        .get("mcpServers")
+        .and_then(|v| v.get(name))
+        .and_then(parse_mcp_entry)
+    {
+        return Some(entry);
+    }
+    // `~/.claude.json` also has `projects.<path>.mcpServers.<name>`.
+    if let Some(projects) = root.get("projects").and_then(JsonValue::as_object) {
+        for (_proj, body) in projects {
+            if let Some(entry) = body
+                .get("mcpServers")
+                .and_then(|v| v.get(name))
+                .and_then(parse_mcp_entry)
+            {
+                return Some(entry);
+            }
+        }
+    }
+    None
+}
+
+fn parse_mcp_entry(v: &JsonValue) -> Option<McpEntry> {
+    let cmd = v.get("command").and_then(JsonValue::as_str).map(str::to_string);
+    Some(McpEntry { command: cmd })
+}
+
+/// Look for a PreToolUse hook block that references `rts-nudge.sh`.
+/// The shape (per `.claude/settings.json` convention) is:
+/// `{ "hooks": { "PreToolUse": [ { "hooks": [ { "command": "..." } ] } ] } }`.
+/// We do a tolerant scan rather than a strict schema match.
+fn has_rts_nudge_hook(root: &JsonValue) -> bool {
+    fn walk(v: &JsonValue) -> bool {
+        match v {
+            JsonValue::String(s) => s.contains("rts-nudge.sh"),
+            JsonValue::Array(a) => a.iter().any(walk),
+            JsonValue::Object(m) => m.values().any(walk),
+            _ => false,
+        }
+    }
+    walk(root)
+}
+
+fn read_and_parse_json(path: &Path) -> Result<JsonValue, String> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            format!("permission denied reading {}", path.display())
+        } else {
+            format!("read error: {e}")
+        }
+    })?;
+    serde_json::from_slice(&bytes).map_err(|e| e.to_string())
+}
+
+/// Validate the entry's binary path; emit OK / FAIL accordingly.
+fn emit_entry_row(
+    finding: &mut HostFinding,
+    label: &str,
+    entry: &McpEntry,
+    config_path: &Path,
+) {
+    match entry.command.as_deref() {
+        Some(cmd) => {
+            if binary_resolves(cmd) {
+                finding.rows.push(Row::ok(
+                    label,
+                    format!("rts registered ({}) via {}", cmd, config_path.display()),
+                ));
+            } else {
+                finding.rows.push(
+                    Row::fail(
+                        label,
+                        format!(
+                            "rts registered in {} but binary {} not found / not executable",
+                            config_path.display(),
+                            cmd
+                        ),
+                    )
+                    .with_fix(
+                        FixSnippet::new(
+                            FixClass::FixMcpBinaryPath,
+                            "claude mcp remove rts && claude mcp add rts -- $(which rts-mcp) --workspace \"$PWD\"",
+                        )
+                        .with_description("rebind rts to a binary that exists on PATH"),
+                    ),
+                );
+            }
+        }
+        None => {
+            finding.rows.push(Row::warn(
+                label,
+                format!("rts entry in {} has no `command` field", config_path.display()),
+            ));
+        }
+    }
+}
+
+/// Does the MCP `command` string resolve to an existing, executable
+/// file? Accepts absolute paths (`/path/to/rts-mcp`) and bare names
+/// resolvable through `$PATH` (`rts-mcp`). Returns true on either.
+pub(crate) fn binary_resolves(cmd: &str) -> bool {
+    let p = Path::new(cmd);
+    if p.is_absolute() || cmd.contains('/') {
+        is_executable_file(p)
+    } else {
+        which_on_path(cmd).is_some()
+    }
+}
+
+fn is_executable_file(p: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(p) else {
+        return false;
+    };
+    if !meta.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        meta.permissions().mode() & 0o111 != 0
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn which_on_path(name: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(name);
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::DoctorArgs;
+    use crate::doctor::DoctorOutput;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn mk_ctx() -> Ctx {
+        Ctx::build(&DoctorArgs {
+            output: DoctorOutput::Json,
+            no_color: true,
+            workspace: None,
+        })
+        .unwrap()
+    }
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(p) = path.parent() {
+            fs::create_dir_all(p).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn absent_config_is_skipped() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        let ctx = mk_ctx();
+        let f = detect_impl(&ctx, Some(home.path()), Some(ws.path()));
+        assert!(f.skipped_reason.is_some());
+        assert!(f.rows.is_empty());
+    }
+
+    #[test]
+    fn user_scope_ok_when_binary_resolves() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        // synthetic executable
+        let bin = home.path().join("rts-mcp");
+        fs::write(&bin, "#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let cfg = home.path().join(".claude.json");
+        write(
+            &cfg,
+            &format!(
+                r#"{{ "mcpServers": {{ "rts": {{ "command": "{}" }} }} }}"#,
+                bin.display()
+            ),
+        );
+
+        let ctx = mk_ctx();
+        let f = detect_impl(&ctx, Some(home.path()), Some(ws.path()));
+        assert_eq!(f.host_name, "claude_code");
+        assert!(f.skipped_reason.is_none());
+        assert!(
+            f.rows.iter().any(|r| r.label == "claude_code:user_scope"
+                && r.kind == crate::doctor::report::RowKind::Ok),
+            "expected OK user_scope row; rows = {:?}",
+            f.rows
+        );
+        assert!(f.rts_registered.is_some());
+    }
+
+    #[test]
+    fn missing_binary_is_fail_with_fix() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        let cfg = home.path().join(".claude.json");
+        write(
+            &cfg,
+            r#"{ "mcpServers": { "rts": { "command": "/nonexistent/rts-mcp" } } }"#,
+        );
+
+        let ctx = mk_ctx();
+        let f = detect_impl(&ctx, Some(home.path()), Some(ws.path()));
+        let row = f
+            .rows
+            .iter()
+            .find(|r| r.label == "claude_code:user_scope")
+            .expect("user_scope row");
+        assert_eq!(row.kind, crate::doctor::report::RowKind::Fail);
+        let fix = row.fix.as_ref().expect("fix");
+        assert_eq!(fix.class, FixClass::FixMcpBinaryPath);
+    }
+
+    #[test]
+    fn malformed_json_is_warn_not_fail() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        let cfg = home.path().join(".claude.json");
+        write(&cfg, "{ this is not json");
+        let ctx = mk_ctx();
+        let f = detect_impl(&ctx, Some(home.path()), Some(ws.path()));
+        let row = f
+            .rows
+            .iter()
+            .find(|r| r.label == "claude_code:user_scope")
+            .expect("user_scope row");
+        assert_eq!(row.kind, crate::doctor::report::RowKind::Warn);
+    }
+
+    #[test]
+    fn multi_scope_drift_yields_two_registrations() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        // Two different "binaries" — neither needs to exist; we only
+        // care that two RegistrationDetails get produced for the
+        // orchestrator's drift check.
+        write(
+            &home.path().join(".claude.json"),
+            r#"{ "mcpServers": { "rts": { "command": "/opt/a/rts-mcp" } } }"#,
+        );
+        write(
+            &ws.path().join(".mcp.json"),
+            r#"{ "mcpServers": { "rts": { "command": "/opt/b/rts-mcp" } } }"#,
+        );
+        let ctx = mk_ctx();
+        let f = detect_impl(&ctx, Some(home.path()), Some(ws.path()));
+        // Two scopes both produced rows (both FAIL on missing binary
+        // but that's fine — drift is detected at the orchestrator
+        // level off `rts_registered` + a peek at `rows`).
+        let scope_rows: Vec<_> = f
+            .rows
+            .iter()
+            .filter(|r| {
+                r.label == "claude_code:user_scope"
+                    || r.label == "claude_code:project_scope"
+            })
+            .collect();
+        assert_eq!(scope_rows.len(), 2);
     }
 }

--- a/crates/rts-bench/src/doctor/hosts/claude_code.rs
+++ b/crates/rts-bench/src/doctor/hosts/claude_code.rs
@@ -61,12 +61,7 @@ pub(crate) fn detect_impl(
                             binary_path: entry.command.clone().map(PathBuf::from),
                             config_path: path.clone(),
                         };
-                        emit_entry_row(
-                            &mut finding,
-                            "claude_code:user_scope",
-                            &entry,
-                            &path,
-                        );
+                        emit_entry_row(&mut finding, "claude_code:user_scope", &entry, &path);
                         registrations.push(detail);
                     }
                     None => {
@@ -109,12 +104,7 @@ pub(crate) fn detect_impl(
                             binary_path: entry.command.clone().map(PathBuf::from),
                             config_path: path.clone(),
                         };
-                        emit_entry_row(
-                            &mut finding,
-                            "claude_code:project_scope",
-                            &entry,
-                            &path,
-                        );
+                        emit_entry_row(&mut finding, "claude_code:project_scope", &entry, &path);
                         registrations.push(detail);
                     } else {
                         finding.rows.push(Row::info(
@@ -231,7 +221,10 @@ fn find_mcp_entry(root: &JsonValue, name: &str) -> Option<McpEntry> {
 }
 
 fn parse_mcp_entry(v: &JsonValue) -> Option<McpEntry> {
-    let cmd = v.get("command").and_then(JsonValue::as_str).map(str::to_string);
+    let cmd = v
+        .get("command")
+        .and_then(JsonValue::as_str)
+        .map(str::to_string);
     Some(McpEntry { command: cmd })
 }
 
@@ -263,12 +256,7 @@ fn read_and_parse_json(path: &Path) -> Result<JsonValue, String> {
 }
 
 /// Validate the entry's binary path; emit OK / FAIL accordingly.
-fn emit_entry_row(
-    finding: &mut HostFinding,
-    label: &str,
-    entry: &McpEntry,
-    config_path: &Path,
-) {
+fn emit_entry_row(finding: &mut HostFinding, label: &str, entry: &McpEntry, config_path: &Path) {
     match entry.command.as_deref() {
         Some(cmd) => {
             if binary_resolves(cmd) {
@@ -299,7 +287,10 @@ fn emit_entry_row(
         None => {
             finding.rows.push(Row::warn(
                 label,
-                format!("rts entry in {} has no `command` field", config_path.display()),
+                format!(
+                    "rts entry in {} has no `command` field",
+                    config_path.display()
+                ),
             ));
         }
     }
@@ -476,8 +467,7 @@ mod tests {
             .rows
             .iter()
             .filter(|r| {
-                r.label == "claude_code:user_scope"
-                    || r.label == "claude_code:project_scope"
+                r.label == "claude_code:user_scope" || r.label == "claude_code:project_scope"
             })
             .collect();
         assert_eq!(scope_rows.len(), 2);

--- a/crates/rts-bench/src/doctor/hosts/cline.rs
+++ b/crates/rts-bench/src/doctor/hosts/cline.rs
@@ -306,11 +306,19 @@ mod tests {
         }
         // For Linux the XDG_CONFIG_HOME may divert candidate_global_storage_dirs
         // away from `home`; override it locally for test determinism.
+        //
+        // Rust 2024 made `std::env::{set_var, remove_var}` `unsafe` because
+        // process-wide env mutation isn't thread-safe; tests in this module
+        // serialize themselves around XDG_CONFIG_HOME via this RAII guard
+        // and don't share an env mutation surface with concurrent tests, so
+        // the unsafe block is sound for the test's intended use.
         #[cfg(target_os = "linux")]
         let _guard = {
             // We just unset to make the function fall back to ~/.config.
             let prev = std::env::var_os("XDG_CONFIG_HOME");
-            std::env::remove_var("XDG_CONFIG_HOME");
+            unsafe {
+                std::env::remove_var("XDG_CONFIG_HOME");
+            }
             scopeguard_restore(prev)
         };
         write_synth_settings(
@@ -334,7 +342,10 @@ mod tests {
         #[cfg(target_os = "linux")]
         let _guard = {
             let prev = std::env::var_os("XDG_CONFIG_HOME");
-            std::env::remove_var("XDG_CONFIG_HOME");
+            // SAFETY: see the long-form note in `ok_when_registered`.
+            unsafe {
+                std::env::remove_var("XDG_CONFIG_HOME");
+            }
             scopeguard_restore(prev)
         };
         write_synth_settings(
@@ -358,7 +369,10 @@ mod tests {
         impl Drop for R {
             fn drop(&mut self) {
                 if let Some(v) = self.0.take() {
-                    std::env::set_var("XDG_CONFIG_HOME", v);
+                    // SAFETY: see the long-form note in `ok_when_registered`.
+                    unsafe {
+                        std::env::set_var("XDG_CONFIG_HOME", v);
+                    }
                 }
             }
         }

--- a/crates/rts-bench/src/doctor/hosts/cline.rs
+++ b/crates/rts-bench/src/doctor/hosts/cline.rs
@@ -58,8 +58,16 @@ pub(crate) fn detect_impl(_ctx: &Ctx, home: Option<&Path>) -> HostFinding {
         }
         any_dir_found = true;
         for candidate_name in [
+            // Current Cline (saoudrizwan.claude-dev v3.x+) stores MCP
+            // settings under `settings/cline_mcp_settings.json`.
             "settings/cline_mcp_settings.json",
+            // Older builds shipped the file at the directory root.
             "cline_mcp_settings.json",
+            // Legacy / pre-rebrand builds used the bare filename.
+            // Including it here avoids false-negative soft-detects
+            // on long-tenured installs — flagged by Codex review on
+            // PR #109.
+            "mcp_settings.json",
         ] {
             let path = base.join(candidate_name);
             if !path.exists() {

--- a/crates/rts-bench/src/doctor/hosts/cline.rs
+++ b/crates/rts-bench/src/doctor/hosts/cline.rs
@@ -57,7 +57,10 @@ pub(crate) fn detect_impl(_ctx: &Ctx, home: Option<&Path>) -> HostFinding {
             continue;
         }
         any_dir_found = true;
-        for candidate_name in ["settings/cline_mcp_settings.json", "cline_mcp_settings.json"] {
+        for candidate_name in [
+            "settings/cline_mcp_settings.json",
+            "cline_mcp_settings.json",
+        ] {
             let path = base.join(candidate_name);
             if !path.exists() {
                 continue;
@@ -105,21 +108,18 @@ fn handle_settings_file(finding: &mut HostFinding, path: &Path) {
         Ok(v) => v,
         Err(e) => {
             finding.rows.push(
-                Row::warn(label, format!("could not parse {}: {}", path.display(), e))
-                    .with_fix(
-                        FixSnippet::new(
-                            FixClass::FixConfigSyntax,
-                            format!("$EDITOR {}", path.display()),
-                        )
-                        .with_description("fix JSON syntax in Cline settings"),
-                    ),
+                Row::warn(label, format!("could not parse {}: {}", path.display(), e)).with_fix(
+                    FixSnippet::new(
+                        FixClass::FixConfigSyntax,
+                        format!("$EDITOR {}", path.display()),
+                    )
+                    .with_description("fix JSON syntax in Cline settings"),
+                ),
             );
             return;
         }
     };
-    let entry = value
-        .get("mcpServers")
-        .and_then(|m| m.get("rts"));
+    let entry = value.get("mcpServers").and_then(|m| m.get("rts"));
     let Some(entry) = entry else {
         finding.rows.push(Row::info(
             label,
@@ -184,7 +184,12 @@ fn candidate_global_storage_dirs(home: &Path) -> Vec<PathBuf> {
     {
         let base = home.join("Library").join("Application Support");
         for product in ["Code", "Code - Insiders", "VSCodium"] {
-            out.push(base.join(product).join("User").join("globalStorage").join(ext));
+            out.push(
+                base.join(product)
+                    .join("User")
+                    .join("globalStorage")
+                    .join(ext),
+            );
         }
     }
     #[cfg(target_os = "linux")]
@@ -195,27 +200,50 @@ fn candidate_global_storage_dirs(home: &Path) -> Vec<PathBuf> {
             .filter(|p| p.is_absolute())
             .unwrap_or_else(|| home.join(".config"));
         for product in ["Code", "Code - Insiders", "VSCodium"] {
-            out.push(xdg.join(product).join("User").join("globalStorage").join(ext));
+            out.push(
+                xdg.join(product)
+                    .join("User")
+                    .join("globalStorage")
+                    .join(ext),
+            );
         }
     }
     #[cfg(target_os = "windows")]
     {
         if let Some(appdata) = std::env::var_os("APPDATA").map(PathBuf::from) {
             for product in ["Code", "Code - Insiders", "VSCodium"] {
-                out.push(appdata.join(product).join("User").join("globalStorage").join(ext));
+                out.push(
+                    appdata
+                        .join(product)
+                        .join("User")
+                        .join("globalStorage")
+                        .join(ext),
+                );
             }
         } else {
             // Fallback: walk under the typical %USERPROFILE%/AppData/Roaming.
             let fallback = home.join("AppData").join("Roaming");
             for product in ["Code", "Code - Insiders", "VSCodium"] {
-                out.push(fallback.join(product).join("User").join("globalStorage").join(ext));
+                out.push(
+                    fallback
+                        .join(product)
+                        .join("User")
+                        .join("globalStorage")
+                        .join(ext),
+                );
             }
         }
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     {
         // Unknown OS: best-effort under ~/.config — better than nothing.
-        out.push(home.join(".config").join("Code").join("User").join("globalStorage").join(ext));
+        out.push(
+            home.join(".config")
+                .join("Code")
+                .join("User")
+                .join("globalStorage")
+                .join(ext),
+        );
     }
 
     out

--- a/crates/rts-bench/src/doctor/hosts/cline.rs
+++ b/crates/rts-bench/src/doctor/hosts/cline.rs
@@ -1,8 +1,20 @@
-//! Cline MCP-registration detector. Soft-detect via VS Code extension
-//! settings (path varies by OS). U7 implements.
+//! Cline MCP-registration detector. Soft-detect via the VS Code
+//! extension's global-storage directory; the path varies by OS.
+//!
+//! - Linux:   `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/`
+//! - macOS:   `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/`
+//! - Windows: `%APPDATA%/Code/User/globalStorage/saoudrizwan.claude-dev/`
+//!
+//! Inside that directory Cline historically stores a JSON file named
+//! `cline_mcp_settings.json` (or, in older builds, `mcp_settings.json`).
+//! We probe both and emit a `[?]` info row when nothing is found.
 
+use std::path::{Path, PathBuf};
+
+use super::{DetectionClass, HostDetector, HostFinding, RegistrationDetail};
 use crate::doctor::ctx::Ctx;
-use super::{DetectionClass, HostDetector, HostFinding};
+use crate::doctor::hosts::claude_code::binary_resolves;
+use crate::doctor::report::{FixClass, FixSnippet, Row};
 
 pub struct Cline;
 
@@ -13,11 +25,307 @@ impl HostDetector for Cline {
     fn detection_class(&self) -> DetectionClass {
         DetectionClass::Soft
     }
-    fn detect(&self, _ctx: &Ctx) -> HostFinding {
-        HostFinding::skipped(
-            self.host_name(),
-            self.detection_class(),
-            "not yet implemented (U7)",
-        )
+    fn detect(&self, ctx: &Ctx) -> HostFinding {
+        detect_impl(ctx, ctx.home.as_deref())
+    }
+}
+
+pub(crate) fn detect_impl(_ctx: &Ctx, home: Option<&Path>) -> HostFinding {
+    let mut finding = HostFinding {
+        host_name: "cline",
+        detection_class: DetectionClass::Soft,
+        rows: Vec::new(),
+        rts_registered: None,
+        skipped_reason: None,
+    };
+
+    let Some(h) = home else {
+        finding.rows.push(Row::info(
+            "cline:detect",
+            "no home directory; cannot soft-detect Cline",
+        ));
+        finding.skipped_reason = Some("no home directory".to_string());
+        return finding;
+    };
+
+    let bases = candidate_global_storage_dirs(h);
+    let mut any_dir_found = false;
+    let mut any_file_found = false;
+
+    for base in &bases {
+        if !base.exists() {
+            continue;
+        }
+        any_dir_found = true;
+        for candidate_name in ["settings/cline_mcp_settings.json", "cline_mcp_settings.json"] {
+            let path = base.join(candidate_name);
+            if !path.exists() {
+                continue;
+            }
+            any_file_found = true;
+            handle_settings_file(&mut finding, &path);
+        }
+    }
+
+    if !any_dir_found {
+        finding.rows.push(Row::info(
+            "cline:detect",
+            "no Cline VS Code extension storage directory found (soft-detect)",
+        ));
+        finding.skipped_reason = Some("not installed".to_string());
+        return finding;
+    }
+    if !any_file_found {
+        finding.rows.push(Row::info(
+            "cline:settings",
+            "Cline extension storage found but no MCP settings file present",
+        ));
+    }
+
+    finding
+}
+
+fn handle_settings_file(finding: &mut HostFinding, path: &Path) {
+    let label = "cline:vs_code_extension";
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) => {
+            finding.rows.push(Row::warn(
+                label,
+                if e.kind() == std::io::ErrorKind::PermissionDenied {
+                    format!("permission denied reading {}", path.display())
+                } else {
+                    format!("read error on {}: {}", path.display(), e)
+                },
+            ));
+            return;
+        }
+    };
+    let value: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            finding.rows.push(
+                Row::warn(label, format!("could not parse {}: {}", path.display(), e))
+                    .with_fix(
+                        FixSnippet::new(
+                            FixClass::FixConfigSyntax,
+                            format!("$EDITOR {}", path.display()),
+                        )
+                        .with_description("fix JSON syntax in Cline settings"),
+                    ),
+            );
+            return;
+        }
+    };
+    let entry = value
+        .get("mcpServers")
+        .and_then(|m| m.get("rts"));
+    let Some(entry) = entry else {
+        finding.rows.push(Row::info(
+            label,
+            format!("rts not registered in {}", path.display()),
+        ));
+        return;
+    };
+    let cmd = entry
+        .get("command")
+        .and_then(|c| c.as_str())
+        .map(str::to_string);
+    match cmd {
+        Some(c) if binary_resolves(&c) => {
+            finding.rows.push(Row::ok(
+                label,
+                format!("rts registered ({}) in {}", c, path.display()),
+            ));
+            if finding.rts_registered.is_none() {
+                finding.rts_registered = Some(RegistrationDetail {
+                    scope: "vs_code_extension".to_string(),
+                    binary_path: Some(PathBuf::from(c)),
+                    config_path: path.to_path_buf(),
+                });
+            }
+        }
+        Some(c) => {
+            finding.rows.push(
+                Row::fail(
+                    label,
+                    format!(
+                        "rts registered in {} but binary {} not found",
+                        path.display(),
+                        c
+                    ),
+                )
+                .with_fix(
+                    FixSnippet::new(
+                        FixClass::FixMcpBinaryPath,
+                        format!("$EDITOR {}", path.display()),
+                    )
+                    .with_description("point Cline's rts entry at an existing binary"),
+                ),
+            );
+        }
+        None => {
+            finding.rows.push(Row::warn(
+                label,
+                format!("rts entry in {} has no `command`", path.display()),
+            ));
+        }
+    }
+}
+
+/// Return the OS-specific list of VS Code `globalStorage/saoudrizwan.claude-dev`
+/// directories to probe. Multiple entries are returned for OSes where
+/// VS Code Insiders / VSCodium ship parallel install trees.
+fn candidate_global_storage_dirs(home: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let ext = "saoudrizwan.claude-dev";
+
+    #[cfg(target_os = "macos")]
+    {
+        let base = home.join("Library").join("Application Support");
+        for product in ["Code", "Code - Insiders", "VSCodium"] {
+            out.push(base.join(product).join("User").join("globalStorage").join(ext));
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // Honor XDG_CONFIG_HOME if set; otherwise default to ~/.config.
+        let xdg = std::env::var_os("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .filter(|p| p.is_absolute())
+            .unwrap_or_else(|| home.join(".config"));
+        for product in ["Code", "Code - Insiders", "VSCodium"] {
+            out.push(xdg.join(product).join("User").join("globalStorage").join(ext));
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(appdata) = std::env::var_os("APPDATA").map(PathBuf::from) {
+            for product in ["Code", "Code - Insiders", "VSCodium"] {
+                out.push(appdata.join(product).join("User").join("globalStorage").join(ext));
+            }
+        } else {
+            // Fallback: walk under the typical %USERPROFILE%/AppData/Roaming.
+            let fallback = home.join("AppData").join("Roaming");
+            for product in ["Code", "Code - Insiders", "VSCodium"] {
+                out.push(fallback.join(product).join("User").join("globalStorage").join(ext));
+            }
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        // Unknown OS: best-effort under ~/.config — better than nothing.
+        out.push(home.join(".config").join("Code").join("User").join("globalStorage").join(ext));
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::report::RowKind;
+    use crate::doctor::{DoctorArgs, DoctorOutput};
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn mk_ctx() -> Ctx {
+        Ctx::build(&DoctorArgs {
+            output: DoctorOutput::Json,
+            no_color: true,
+            workspace: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn absent_extension_dir_yields_info_and_skipped() {
+        let home = tempdir().unwrap();
+        let f = detect_impl(&mk_ctx(), Some(home.path()));
+        assert!(f.skipped_reason.is_some());
+        assert!(f.rows.iter().any(|r| r.kind == RowKind::Info));
+    }
+
+    /// Build a synthetic Cline-extension dir for the current OS and
+    /// drop a settings file in it.
+    fn write_synth_settings(home: &Path, contents: &str) -> PathBuf {
+        let dirs = candidate_global_storage_dirs(home);
+        let base = dirs.into_iter().next().expect("at least one candidate");
+        let settings = base.join("settings");
+        fs::create_dir_all(&settings).unwrap();
+        let path = settings.join("cline_mcp_settings.json");
+        fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn registered_with_resolving_binary_is_ok() {
+        let home = tempdir().unwrap();
+        let bin = home.path().join("rts-mcp");
+        fs::write(&bin, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        // For Linux the XDG_CONFIG_HOME may divert candidate_global_storage_dirs
+        // away from `home`; override it locally for test determinism.
+        #[cfg(target_os = "linux")]
+        let _guard = {
+            // We just unset to make the function fall back to ~/.config.
+            let prev = std::env::var_os("XDG_CONFIG_HOME");
+            std::env::remove_var("XDG_CONFIG_HOME");
+            scopeguard_restore(prev)
+        };
+        write_synth_settings(
+            home.path(),
+            &format!(
+                r#"{{ "mcpServers": {{ "rts": {{ "command": "{}" }} }} }}"#,
+                bin.display()
+            ),
+        );
+        let f = detect_impl(&mk_ctx(), Some(home.path()));
+        assert!(
+            f.rows.iter().any(|r| r.kind == RowKind::Ok),
+            "rows: {:?}",
+            f.rows
+        );
+    }
+
+    #[test]
+    fn missing_binary_is_fail() {
+        let home = tempdir().unwrap();
+        #[cfg(target_os = "linux")]
+        let _guard = {
+            let prev = std::env::var_os("XDG_CONFIG_HOME");
+            std::env::remove_var("XDG_CONFIG_HOME");
+            scopeguard_restore(prev)
+        };
+        write_synth_settings(
+            home.path(),
+            r#"{ "mcpServers": { "rts": { "command": "/nope/rts-mcp" } } }"#,
+        );
+        let f = detect_impl(&mk_ctx(), Some(home.path()));
+        let row = f
+            .rows
+            .iter()
+            .find(|r| r.label == "cline:vs_code_extension")
+            .expect("vs_code_extension row");
+        assert_eq!(row.kind, RowKind::Fail);
+        assert_eq!(row.fix.as_ref().unwrap().class, FixClass::FixMcpBinaryPath);
+    }
+
+    // -- tiny RAII helper used only on Linux to restore XDG_CONFIG_HOME.
+    #[cfg(target_os = "linux")]
+    fn scopeguard_restore(prev: Option<std::ffi::OsString>) -> impl Drop {
+        struct R(Option<std::ffi::OsString>);
+        impl Drop for R {
+            fn drop(&mut self) {
+                if let Some(v) = self.0.take() {
+                    std::env::set_var("XDG_CONFIG_HOME", v);
+                }
+            }
+        }
+        R(prev)
     }
 }

--- a/crates/rts-bench/src/doctor/hosts/cline.rs
+++ b/crates/rts-bench/src/doctor/hosts/cline.rs
@@ -1,0 +1,23 @@
+//! Cline MCP-registration detector. Soft-detect via VS Code extension
+//! settings (path varies by OS). U7 implements.
+
+use crate::doctor::ctx::Ctx;
+use super::{DetectionClass, HostDetector, HostFinding};
+
+pub struct Cline;
+
+impl HostDetector for Cline {
+    fn host_name(&self) -> &'static str {
+        "cline"
+    }
+    fn detection_class(&self) -> DetectionClass {
+        DetectionClass::Soft
+    }
+    fn detect(&self, _ctx: &Ctx) -> HostFinding {
+        HostFinding::skipped(
+            self.host_name(),
+            self.detection_class(),
+            "not yet implemented (U7)",
+        )
+    }
+}

--- a/crates/rts-bench/src/doctor/hosts/cline.rs
+++ b/crates/rts-bench/src/doctor/hosts/cline.rs
@@ -26,11 +26,20 @@ impl HostDetector for Cline {
         DetectionClass::Soft
     }
     fn detect(&self, ctx: &Ctx) -> HostFinding {
-        detect_impl(ctx, ctx.home.as_deref())
+        // Production path: read the live env once at the trait
+        // entry, then thread the resolved value down through the
+        // dependency-free helper(s). Tests bypass via the
+        // explicit-override entry below.
+        let xdg = std::env::var_os("XDG_CONFIG_HOME").map(std::path::PathBuf::from);
+        detect_impl(ctx, ctx.home.as_deref(), xdg.as_deref())
     }
 }
 
-pub(crate) fn detect_impl(_ctx: &Ctx, home: Option<&Path>) -> HostFinding {
+pub(crate) fn detect_impl(
+    _ctx: &Ctx,
+    home: Option<&Path>,
+    xdg_config_home: Option<&Path>,
+) -> HostFinding {
     let mut finding = HostFinding {
         host_name: "cline",
         detection_class: DetectionClass::Soft,
@@ -48,7 +57,7 @@ pub(crate) fn detect_impl(_ctx: &Ctx, home: Option<&Path>) -> HostFinding {
         return finding;
     };
 
-    let bases = candidate_global_storage_dirs(h);
+    let bases = candidate_global_storage_dirs(h, xdg_config_home);
     let mut any_dir_found = false;
     let mut any_file_found = false;
 
@@ -184,7 +193,17 @@ fn handle_settings_file(finding: &mut HostFinding, path: &Path) {
 /// Return the OS-specific list of VS Code `globalStorage/saoudrizwan.claude-dev`
 /// directories to probe. Multiple entries are returned for OSes where
 /// VS Code Insiders / VSCodium ship parallel install trees.
-fn candidate_global_storage_dirs(home: &Path) -> Vec<PathBuf> {
+///
+/// `xdg_config_home` is the resolved value of the `XDG_CONFIG_HOME`
+/// env var (Linux only). The production caller reads the env once at
+/// `detect_impl` entry and passes it down; tests pass `None` (or a
+/// synthetic path) so they don't have to mutate the process-wide env
+/// — `std::env::set_var` is `unsafe` under Rust 2024 and forbidden by
+/// the workspace's `unsafe_code = "deny"` lint.
+fn candidate_global_storage_dirs(
+    home: &Path,
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] xdg_config_home: Option<&Path>,
+) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let ext = "saoudrizwan.claude-dev";
 
@@ -202,8 +221,9 @@ fn candidate_global_storage_dirs(home: &Path) -> Vec<PathBuf> {
     }
     #[cfg(target_os = "linux")]
     {
-        // Honor XDG_CONFIG_HOME if set; otherwise default to ~/.config.
-        let xdg = std::env::var_os("XDG_CONFIG_HOME")
+        // Honor the passed-in XDG_CONFIG_HOME if set + absolute;
+        // otherwise default to `~/.config`.
+        let xdg = xdg_config_home
             .map(PathBuf::from)
             .filter(|p| p.is_absolute())
             .unwrap_or_else(|| home.join(".config"));
@@ -277,15 +297,18 @@ mod tests {
     #[test]
     fn absent_extension_dir_yields_info_and_skipped() {
         let home = tempdir().unwrap();
-        let f = detect_impl(&mk_ctx(), Some(home.path()));
+        // Pass `None` for the XDG override so the test stays
+        // hermetic regardless of the runner's real `XDG_CONFIG_HOME`.
+        let f = detect_impl(&mk_ctx(), Some(home.path()), None);
         assert!(f.skipped_reason.is_some());
         assert!(f.rows.iter().any(|r| r.kind == RowKind::Info));
     }
 
     /// Build a synthetic Cline-extension dir for the current OS and
-    /// drop a settings file in it.
+    /// drop a settings file in it. Mirrors what
+    /// `candidate_global_storage_dirs(home, None)` would return.
     fn write_synth_settings(home: &Path, contents: &str) -> PathBuf {
-        let dirs = candidate_global_storage_dirs(home);
+        let dirs = candidate_global_storage_dirs(home, None);
         let base = dirs.into_iter().next().expect("at least one candidate");
         let settings = base.join("settings");
         fs::create_dir_all(&settings).unwrap();
@@ -304,23 +327,9 @@ mod tests {
             use std::os::unix::fs::PermissionsExt;
             fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
         }
-        // For Linux the XDG_CONFIG_HOME may divert candidate_global_storage_dirs
-        // away from `home`; override it locally for test determinism.
-        //
-        // Rust 2024 made `std::env::{set_var, remove_var}` `unsafe` because
-        // process-wide env mutation isn't thread-safe; tests in this module
-        // serialize themselves around XDG_CONFIG_HOME via this RAII guard
-        // and don't share an env mutation surface with concurrent tests, so
-        // the unsafe block is sound for the test's intended use.
-        #[cfg(target_os = "linux")]
-        let _guard = {
-            // We just unset to make the function fall back to ~/.config.
-            let prev = std::env::var_os("XDG_CONFIG_HOME");
-            unsafe {
-                std::env::remove_var("XDG_CONFIG_HOME");
-            }
-            scopeguard_restore(prev)
-        };
+        // No env mutation needed: pass `None` so the function
+        // defaults to `<home>/.config` on Linux (matches what
+        // `write_synth_settings` writes to).
         write_synth_settings(
             home.path(),
             &format!(
@@ -328,7 +337,7 @@ mod tests {
                 bin.display()
             ),
         );
-        let f = detect_impl(&mk_ctx(), Some(home.path()));
+        let f = detect_impl(&mk_ctx(), Some(home.path()), None);
         assert!(
             f.rows.iter().any(|r| r.kind == RowKind::Ok),
             "rows: {:?}",
@@ -339,20 +348,11 @@ mod tests {
     #[test]
     fn missing_binary_is_fail() {
         let home = tempdir().unwrap();
-        #[cfg(target_os = "linux")]
-        let _guard = {
-            let prev = std::env::var_os("XDG_CONFIG_HOME");
-            // SAFETY: see the long-form note in `ok_when_registered`.
-            unsafe {
-                std::env::remove_var("XDG_CONFIG_HOME");
-            }
-            scopeguard_restore(prev)
-        };
         write_synth_settings(
             home.path(),
             r#"{ "mcpServers": { "rts": { "command": "/nope/rts-mcp" } } }"#,
         );
-        let f = detect_impl(&mk_ctx(), Some(home.path()));
+        let f = detect_impl(&mk_ctx(), Some(home.path()), None);
         let row = f
             .rows
             .iter()
@@ -360,22 +360,5 @@ mod tests {
             .expect("vs_code_extension row");
         assert_eq!(row.kind, RowKind::Fail);
         assert_eq!(row.fix.as_ref().unwrap().class, FixClass::FixMcpBinaryPath);
-    }
-
-    // -- tiny RAII helper used only on Linux to restore XDG_CONFIG_HOME.
-    #[cfg(target_os = "linux")]
-    fn scopeguard_restore(prev: Option<std::ffi::OsString>) -> impl Drop {
-        struct R(Option<std::ffi::OsString>);
-        impl Drop for R {
-            fn drop(&mut self) {
-                if let Some(v) = self.0.take() {
-                    // SAFETY: see the long-form note in `ok_when_registered`.
-                    unsafe {
-                        std::env::set_var("XDG_CONFIG_HOME", v);
-                    }
-                }
-            }
-        }
-        R(prev)
     }
 }

--- a/crates/rts-bench/src/doctor/hosts/continue_.rs
+++ b/crates/rts-bench/src/doctor/hosts/continue_.rs
@@ -1,0 +1,24 @@
+//! Continue MCP-registration detector. Hard-detect at
+//! `~/.continue/config.yaml` or `<workspace>/.continue/config.yaml`
+//! (YAML, per `docs/install.md`). U7 implements.
+
+use crate::doctor::ctx::Ctx;
+use super::{DetectionClass, HostDetector, HostFinding};
+
+pub struct Continue;
+
+impl HostDetector for Continue {
+    fn host_name(&self) -> &'static str {
+        "continue"
+    }
+    fn detection_class(&self) -> DetectionClass {
+        DetectionClass::Hard
+    }
+    fn detect(&self, _ctx: &Ctx) -> HostFinding {
+        HostFinding::skipped(
+            self.host_name(),
+            self.detection_class(),
+            "not yet implemented (U7)",
+        )
+    }
+}

--- a/crates/rts-bench/src/doctor/hosts/continue_.rs
+++ b/crates/rts-bench/src/doctor/hosts/continue_.rs
@@ -1,9 +1,19 @@
 //! Continue MCP-registration detector. Hard-detect at
 //! `~/.continue/config.yaml` or `<workspace>/.continue/config.yaml`
-//! (YAML, per `docs/install.md`). U7 implements.
+//! (YAML, per `docs/install.md`).
+//!
+//! Continue's `mcpServers` is a YAML *list* of objects (with a `name`
+//! field), not a map keyed by server name — this is the schema documented
+//! in `docs/install.md:137-144`.
 
+use std::path::{Path, PathBuf};
+
+use serde_yaml::Value as YamlValue;
+
+use super::{DetectionClass, HostDetector, HostFinding, RegistrationDetail};
 use crate::doctor::ctx::Ctx;
-use super::{DetectionClass, HostDetector, HostFinding};
+use crate::doctor::hosts::claude_code::binary_resolves;
+use crate::doctor::report::{FixClass, FixSnippet, Row};
 
 pub struct Continue;
 
@@ -14,11 +24,251 @@ impl HostDetector for Continue {
     fn detection_class(&self) -> DetectionClass {
         DetectionClass::Hard
     }
-    fn detect(&self, _ctx: &Ctx) -> HostFinding {
-        HostFinding::skipped(
-            self.host_name(),
-            self.detection_class(),
-            "not yet implemented (U7)",
-        )
+    fn detect(&self, ctx: &Ctx) -> HostFinding {
+        detect_impl(ctx, ctx.home.as_deref(), ctx.workspace_path.as_deref())
+    }
+}
+
+pub(crate) fn detect_impl(
+    _ctx: &Ctx,
+    home: Option<&Path>,
+    workspace: Option<&Path>,
+) -> HostFinding {
+    let mut finding = HostFinding {
+        host_name: "continue",
+        detection_class: DetectionClass::Hard,
+        rows: Vec::new(),
+        rts_registered: None,
+        skipped_reason: None,
+    };
+
+    // Order: workspace override first, then user-global. Both are valid;
+    // we surface a row per scope so users can see which file declared it.
+    let mut candidates: Vec<(&'static str, PathBuf)> = Vec::new();
+    if let Some(ws) = workspace {
+        candidates.push((
+            "project_scope",
+            ws.join(".continue").join("config.yaml"),
+        ));
+    }
+    if let Some(h) = home {
+        candidates.push(("user_scope", h.join(".continue").join("config.yaml")));
+    }
+
+    let mut any_seen = false;
+    for (scope, path) in candidates {
+        if !path.exists() {
+            continue;
+        }
+        any_seen = true;
+        let label = format!("continue:{}", scope);
+        match read_and_parse_yaml(&path) {
+            Ok(v) => match find_rts_entry(&v) {
+                Some(cmd) => {
+                    let resolves = cmd.as_deref().map(binary_resolves).unwrap_or(false);
+                    if let Some(c) = cmd.as_deref() {
+                        if resolves {
+                            finding.rows.push(Row::ok(
+                                label.clone(),
+                                format!("rts registered ({}) in {}", c, path.display()),
+                            ));
+                        } else {
+                            finding.rows.push(
+                                Row::fail(
+                                    label.clone(),
+                                    format!(
+                                        "rts registered in {} but binary {} not found",
+                                        path.display(),
+                                        c
+                                    ),
+                                )
+                                .with_fix(
+                                    FixSnippet::new(
+                                        FixClass::FixMcpBinaryPath,
+                                        format!(
+                                            "$EDITOR {}  # update mcpServers[].command",
+                                            path.display()
+                                        ),
+                                    )
+                                    .with_description(
+                                        "point Continue's rts entry at an existing binary",
+                                    ),
+                                ),
+                            );
+                        }
+                        if finding.rts_registered.is_none() {
+                            finding.rts_registered = Some(RegistrationDetail {
+                                scope: scope.to_string(),
+                                binary_path: Some(PathBuf::from(c)),
+                                config_path: path.clone(),
+                            });
+                        }
+                    } else {
+                        finding.rows.push(Row::warn(
+                            label,
+                            format!("rts entry in {} has no `command`", path.display()),
+                        ));
+                    }
+                }
+                None => {
+                    finding.rows.push(Row::info(
+                        label,
+                        format!("rts not registered in {}", path.display()),
+                    ));
+                }
+            },
+            Err(msg) => {
+                finding.rows.push(
+                    Row::warn(label, format!("could not parse {}: {}", path.display(), msg))
+                        .with_fix(
+                            FixSnippet::new(
+                                FixClass::FixConfigSyntax,
+                                format!("$EDITOR {}", path.display()),
+                            )
+                            .with_description("fix YAML syntax in Continue config"),
+                        ),
+                );
+            }
+        }
+    }
+
+    if !any_seen {
+        return HostFinding::skipped(
+            "continue",
+            DetectionClass::Hard,
+            "not installed (no ~/.continue/config.yaml found)",
+        );
+    }
+    finding
+}
+
+fn read_and_parse_yaml(path: &Path) -> Result<YamlValue, String> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            format!("permission denied reading {}", path.display())
+        } else {
+            format!("read error: {e}")
+        }
+    })?;
+    serde_yaml::from_slice(&bytes).map_err(|e| e.to_string())
+}
+
+/// Extract the `command` for an mcpServer named `rts`. Continue's
+/// schema lists `mcpServers` as a sequence of `{name, command, args}`
+/// maps; older docs sometimes show a map keyed by name. We tolerate both.
+fn find_rts_entry(root: &YamlValue) -> Option<Option<String>> {
+    let mcp = root.get("mcpServers")?;
+    if let Some(seq) = mcp.as_sequence() {
+        for item in seq {
+            let name = item.get("name").and_then(YamlValue::as_str);
+            if name == Some("rts") {
+                let cmd = item
+                    .get("command")
+                    .and_then(YamlValue::as_str)
+                    .map(str::to_string);
+                return Some(cmd);
+            }
+        }
+        return None;
+    }
+    if let Some(map) = mcp.as_mapping() {
+        // Map-style fallback: `mcpServers: { rts: { command: ... } }`.
+        let key = YamlValue::String("rts".to_string());
+        if let Some(entry) = map.get(&key) {
+            let cmd = entry
+                .get("command")
+                .and_then(YamlValue::as_str)
+                .map(str::to_string);
+            return Some(cmd);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::report::RowKind;
+    use crate::doctor::{DoctorArgs, DoctorOutput};
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn mk_ctx() -> Ctx {
+        Ctx::build(&DoctorArgs {
+            output: DoctorOutput::Json,
+            no_color: true,
+            workspace: None,
+        })
+        .unwrap()
+    }
+
+    fn write_config(dir: &Path, contents: &str) -> PathBuf {
+        let cfg = dir.join(".continue").join("config.yaml");
+        fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        fs::write(&cfg, contents).unwrap();
+        cfg
+    }
+
+    #[test]
+    fn absent_config_is_skipped() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        let f = detect_impl(&mk_ctx(), Some(home.path()), Some(ws.path()));
+        assert!(f.skipped_reason.is_some());
+    }
+
+    #[test]
+    fn registered_sequence_form_is_ok() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        let bin = home.path().join("rts-mcp");
+        fs::write(&bin, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        write_config(
+            home.path(),
+            &format!(
+                "mcpServers:\n  - name: rts\n    command: {}\n    args:\n      - --workspace\n      - .\n",
+                bin.display()
+            ),
+        );
+        let f = detect_impl(&mk_ctx(), Some(home.path()), Some(ws.path()));
+        assert!(f.rows.iter().any(|r| r.kind == RowKind::Ok));
+        assert!(f.rts_registered.is_some());
+    }
+
+    #[test]
+    fn missing_binary_is_fail() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        write_config(
+            home.path(),
+            "mcpServers:\n  - name: rts\n    command: /nope/rts-mcp\n",
+        );
+        let f = detect_impl(&mk_ctx(), Some(home.path()), Some(ws.path()));
+        let row = f
+            .rows
+            .iter()
+            .find(|r| r.label == "continue:user_scope")
+            .expect("user_scope row");
+        assert_eq!(row.kind, RowKind::Fail);
+        assert_eq!(row.fix.as_ref().unwrap().class, FixClass::FixMcpBinaryPath);
+    }
+
+    #[test]
+    fn malformed_yaml_warns() {
+        let home = tempdir().unwrap();
+        let ws = tempdir().unwrap();
+        write_config(home.path(), "mcpServers: [unclosed");
+        let f = detect_impl(&mk_ctx(), Some(home.path()), Some(ws.path()));
+        let row = f
+            .rows
+            .iter()
+            .find(|r| r.label == "continue:user_scope")
+            .expect("user_scope row");
+        assert_eq!(row.kind, RowKind::Warn);
     }
 }

--- a/crates/rts-bench/src/doctor/hosts/continue_.rs
+++ b/crates/rts-bench/src/doctor/hosts/continue_.rs
@@ -46,10 +46,7 @@ pub(crate) fn detect_impl(
     // we surface a row per scope so users can see which file declared it.
     let mut candidates: Vec<(&'static str, PathBuf)> = Vec::new();
     if let Some(ws) = workspace {
-        candidates.push((
-            "project_scope",
-            ws.join(".continue").join("config.yaml"),
-        ));
+        candidates.push(("project_scope", ws.join(".continue").join("config.yaml")));
     }
     if let Some(h) = home {
         candidates.push(("user_scope", h.join(".continue").join("config.yaml")));
@@ -119,14 +116,17 @@ pub(crate) fn detect_impl(
             },
             Err(msg) => {
                 finding.rows.push(
-                    Row::warn(label, format!("could not parse {}: {}", path.display(), msg))
-                        .with_fix(
-                            FixSnippet::new(
-                                FixClass::FixConfigSyntax,
-                                format!("$EDITOR {}", path.display()),
-                            )
-                            .with_description("fix YAML syntax in Continue config"),
-                        ),
+                    Row::warn(
+                        label,
+                        format!("could not parse {}: {}", path.display(), msg),
+                    )
+                    .with_fix(
+                        FixSnippet::new(
+                            FixClass::FixConfigSyntax,
+                            format!("$EDITOR {}", path.display()),
+                        )
+                        .with_description("fix YAML syntax in Continue config"),
+                    ),
                 );
             }
         }

--- a/crates/rts-bench/src/doctor/hosts/cursor.rs
+++ b/crates/rts-bench/src/doctor/hosts/cursor.rs
@@ -73,10 +73,7 @@ pub(crate) fn detect_impl(_ctx: &Ctx, home: Option<&Path>) -> HostFinding {
         }
     };
 
-    let entry = value
-        .get("mcpServers")
-        .and_then(|v| v.get("rts"))
-        .cloned();
+    let entry = value.get("mcpServers").and_then(|v| v.get("rts")).cloned();
     let Some(entry) = entry else {
         finding.rows.push(Row::info(
             "cursor:user_scope",
@@ -113,7 +110,10 @@ pub(crate) fn detect_impl(_ctx: &Ctx, home: Option<&Path>) -> HostFinding {
                 .with_fix(
                     FixSnippet::new(
                         FixClass::FixMcpBinaryPath,
-                        format!("$EDITOR {}  # update mcpServers.rts.command", path.display()),
+                        format!(
+                            "$EDITOR {}  # update mcpServers.rts.command",
+                            path.display()
+                        ),
                     )
                     .with_description("point Cursor's rts entry at an existing binary"),
                 ),

--- a/crates/rts-bench/src/doctor/hosts/cursor.rs
+++ b/crates/rts-bench/src/doctor/hosts/cursor.rs
@@ -1,0 +1,23 @@
+//! Cursor MCP-registration detector. Hard-detect at `~/.cursor/mcp.json`
+//! (per `docs/install.md`). U7 implements.
+
+use crate::doctor::ctx::Ctx;
+use super::{DetectionClass, HostDetector, HostFinding};
+
+pub struct Cursor;
+
+impl HostDetector for Cursor {
+    fn host_name(&self) -> &'static str {
+        "cursor"
+    }
+    fn detection_class(&self) -> DetectionClass {
+        DetectionClass::Hard
+    }
+    fn detect(&self, _ctx: &Ctx) -> HostFinding {
+        HostFinding::skipped(
+            self.host_name(),
+            self.detection_class(),
+            "not yet implemented (U7)",
+        )
+    }
+}

--- a/crates/rts-bench/src/doctor/hosts/cursor.rs
+++ b/crates/rts-bench/src/doctor/hosts/cursor.rs
@@ -1,8 +1,12 @@
 //! Cursor MCP-registration detector. Hard-detect at `~/.cursor/mcp.json`
-//! (per `docs/install.md`). U7 implements.
+//! (per `docs/install.md`).
 
+use std::path::{Path, PathBuf};
+
+use super::{DetectionClass, HostDetector, HostFinding, RegistrationDetail};
 use crate::doctor::ctx::Ctx;
-use super::{DetectionClass, HostDetector, HostFinding};
+use crate::doctor::hosts::claude_code::binary_resolves;
+use crate::doctor::report::{FixClass, FixSnippet, Row};
 
 pub struct Cursor;
 
@@ -13,11 +17,205 @@ impl HostDetector for Cursor {
     fn detection_class(&self) -> DetectionClass {
         DetectionClass::Hard
     }
-    fn detect(&self, _ctx: &Ctx) -> HostFinding {
-        HostFinding::skipped(
-            self.host_name(),
-            self.detection_class(),
-            "not yet implemented (U7)",
+    fn detect(&self, ctx: &Ctx) -> HostFinding {
+        detect_impl(ctx, ctx.home.as_deref())
+    }
+}
+
+pub(crate) fn detect_impl(_ctx: &Ctx, home: Option<&Path>) -> HostFinding {
+    let Some(h) = home else {
+        return HostFinding::skipped("cursor", DetectionClass::Hard, "no home directory");
+    };
+    let path = h.join(".cursor").join("mcp.json");
+    if !path.exists() {
+        return HostFinding::skipped("cursor", DetectionClass::Hard, "not installed");
+    }
+
+    let mut finding = HostFinding {
+        host_name: "cursor",
+        detection_class: DetectionClass::Hard,
+        rows: Vec::new(),
+        rts_registered: None,
+        skipped_reason: None,
+    };
+
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            finding.rows.push(Row::warn(
+                "cursor:user_scope",
+                if e.kind() == std::io::ErrorKind::PermissionDenied {
+                    format!("permission denied reading {}", path.display())
+                } else {
+                    format!("read error on {}: {}", path.display(), e)
+                },
+            ));
+            return finding;
+        }
+    };
+    let value: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            finding.rows.push(
+                Row::warn(
+                    "cursor:user_scope",
+                    format!("could not parse {}: {}", path.display(), e),
+                )
+                .with_fix(
+                    FixSnippet::new(
+                        FixClass::FixConfigSyntax,
+                        format!("$EDITOR {}", path.display()),
+                    )
+                    .with_description("fix JSON syntax in Cursor's mcp.json"),
+                ),
+            );
+            return finding;
+        }
+    };
+
+    let entry = value
+        .get("mcpServers")
+        .and_then(|v| v.get("rts"))
+        .cloned();
+    let Some(entry) = entry else {
+        finding.rows.push(Row::info(
+            "cursor:user_scope",
+            format!("rts not registered in {}", path.display()),
+        ));
+        return finding;
+    };
+    let command = entry
+        .get("command")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    if let Some(cmd) = command.as_deref() {
+        if binary_resolves(cmd) {
+            finding.rows.push(Row::ok(
+                "cursor:user_scope",
+                format!("rts registered ({}) in {}", cmd, path.display()),
+            ));
+            finding.rts_registered = Some(RegistrationDetail {
+                scope: "user_scope".to_string(),
+                binary_path: Some(PathBuf::from(cmd)),
+                config_path: path.clone(),
+            });
+        } else {
+            finding.rows.push(
+                Row::fail(
+                    "cursor:user_scope",
+                    format!(
+                        "rts registered in {} but binary {} not found",
+                        path.display(),
+                        cmd
+                    ),
+                )
+                .with_fix(
+                    FixSnippet::new(
+                        FixClass::FixMcpBinaryPath,
+                        format!("$EDITOR {}  # update mcpServers.rts.command", path.display()),
+                    )
+                    .with_description("point Cursor's rts entry at an existing binary"),
+                ),
+            );
+            // Still record the registration so the orchestrator sees it.
+            finding.rts_registered = Some(RegistrationDetail {
+                scope: "user_scope".to_string(),
+                binary_path: Some(PathBuf::from(cmd)),
+                config_path: path.clone(),
+            });
+        }
+    } else {
+        finding.rows.push(Row::warn(
+            "cursor:user_scope",
+            format!("rts entry in {} has no `command`", path.display()),
+        ));
+    }
+
+    finding
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::report::RowKind;
+    use crate::doctor::{DoctorArgs, DoctorOutput};
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn mk_ctx() -> Ctx {
+        Ctx::build(&DoctorArgs {
+            output: DoctorOutput::Json,
+            no_color: true,
+            workspace: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn absent_config_is_skipped() {
+        let home = tempdir().unwrap();
+        let f = detect_impl(&mk_ctx(), Some(home.path()));
+        assert!(f.skipped_reason.is_some());
+    }
+
+    #[test]
+    fn registered_with_resolving_binary_is_ok() {
+        let home = tempdir().unwrap();
+        let bin = home.path().join("rts-mcp");
+        fs::write(&bin, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let cfg = home.path().join(".cursor").join("mcp.json");
+        fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        fs::write(
+            &cfg,
+            format!(
+                r#"{{ "mcpServers": {{ "rts": {{ "command": "{}" }} }} }}"#,
+                bin.display()
+            ),
         )
+        .unwrap();
+        let f = detect_impl(&mk_ctx(), Some(home.path()));
+        assert!(f.rows.iter().any(|r| r.kind == RowKind::Ok));
+        assert!(f.rts_registered.is_some());
+    }
+
+    #[test]
+    fn missing_binary_is_fail_with_fix_class() {
+        let home = tempdir().unwrap();
+        let cfg = home.path().join(".cursor").join("mcp.json");
+        fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        fs::write(
+            &cfg,
+            r#"{ "mcpServers": { "rts": { "command": "/nope/rts-mcp" } } }"#,
+        )
+        .unwrap();
+        let f = detect_impl(&mk_ctx(), Some(home.path()));
+        let row = f
+            .rows
+            .iter()
+            .find(|r| r.label == "cursor:user_scope")
+            .expect("user_scope row");
+        assert_eq!(row.kind, RowKind::Fail);
+        assert_eq!(row.fix.as_ref().unwrap().class, FixClass::FixMcpBinaryPath);
+    }
+
+    #[test]
+    fn malformed_json_warns_not_fails() {
+        let home = tempdir().unwrap();
+        let cfg = home.path().join(".cursor").join("mcp.json");
+        fs::create_dir_all(cfg.parent().unwrap()).unwrap();
+        fs::write(&cfg, "not json").unwrap();
+        let f = detect_impl(&mk_ctx(), Some(home.path()));
+        let row = f
+            .rows
+            .iter()
+            .find(|r| r.label == "cursor:user_scope")
+            .expect("user_scope row");
+        assert_eq!(row.kind, RowKind::Warn);
     }
 }

--- a/crates/rts-bench/src/doctor/hosts/mod.rs
+++ b/crates/rts-bench/src/doctor/hosts/mod.rs
@@ -1,0 +1,80 @@
+//! Per-host MCP-registration detectors. U7 wires the dispatcher and
+//! per-host implementations; this file defines the shared trait so
+//! sub-agents can implement hosts independently against a stable
+//! interface.
+
+use std::path::PathBuf;
+
+use crate::doctor::ctx::Ctx;
+use crate::doctor::report::Row;
+
+pub mod aider;
+pub mod claude_code;
+pub mod cline;
+pub mod continue_;
+pub mod cursor;
+
+/// Detection class for each host. Hard hosts have canonical config-file
+/// paths; soft hosts use best-effort discovery (file existence,
+/// CLI-flag scan, VS Code extension state).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DetectionClass {
+    Hard,
+    Soft,
+}
+
+/// One host's discovery result. The host implementer collects rows
+/// (per-scope OK/WARN/FAIL findings) plus an optional registration
+/// detail used by the orchestrator's cross-host policies (e.g.
+/// "Claude Code's user-scope and project-scope point at different
+/// rts binaries").
+#[derive(Clone, Debug)]
+pub struct HostFinding {
+    pub host_name: &'static str,
+    pub detection_class: DetectionClass,
+    pub rows: Vec<Row>,
+    /// Populated when an rts MCP entry was found. None when not
+    /// installed or undetected. Multi-scope hosts (Claude Code) may
+    /// have multiple entries; in that case `rts_registered` carries
+    /// the first one and per-scope rows enumerate the rest.
+    pub rts_registered: Option<RegistrationDetail>,
+    /// Set when discovery aborted with a recoverable reason
+    /// ("permission denied", "not installed"). The orchestrator
+    /// surfaces these as partial-failures on the parent section.
+    pub skipped_reason: Option<String>,
+}
+
+impl HostFinding {
+    pub fn skipped(name: &'static str, class: DetectionClass, reason: impl Into<String>) -> Self {
+        Self {
+            host_name: name,
+            detection_class: class,
+            rows: Vec::new(),
+            rts_registered: None,
+            skipped_reason: Some(reason.into()),
+        }
+    }
+}
+
+/// Where rts was found, and at what version/binary path. Used by
+/// the orchestrator to detect cross-scope version drift.
+#[derive(Clone, Debug)]
+pub struct RegistrationDetail {
+    /// e.g. `"user_scope"`, `"project_scope"`, `"vs_code_extension"`.
+    pub scope: String,
+    /// The MCP `command` value, typically an absolute path to a
+    /// `rts-mcp` binary (or a `cargo run` invocation).
+    pub binary_path: Option<PathBuf>,
+    /// Path to the host's config file that declared the registration.
+    pub config_path: PathBuf,
+}
+
+/// Host detector contract. Each implementation reads its host's
+/// canonical config path(s), returns a `HostFinding`. Implementations
+/// must NOT panic on malformed input; surface parse errors as
+/// `skipped_reason` or as WARN rows.
+pub trait HostDetector {
+    fn host_name(&self) -> &'static str;
+    fn detection_class(&self) -> DetectionClass;
+    fn detect(&self, ctx: &Ctx) -> HostFinding;
+}

--- a/crates/rts-bench/src/doctor/hosts/mod.rs
+++ b/crates/rts-bench/src/doctor/hosts/mod.rs
@@ -29,6 +29,7 @@ pub enum DetectionClass {
 /// "Claude Code's user-scope and project-scope point at different
 /// rts binaries").
 #[derive(Clone, Debug)]
+#[allow(dead_code)] // detection_class is part of the public contract; U9 reads it.
 pub struct HostFinding {
     pub host_name: &'static str,
     pub detection_class: DetectionClass,
@@ -59,6 +60,7 @@ impl HostFinding {
 /// Where rts was found, and at what version/binary path. Used by
 /// the orchestrator to detect cross-scope version drift.
 #[derive(Clone, Debug)]
+#[allow(dead_code)] // scope/binary_path/config_path consumed by U9 fix-snippet rendering.
 pub struct RegistrationDetail {
     /// e.g. `"user_scope"`, `"project_scope"`, `"vs_code_extension"`.
     pub scope: String,

--- a/crates/rts-bench/src/doctor/mcp_section.rs
+++ b/crates/rts-bench/src/doctor/mcp_section.rs
@@ -8,8 +8,8 @@
 
 use super::ctx::Ctx;
 use super::hosts::{
-    aider::Aider, claude_code::ClaudeCode, cline::Cline, continue_::Continue, cursor::Cursor,
-    HostDetector, HostFinding,
+    HostDetector, HostFinding, aider::Aider, claude_code::ClaudeCode, cline::Cline,
+    continue_::Continue, cursor::Cursor,
 };
 use super::report::{Row, SectionReport};
 
@@ -19,13 +19,7 @@ pub fn run(ctx: &Ctx) -> SectionReport {
     // Detector order matches docs/install.md's wiring order: Claude
     // Code first (canonical), then Cursor / Cline / Aider / Continue.
     // Doctor's row stream is stable across runs because this list is.
-    let detectors: [&dyn HostDetector; 5] = [
-        &ClaudeCode,
-        &Cursor,
-        &Continue,
-        &Aider,
-        &Cline,
-    ];
+    let detectors: [&dyn HostDetector; 5] = [&ClaudeCode, &Cursor, &Continue, &Aider, &Cline];
 
     let mut findings: Vec<HostFinding> = Vec::with_capacity(detectors.len());
     for d in detectors {
@@ -110,11 +104,7 @@ fn claude_code_drift_row(cc: &HostFinding) -> Option<Row> {
         }
     }
     if paths.len() >= 2 {
-        let joined = paths
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>()
-            .join(", ");
+        let joined = paths.iter().cloned().collect::<Vec<_>>().join(", ");
         Some(Row::warn(
             "claude_code:multi_scope_drift",
             format!(

--- a/crates/rts-bench/src/doctor/mcp_section.rs
+++ b/crates/rts-bench/src/doctor/mcp_section.rs
@@ -1,0 +1,16 @@
+//! `mcp_registration` section — dispatches to per-host detectors and
+//! aggregates their results. Cross-host policies (e.g. Claude Code
+//! multi-scope version drift) computed here on the union of host
+//! findings. U7 implements.
+
+use super::ctx::Ctx;
+use super::report::{Row, SectionReport};
+
+pub fn run(_ctx: &Ctx) -> SectionReport {
+    let mut s = SectionReport::new("mcp_registration");
+    s.push(Row::info(
+        "mcp_registration:placeholder",
+        "mcp_registration section not yet implemented",
+    ));
+    s
+}

--- a/crates/rts-bench/src/doctor/mcp_section.rs
+++ b/crates/rts-bench/src/doctor/mcp_section.rs
@@ -1,16 +1,218 @@
 //! `mcp_registration` section — dispatches to per-host detectors and
-//! aggregates their results. Cross-host policies (e.g. Claude Code
-//! multi-scope version drift) computed here on the union of host
-//! findings. U7 implements.
+//! aggregates their results. Cross-host policies (Claude Code multi-scope
+//! version drift) are computed here on the union of host findings.
+//!
+//! Each detector runs sequentially; per-host work is dominated by
+//! filesystem reads of small JSON/YAML files, so the savings from
+//! threading would not be observable inside doctor's <500 ms budget.
 
 use super::ctx::Ctx;
+use super::hosts::{
+    aider::Aider, claude_code::ClaudeCode, cline::Cline, continue_::Continue, cursor::Cursor,
+    HostDetector, HostFinding,
+};
 use super::report::{Row, SectionReport};
 
-pub fn run(_ctx: &Ctx) -> SectionReport {
-    let mut s = SectionReport::new("mcp_registration");
-    s.push(Row::info(
-        "mcp_registration:placeholder",
-        "mcp_registration section not yet implemented",
-    ));
-    s
+pub fn run(ctx: &Ctx) -> SectionReport {
+    let mut section = SectionReport::new("mcp_registration");
+
+    // Detector order matches docs/install.md's wiring order: Claude
+    // Code first (canonical), then Cursor / Cline / Aider / Continue.
+    // Doctor's row stream is stable across runs because this list is.
+    let detectors: [&dyn HostDetector; 5] = [
+        &ClaudeCode,
+        &Cursor,
+        &Continue,
+        &Aider,
+        &Cline,
+    ];
+
+    let mut findings: Vec<HostFinding> = Vec::with_capacity(detectors.len());
+    for d in detectors {
+        let f = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| d.detect(ctx)))
+            .unwrap_or_else(|_| {
+                let mut hf = HostFinding {
+                    host_name: d.host_name(),
+                    detection_class: d.detection_class(),
+                    rows: Vec::new(),
+                    rts_registered: None,
+                    skipped_reason: Some("detector panicked".to_string()),
+                };
+                hf.rows.push(Row::warn(
+                    format!("{}:detect", d.host_name()),
+                    "detector panicked; treating host as not installed",
+                ));
+                hf
+            });
+        findings.push(f);
+    }
+
+    // Cross-host policy: Claude Code multi-scope drift. If Claude Code
+    // produced multiple OK / FAIL rows across distinct scopes that point
+    // at different binary paths, surface a WARN row synthesizing the
+    // drift. We read this off the row stream rather than carrying a
+    // separate list, so the policy stays self-contained.
+    if let Some(cc) = findings.iter().find(|f| f.host_name == "claude_code") {
+        if let Some(drift_row) = claude_code_drift_row(cc) {
+            section.push(drift_row);
+        }
+    }
+
+    for f in findings {
+        // Per-host skipped_reason surfaces as a partial-failure
+        // annotation; doctor exit code stays unaffected.
+        if let Some(reason) = &f.skipped_reason {
+            section.push_partial_failure(format!("{}:skipped", f.host_name), reason);
+            // For absent hard hosts the detector emits no rows; add a
+            // single `[?]` info row so the user sees that we checked.
+            // Soft hosts already emit their own `[?]` row.
+            if f.rows.is_empty() {
+                section.push(Row::info(
+                    format!("{}:skipped", f.host_name),
+                    format!("{} ({})", f.host_name, reason),
+                ));
+            }
+        }
+        for row in f.rows {
+            section.push(row);
+        }
+    }
+
+    section
+}
+
+/// Inspect a Claude Code finding for cross-scope binary drift. Returns
+/// `Some(warn_row)` when ≥2 scopes register rts at distinct paths.
+fn claude_code_drift_row(cc: &HostFinding) -> Option<Row> {
+    use std::collections::BTreeSet;
+
+    // Collect distinct binary paths mentioned in successful (OK or FAIL)
+    // scope rows. The detector only carries the *first* registration in
+    // `rts_registered`, so we parse the row messages here. Since the
+    // detector's message format is stable (`"rts registered (PATH) ..."`),
+    // a tiny prefix match is enough.
+    let mut paths: BTreeSet<String> = BTreeSet::new();
+    for row in &cc.rows {
+        if !row.label.starts_with("claude_code:") {
+            continue;
+        }
+        if let Some(start) = row.message.find("rts registered (") {
+            let rest = &row.message[start + "rts registered (".len()..];
+            if let Some(end) = rest.find(')') {
+                paths.insert(rest[..end].to_string());
+            }
+        } else if let Some(idx) = row.message.find("but binary ") {
+            // FAIL form: "rts registered in CONFIG but binary BIN not found"
+            let rest = &row.message[idx + "but binary ".len()..];
+            if let Some(end) = rest.find(' ') {
+                paths.insert(rest[..end].to_string());
+            }
+        }
+    }
+    if paths.len() >= 2 {
+        let joined = paths
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        Some(Row::warn(
+            "claude_code:multi_scope_drift",
+            format!(
+                "Claude Code registers rts at multiple distinct binaries across scopes: {}",
+                joined
+            ),
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::report::RowKind;
+    use crate::doctor::{DoctorArgs, DoctorOutput};
+
+    fn mk_ctx() -> Ctx {
+        Ctx::build(&DoctorArgs {
+            output: DoctorOutput::Json,
+            no_color: true,
+            workspace: None,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn section_runs_all_five_detectors() {
+        // Without a tempdir fixture set, all detectors should still
+        // run without panicking and produce a SectionReport.
+        let ctx = mk_ctx();
+        let s = run(&ctx);
+        assert_eq!(s.name, "mcp_registration");
+        // Soft hosts (Aider, Cline) emit at least an info row each
+        // even on a bare system, so the section is non-empty.
+        assert!(!s.rows.is_empty(), "expected at least soft-host rows");
+    }
+
+    #[test]
+    fn drift_row_emitted_for_multi_scope_finding() {
+        // Build a synthetic Claude Code HostFinding with two scope rows
+        // pointing at different binaries.
+        let mut cc = HostFinding {
+            host_name: "claude_code",
+            detection_class: crate::doctor::hosts::DetectionClass::Hard,
+            rows: Vec::new(),
+            rts_registered: None,
+            skipped_reason: None,
+        };
+        cc.rows.push(Row::ok(
+            "claude_code:user_scope",
+            "rts registered (/opt/a/rts-mcp) via /home/u/.claude.json",
+        ));
+        cc.rows.push(Row::ok(
+            "claude_code:project_scope",
+            "rts registered (/opt/b/rts-mcp) via /ws/.mcp.json",
+        ));
+        let drift = claude_code_drift_row(&cc).expect("drift detected");
+        assert_eq!(drift.kind, RowKind::Warn);
+        assert_eq!(drift.label, "claude_code:multi_scope_drift");
+        assert!(drift.message.contains("/opt/a/rts-mcp"));
+        assert!(drift.message.contains("/opt/b/rts-mcp"));
+    }
+
+    #[test]
+    fn no_drift_when_single_scope() {
+        let mut cc = HostFinding {
+            host_name: "claude_code",
+            detection_class: crate::doctor::hosts::DetectionClass::Hard,
+            rows: Vec::new(),
+            rts_registered: None,
+            skipped_reason: None,
+        };
+        cc.rows.push(Row::ok(
+            "claude_code:user_scope",
+            "rts registered (/opt/a/rts-mcp) via ~/.claude.json",
+        ));
+        assert!(claude_code_drift_row(&cc).is_none());
+    }
+
+    #[test]
+    fn no_drift_when_same_binary_in_two_scopes() {
+        let mut cc = HostFinding {
+            host_name: "claude_code",
+            detection_class: crate::doctor::hosts::DetectionClass::Hard,
+            rows: Vec::new(),
+            rts_registered: None,
+            skipped_reason: None,
+        };
+        cc.rows.push(Row::ok(
+            "claude_code:user_scope",
+            "rts registered (/opt/a/rts-mcp) via ~/.claude.json",
+        ));
+        cc.rows.push(Row::ok(
+            "claude_code:project_scope",
+            "rts registered (/opt/a/rts-mcp) via /ws/.mcp.json",
+        ));
+        assert!(claude_code_drift_row(&cc).is_none());
+    }
 }

--- a/crates/rts-bench/src/doctor/mod.rs
+++ b/crates/rts-bench/src/doctor/mod.rs
@@ -65,9 +65,7 @@ pub async fn run(args: DoctorArgs) -> i32 {
             Ok(ctx) => ctx,
             Err(e) => {
                 eprintln!("rts-bench doctor: failed to initialize context: {e}");
-                return DoctorReport::self_error(format!(
-                    "context init failed: {e}"
-                ));
+                return DoctorReport::self_error(format!("context init failed: {e}"));
             }
         };
 

--- a/crates/rts-bench/src/doctor/mod.rs
+++ b/crates/rts-bench/src/doctor/mod.rs
@@ -1,0 +1,119 @@
+//! `rts-bench doctor` — read-only first-run health check.
+//!
+//! Inspects rts install state (binary version, daemon reachability, MCP
+//! registration in 5 agent hosts, hook file presence) and per-workspace
+//! index state (daemon PID, pinned-workspace path, index generation,
+//! cold-walk completion). Prints OK/WARN/FAIL rows with copy-pasteable
+//! one-line fix snippets.
+//!
+//! See `docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md` for the
+//! full plan; `docs/doctor-schema.md` (added in U10) for the wire shape.
+
+use std::path::PathBuf;
+
+use clap::ValueEnum;
+
+pub mod ctx;
+pub mod render;
+pub mod report;
+
+pub mod binary_section;
+pub mod daemon_section;
+pub mod mcp_section;
+pub mod nudge_hook;
+pub mod workspace_section;
+
+pub mod hosts;
+
+use ctx::Ctx;
+use report::{DoctorReport, ExitClass};
+
+/// Output format for `rts-bench doctor`.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum DoctorOutput {
+    /// Human-readable OK/WARN/FAIL checklist with inline fix snippets.
+    /// Default. ANSI color when stdout is a TTY and NO_COLOR is unset.
+    Human,
+    /// Machine-readable JSON. `schema_version: "doctor-v0"`. Stable
+    /// across patch releases; additive evolution via `capabilities`.
+    Json,
+}
+
+/// Clap-derived input arguments threaded down from `main.rs`.
+#[derive(Debug, Clone)]
+pub struct DoctorArgs {
+    pub output: DoctorOutput,
+    pub no_color: bool,
+    pub workspace: Option<PathBuf>,
+}
+
+/// Doctor's runtime entry. Returns the process exit code per the
+/// documented contract:
+/// - 0 — no FAIL rows (any WARN allowed)
+/// - 1 — at least one FAIL row
+/// - 2 — doctor itself panicked or its own I/O failed
+///
+/// `>= 3` is reserved; CI gates must not depend on specific values
+/// above 2.
+pub async fn run(args: DoctorArgs) -> i32 {
+    // Wrap the whole run in catch_unwind so a panic in any section
+    // becomes exit code 2 with a structured `error` envelope in JSON
+    // mode, rather than a crash. This is the contract from plan U9 /
+    // AC13 — section panics are recoverable, doctor itself stays alive.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let ctx = match Ctx::build(&args) {
+            Ok(ctx) => ctx,
+            Err(e) => {
+                eprintln!("rts-bench doctor: failed to initialize context: {e}");
+                return DoctorReport::self_error(format!(
+                    "context init failed: {e}"
+                ));
+            }
+        };
+
+        // Section dispatch in normative order. Each section returns a
+        // SectionReport; cross-section state (e.g. daemon.rs populates
+        // the Stats response that workspace_section.rs reads) is
+        // threaded via Ctx, which sections are allowed to mutate.
+        let mut ctx = ctx;
+        let mut sections = Vec::with_capacity(5);
+        sections.push(binary_section::run(&ctx));
+        sections.push(daemon_section::run(&mut ctx));
+        sections.push(mcp_section::run(&ctx));
+        sections.push(nudge_hook::run(&ctx));
+        sections.push(workspace_section::run(&ctx));
+
+        DoctorReport::from_sections(sections)
+    }));
+
+    let report = match result {
+        Ok(report) => report,
+        Err(panic) => {
+            let msg = panic
+                .downcast_ref::<&'static str>()
+                .map(|s| s.to_string())
+                .or_else(|| panic.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "doctor panicked".to_string());
+            DoctorReport::self_error(msg)
+        }
+    };
+
+    // Render. JSON always succeeds (serde never errors on well-formed
+    // input); human render is also infallible.
+    match args.output {
+        DoctorOutput::Json => render::render_json(&report, &mut std::io::stdout()),
+        DoctorOutput::Human => render::render_human(
+            &report,
+            &mut std::io::stdout(),
+            !args.no_color && std::env::var_os("NO_COLOR").is_none(),
+        ),
+    }
+
+    // Self-error path: stdout already received the JSON envelope (if
+    // requested); exit 2 regardless of section row contents.
+    match report.exit_class {
+        ExitClass::SelfError => 2,
+        ExitClass::Fail => 1,
+        ExitClass::Ok | ExitClass::Warn => 0,
+    }
+}

--- a/crates/rts-bench/src/doctor/mod.rs
+++ b/crates/rts-bench/src/doctor/mod.rs
@@ -76,12 +76,16 @@ pub async fn run(args: DoctorArgs) -> i32 {
         // the Stats response that workspace_section.rs reads) is
         // threaded via Ctx, which sections are allowed to mutate.
         let mut ctx = ctx;
-        let mut sections = Vec::with_capacity(5);
-        sections.push(binary_section::run(&ctx));
-        sections.push(daemon_section::run(&mut ctx));
-        sections.push(mcp_section::run(&ctx));
-        sections.push(nudge_hook::run(&ctx));
-        sections.push(workspace_section::run(&ctx));
+        // Build the section list explicitly so the daemon section can
+        // mutate `ctx.daemon_stats` before workspace_section reads it.
+        // The `vec![]` macro can't sequence `&` vs `&mut` borrows of the
+        // same Ctx; we accumulate one section at a time.
+        let binary = binary_section::run(&ctx);
+        let daemon = daemon_section::run(&mut ctx);
+        let mcp = mcp_section::run(&ctx);
+        let hook = nudge_hook::run(&ctx);
+        let workspace = workspace_section::run(&ctx);
+        let sections = vec![binary, daemon, mcp, hook, workspace];
 
         DoctorReport::from_sections(sections)
     }));

--- a/crates/rts-bench/src/doctor/nudge_hook.rs
+++ b/crates/rts-bench/src/doctor/nudge_hook.rs
@@ -58,11 +58,7 @@ fn check_hook(hook_path: &Path, doctor_version: &str, s: &mut SectionReport) {
         Err(_) => {
             // Absent (or unreadable — same remediation either way).
             s.push(
-                Row::warn(
-                    "hook:absent",
-                    "PreToolUse nudge hook not installed",
-                )
-                .with_fix(
+                Row::warn("hook:absent", "PreToolUse nudge hook not installed").with_fix(
                     FixSnippet::new(
                         FixClass::UpdateHook,
                         format!(
@@ -88,12 +84,10 @@ register it in .claude/settings.json — see docs/install.md)",
                 "hook:not_executable",
                 "hook not executable; chmod +x required",
             )
-            .with_fix(
-                FixSnippet::new(
-                    FixClass::MakeHookExecutable,
-                    format!("chmod +x {}", hook_path.display()),
-                ),
-            ),
+            .with_fix(FixSnippet::new(
+                FixClass::MakeHookExecutable,
+                format!("chmod +x {}", hook_path.display()),
+            )),
         );
         return;
     }
@@ -129,10 +123,7 @@ register it in .claude/settings.json — see docs/install.md)",
         Some(hook_version) if hook_version == doctor_version => {
             s.push(Row::ok(
                 "hook:current",
-                format!(
-                    "hook installed and current (v{ver})",
-                    ver = hook_version
-                ),
+                format!("hook installed and current (v{ver})", ver = hook_version),
             ));
         }
         Some(hook_version) => {
@@ -207,10 +198,10 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use super::super::ctx::Ctx;
-    use super::super::report::RowKind;
     use super::super::DoctorArgs;
     use super::super::DoctorOutput;
+    use super::super::ctx::Ctx;
+    use super::super::report::RowKind;
 
     /// Construct a `Ctx` rooted at `workspace`. We can't go through
     /// `Ctx::build` because it canonicalizes via `current_dir()` and
@@ -409,8 +400,8 @@ mod tests {
             // fail (this test is a guardrail for the repo, not the crate).
             return;
         };
-        let marker = parse_version_marker(&body)
-            .expect("workspace hook must carry a `# version:` marker");
+        let marker =
+            parse_version_marker(&body).expect("workspace hook must carry a `# version:` marker");
         assert_eq!(
             marker,
             env!("CARGO_PKG_VERSION"),

--- a/crates/rts-bench/src/doctor/nudge_hook.rs
+++ b/crates/rts-bench/src/doctor/nudge_hook.rs
@@ -1,14 +1,426 @@
 //! `hook` section — `.claude/hooks/rts-nudge.sh` presence,
-//! executability, version-marker match. U8 implements.
+//! executability, version-marker match.
+//!
+//! Four observable states (in worsening-to-best order of "looks like a
+//! drift"):
+//!
+//!   1. No workspace → single `[?]` info row; we can't check anything.
+//!   2. Hook file absent → `[WARN]` + install-fix snippet.
+//!   3. Hook present but not executable → `[WARN]` + `chmod +x` fix.
+//!   4. Hook present + executable but version marker missing or
+//!      mismatched against `ctx.doctor_version` → `[WARN]` + update fix.
+//!   5. Hook present + executable + version marker matches → `[OK]`.
+//!
+//! The version marker is a single line near the top of the hook file
+//! shaped `# version: <semver>`. Adding the marker to the hook itself
+//! is part of U8 — see `.claude/hooks/rts-nudge.sh`. The marker is a
+//! soft-drift signal: when the hook bundled with the user's workspace
+//! diverges from the version doctor was compiled against, we don't
+//! know whether the drift matters, only that the maintainer may want
+//! to refresh the hook.
+
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use super::ctx::Ctx;
-use super::report::{Row, SectionReport};
+use super::report::{FixClass, FixSnippet, Row, SectionReport};
 
-pub fn run(_ctx: &Ctx) -> SectionReport {
+/// Relative path inside the workspace where the PreToolUse nudge hook
+/// lives. Kept as a constant so the test helpers and the runtime check
+/// can never drift.
+const HOOK_REL_PATH: &str = ".claude/hooks/rts-nudge.sh";
+
+pub fn run(ctx: &Ctx) -> SectionReport {
     let mut s = SectionReport::new("hook");
-    s.push(Row::info(
-        "hook:placeholder",
-        "hook section not yet implemented",
-    ));
+
+    let workspace = match ctx.workspace_path.as_deref() {
+        Some(p) => p,
+        None => {
+            s.push(Row::info(
+                "hook:no_workspace",
+                "no workspace; cannot check hook",
+            ));
+            return s;
+        }
+    };
+
+    let hook_path: PathBuf = workspace.join(HOOK_REL_PATH);
+    check_hook(&hook_path, ctx.doctor_version, &mut s);
     s
+}
+
+/// Inspect `hook_path` and push one row reflecting the highest-
+/// severity observation. Extracted from `run` so tests can drive it
+/// against synthetic temp dirs without constructing a full `Ctx`.
+fn check_hook(hook_path: &Path, doctor_version: &str, s: &mut SectionReport) {
+    let meta = match fs::metadata(hook_path) {
+        Ok(m) => m,
+        Err(_) => {
+            // Absent (or unreadable — same remediation either way).
+            s.push(
+                Row::warn(
+                    "hook:absent",
+                    "PreToolUse nudge hook not installed",
+                )
+                .with_fix(
+                    FixSnippet::new(
+                        FixClass::UpdateHook,
+                        format!(
+                            "mkdir -p .claude/hooks && curl -fsSL \
+https://raw.githubusercontent.com/yourusername/rust_tree_sitter/main/.claude/hooks/rts-nudge.sh \
+-o {rel} && chmod +x {rel}",
+                            rel = HOOK_REL_PATH
+                        ),
+                    )
+                    .with_description(
+                        "install the bundled PreToolUse nudge hook (also \
+register it in .claude/settings.json — see docs/install.md)",
+                    ),
+                ),
+            );
+            return;
+        }
+    };
+
+    if !is_executable(&meta) {
+        s.push(
+            Row::warn(
+                "hook:not_executable",
+                "hook not executable; chmod +x required",
+            )
+            .with_fix(
+                FixSnippet::new(
+                    FixClass::MakeHookExecutable,
+                    format!("chmod +x {}", hook_path.display()),
+                ),
+            ),
+        );
+        return;
+    }
+
+    // Present + executable: read the file and look for the version marker.
+    let contents = match fs::read_to_string(hook_path) {
+        Ok(c) => c,
+        Err(_) => {
+            // Unreadable on a path that fs::metadata said exists — treat
+            // as a soft "no marker" rather than escalating to FAIL. The
+            // operator can re-install with the same UpdateHook fix.
+            s.push(
+                Row::warn(
+                    "hook:unreadable",
+                    "hook present but unreadable; consider re-installing",
+                )
+                .with_fix(update_hook_fix(hook_path)),
+            );
+            return;
+        }
+    };
+
+    match parse_version_marker(&contents) {
+        None => {
+            s.push(
+                Row::warn(
+                    "hook:no_version_marker",
+                    "hook present but no version marker; consider updating",
+                )
+                .with_fix(update_hook_fix(hook_path)),
+            );
+        }
+        Some(hook_version) if hook_version == doctor_version => {
+            s.push(Row::ok(
+                "hook:current",
+                format!(
+                    "hook installed and current (v{ver})",
+                    ver = hook_version
+                ),
+            ));
+        }
+        Some(hook_version) => {
+            s.push(
+                Row::warn(
+                    "hook:version_mismatch",
+                    format!(
+                        "hook is v{old}, doctor is v{new}; consider updating",
+                        old = hook_version,
+                        new = doctor_version,
+                    ),
+                )
+                .with_fix(update_hook_fix(hook_path)),
+            );
+        }
+    }
+}
+
+/// Standard "refresh the hook from the upstream copy" fix snippet,
+/// reused across the no-marker / mismatch / unreadable paths.
+fn update_hook_fix(hook_path: &Path) -> FixSnippet {
+    FixSnippet::new(
+        FixClass::UpdateHook,
+        format!(
+            "curl -fsSL \
+https://raw.githubusercontent.com/yourusername/rust_tree_sitter/main/.claude/hooks/rts-nudge.sh \
+-o {path} && chmod +x {path}",
+            path = hook_path.display()
+        ),
+    )
+    .with_description("refresh the PreToolUse nudge hook to the bundled version")
+}
+
+/// Unix executable bit on owner. The hook is a bash script the user
+/// owns; we don't need to walk group/other or care about ACLs.
+#[cfg(unix)]
+fn is_executable(meta: &fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    meta.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn is_executable(_meta: &fs::Metadata) -> bool {
+    // On non-unix targets we don't enforce the executable bit (Windows
+    // doesn't have a meaningful one for shell scripts). Treat as
+    // executable so we fall through to the version-marker check.
+    true
+}
+
+/// Scan `contents` for a `# version: <semver>` line. The marker may be
+/// preceded by any whitespace; trailing whitespace is trimmed. We only
+/// look at the first 50 lines — the marker lives near the top and
+/// scanning further is wasted work on large hook files.
+fn parse_version_marker(contents: &str) -> Option<String> {
+    for line in contents.lines().take(50) {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("# version:") {
+            let ver = rest.trim();
+            if !ver.is_empty() {
+                return Some(ver.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    use tempfile::TempDir;
+
+    use super::super::ctx::Ctx;
+    use super::super::report::RowKind;
+    use super::super::DoctorArgs;
+    use super::super::DoctorOutput;
+
+    /// Construct a `Ctx` rooted at `workspace`. We can't go through
+    /// `Ctx::build` because it canonicalizes via `current_dir()` and
+    /// our tests need a deterministic synthetic root.
+    fn ctx_with_workspace(workspace: Option<PathBuf>) -> Ctx {
+        Ctx {
+            workspace_path: workspace,
+            home: None,
+            doctor_version: env!("CARGO_PKG_VERSION"),
+            color_enabled: false,
+            daemon_stats: None,
+            socket_path: None,
+        }
+    }
+
+    /// Write `body` to `<workspace>/.claude/hooks/rts-nudge.sh`,
+    /// creating parent dirs. `executable` toggles the owner-x bit.
+    fn write_hook(workspace: &Path, body: &str, executable: bool) -> PathBuf {
+        let hook = workspace.join(HOOK_REL_PATH);
+        fs::create_dir_all(hook.parent().unwrap()).unwrap();
+        fs::write(&hook, body).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = if executable { 0o755 } else { 0o644 };
+            fs::set_permissions(&hook, fs::Permissions::from_mode(mode)).unwrap();
+        }
+        let _ = executable;
+        hook
+    }
+
+    fn first_row(s: &SectionReport) -> &Row {
+        s.rows.first().expect("section must have at least one row")
+    }
+
+    #[test]
+    fn hook_absent_warns_and_provides_install_fix() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = ctx_with_workspace(Some(tmp.path().to_path_buf()));
+
+        let s = run(&ctx);
+        let row = first_row(&s);
+        assert_eq!(row.kind, RowKind::Warn);
+        assert_eq!(row.label, "hook:absent");
+        assert!(
+            row.message.contains("not installed"),
+            "message was: {}",
+            row.message
+        );
+        let fix = row.fix.as_ref().expect("absent hook must include a fix");
+        assert_eq!(fix.class, FixClass::UpdateHook);
+        assert!(
+            fix.command.contains("rts-nudge.sh"),
+            "fix command should reference the hook path: {}",
+            fix.command
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hook_present_non_executable_warns_chmod() {
+        let tmp = TempDir::new().unwrap();
+        write_hook(
+            tmp.path(),
+            "#!/usr/bin/env bash\n# version: 0.5.5\necho hi\n",
+            false,
+        );
+        let ctx = ctx_with_workspace(Some(tmp.path().to_path_buf()));
+
+        let s = run(&ctx);
+        let row = first_row(&s);
+        assert_eq!(row.kind, RowKind::Warn);
+        assert_eq!(row.label, "hook:not_executable");
+        let fix = row.fix.as_ref().expect("non-exec hook must include a fix");
+        assert_eq!(fix.class, FixClass::MakeHookExecutable);
+        assert!(
+            fix.command.starts_with("chmod +x "),
+            "fix command should be a chmod: {}",
+            fix.command
+        );
+    }
+
+    #[test]
+    fn hook_present_executable_no_version_marker_warns() {
+        let tmp = TempDir::new().unwrap();
+        // Body intentionally omits the marker.
+        write_hook(
+            tmp.path(),
+            "#!/usr/bin/env bash\n# rts-nudge.sh — no marker here\nexit 0\n",
+            true,
+        );
+        let ctx = ctx_with_workspace(Some(tmp.path().to_path_buf()));
+
+        let s = run(&ctx);
+        let row = first_row(&s);
+        assert_eq!(row.kind, RowKind::Warn);
+        assert_eq!(row.label, "hook:no_version_marker");
+        let fix = row.fix.as_ref().expect("no-marker hook must include a fix");
+        assert_eq!(fix.class, FixClass::UpdateHook);
+    }
+
+    #[test]
+    fn hook_present_executable_version_matches_ok() {
+        let tmp = TempDir::new().unwrap();
+        let body = format!(
+            "#!/usr/bin/env bash\n# version: {ver}\nexit 0\n",
+            ver = env!("CARGO_PKG_VERSION")
+        );
+        write_hook(tmp.path(), &body, true);
+        let ctx = ctx_with_workspace(Some(tmp.path().to_path_buf()));
+
+        let s = run(&ctx);
+        let row = first_row(&s);
+        assert_eq!(row.kind, RowKind::Ok);
+        assert_eq!(row.label, "hook:current");
+        assert!(row.fix.is_none(), "OK row must not carry a fix");
+        assert!(
+            row.message.contains(env!("CARGO_PKG_VERSION")),
+            "message should mention the current version: {}",
+            row.message
+        );
+    }
+
+    #[test]
+    fn hook_present_executable_version_mismatch_warns_update() {
+        let tmp = TempDir::new().unwrap();
+        write_hook(
+            tmp.path(),
+            "#!/usr/bin/env bash\n# version: 0.0.1-ancient\nexit 0\n",
+            true,
+        );
+        let ctx = ctx_with_workspace(Some(tmp.path().to_path_buf()));
+
+        let s = run(&ctx);
+        let row = first_row(&s);
+        assert_eq!(row.kind, RowKind::Warn);
+        assert_eq!(row.label, "hook:version_mismatch");
+        assert!(
+            row.message.contains("0.0.1-ancient")
+                && row.message.contains(env!("CARGO_PKG_VERSION")),
+            "mismatch message should name both versions: {}",
+            row.message
+        );
+        let fix = row.fix.as_ref().expect("mismatch must include a fix");
+        assert_eq!(fix.class, FixClass::UpdateHook);
+    }
+
+    #[test]
+    fn hook_no_workspace_returns_info_row() {
+        let ctx = ctx_with_workspace(None);
+        let s = run(&ctx);
+        let row = first_row(&s);
+        assert_eq!(row.kind, RowKind::Info);
+        assert_eq!(row.label, "hook:no_workspace");
+        assert!(row.fix.is_none(), "info row must not carry a fix");
+    }
+
+    #[test]
+    fn parse_version_marker_finds_top_of_file() {
+        let body = "#!/usr/bin/env bash\n# version: 1.2.3\n# more comments\n";
+        assert_eq!(parse_version_marker(body).as_deref(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn parse_version_marker_ignores_trailing_whitespace() {
+        let body = "#!/usr/bin/env bash\n# version: 1.2.3   \n";
+        assert_eq!(parse_version_marker(body).as_deref(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn parse_version_marker_returns_none_when_missing() {
+        let body = "#!/usr/bin/env bash\necho hi\n";
+        assert!(parse_version_marker(body).is_none());
+    }
+
+    /// Belt-and-suspenders: the marker we shipped in the workspace
+    /// hook file must match the rts-bench crate version, otherwise
+    /// `doctor` against this very repo would emit a `version_mismatch`
+    /// row out of the box. This protects against forgetting to bump
+    /// the hook marker when bumping the workspace version.
+    #[test]
+    fn workspace_hook_marker_matches_crate_version() {
+        // CARGO_MANIFEST_DIR points at crates/rts-bench. The hook lives
+        // at <workspace_root>/.claude/hooks/rts-nudge.sh.
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|p| p.to_path_buf());
+        let Some(workspace_root) = workspace_root else {
+            // Out-of-tree build (e.g. published crate); skip.
+            return;
+        };
+        let hook = workspace_root.join(HOOK_REL_PATH);
+        let Ok(body) = fs::read_to_string(&hook) else {
+            // Hook not present in this build context; skip rather than
+            // fail (this test is a guardrail for the repo, not the crate).
+            return;
+        };
+        let marker = parse_version_marker(&body)
+            .expect("workspace hook must carry a `# version:` marker");
+        assert_eq!(
+            marker,
+            env!("CARGO_PKG_VERSION"),
+            "hook marker drifted from crate version; bump .claude/hooks/rts-nudge.sh"
+        );
+    }
+
+    // Keep DoctorArgs / DoctorOutput referenced so a future refactor
+    // that drops them from the public surface trips this section's
+    // tests, not some far-away callsite.
+    #[allow(dead_code)]
+    fn _link_check(_a: DoctorArgs, _o: DoctorOutput) {}
 }

--- a/crates/rts-bench/src/doctor/nudge_hook.rs
+++ b/crates/rts-bench/src/doctor/nudge_hook.rs
@@ -63,7 +63,7 @@ fn check_hook(hook_path: &Path, doctor_version: &str, s: &mut SectionReport) {
                         FixClass::UpdateHook,
                         format!(
                             "mkdir -p .claude/hooks && curl -fsSL \
-https://raw.githubusercontent.com/yourusername/rust_tree_sitter/main/.claude/hooks/rts-nudge.sh \
+https://raw.githubusercontent.com/njfio/rs-agent-code-utility/main/.claude/hooks/rts-nudge.sh \
 -o {rel} && chmod +x {rel}",
                             rel = HOOK_REL_PATH
                         ),
@@ -149,7 +149,7 @@ fn update_hook_fix(hook_path: &Path) -> FixSnippet {
         FixClass::UpdateHook,
         format!(
             "curl -fsSL \
-https://raw.githubusercontent.com/yourusername/rust_tree_sitter/main/.claude/hooks/rts-nudge.sh \
+https://raw.githubusercontent.com/njfio/rs-agent-code-utility/main/.claude/hooks/rts-nudge.sh \
 -o {path} && chmod +x {path}",
             path = hook_path.display()
         ),

--- a/crates/rts-bench/src/doctor/nudge_hook.rs
+++ b/crates/rts-bench/src/doctor/nudge_hook.rs
@@ -1,0 +1,14 @@
+//! `hook` section — `.claude/hooks/rts-nudge.sh` presence,
+//! executability, version-marker match. U8 implements.
+
+use super::ctx::Ctx;
+use super::report::{Row, SectionReport};
+
+pub fn run(_ctx: &Ctx) -> SectionReport {
+    let mut s = SectionReport::new("hook");
+    s.push(Row::info(
+        "hook:placeholder",
+        "hook section not yet implemented",
+    ));
+    s
+}

--- a/crates/rts-bench/src/doctor/render.rs
+++ b/crates/rts-bench/src/doctor/render.rs
@@ -139,13 +139,15 @@ mod tests {
 
     fn sample_report() -> DoctorReport {
         let mut binary = SectionReport::new("binary");
-        binary.push(Row::ok("binary:on_path", "rts-daemon at /usr/local/bin/rts-daemon"));
+        binary.push(Row::ok(
+            "binary:on_path",
+            "rts-daemon at /usr/local/bin/rts-daemon",
+        ));
         let mut daemon = SectionReport::new("daemon");
         daemon.push(
-            Row::warn("daemon:not_running", "no daemon socket for this workspace")
-                .with_fix(
-                    FixSnippet::new(FixClass::StartDaemon, "rts-daemon --workspace $PWD &"),
-                ),
+            Row::warn("daemon:not_running", "no daemon socket for this workspace").with_fix(
+                FixSnippet::new(FixClass::StartDaemon, "rts-daemon --workspace $PWD &"),
+            ),
         );
         DoctorReport::from_sections(vec![binary, daemon])
     }
@@ -174,7 +176,10 @@ mod tests {
         let mut buf = Vec::new();
         render_human(&r, &mut buf, true);
         let s = String::from_utf8(buf).unwrap();
-        assert!(s.contains('\x1b'), "ANSI escape codes should appear in color mode");
+        assert!(
+            s.contains('\x1b'),
+            "ANSI escape codes should appear in color mode"
+        );
     }
 
     #[test]

--- a/crates/rts-bench/src/doctor/render.rs
+++ b/crates/rts-bench/src/doctor/render.rs
@@ -1,0 +1,203 @@
+//! Output rendering for `rts-bench doctor`. Two modes, both stable for
+//! snapshot testing: `render_human` (default — checklist + inline fix
+//! snippets, ANSI gated by TTY + `NO_COLOR`) and `render_json` (the
+//! `doctor-v0` schema for agent consumption).
+//!
+//! U3 owns this surface. The implementation is intentionally
+//! dependency-light (no `anstream` indirection — we just write the
+//! escape codes directly when color is enabled) so the binary's
+//! transitive-dep tree stays compact.
+
+use std::io::Write;
+
+use super::report::{DoctorReport, RowKind, SectionReport};
+
+// ANSI escape codes. We emit these verbatim when color_enabled is
+// true; otherwise the rows render as plain ASCII with `[OK]` /
+// `[WARN]` / `[FAIL]` / `[?]` prefixes.
+const RESET: &str = "\x1b[0m";
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const RED: &str = "\x1b[31m";
+const CYAN: &str = "\x1b[36m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+
+/// Render the report as a human-readable checklist with inline fix
+/// snippets. Section ordering is normative (see `report::SECTION_NAMES`).
+///
+/// `color` controls ANSI: callers pass `true` when stdout is a TTY,
+/// `--no-color` is unset, and `NO_COLOR` is unset.
+pub fn render_human<W: Write>(report: &DoctorReport, w: &mut W, color: bool) {
+    // Header. Doctor binary version + schema version. No wall-clock
+    // timestamps — these would flake snapshot tests.
+    let _ = writeln!(
+        w,
+        "{bold}rts-bench doctor{reset} {dim}(schema={schema}){reset}",
+        bold = if color { BOLD } else { "" },
+        reset = if color { RESET } else { "" },
+        dim = if color { DIM } else { "" },
+        schema = report.schema_version,
+    );
+    let _ = writeln!(w);
+
+    // Self-error: short-circuit before walking sections.
+    if let Some(err) = &report.error {
+        let _ = writeln!(
+            w,
+            "{red}[SELF-ERROR]{reset} {err}",
+            red = if color { RED } else { "" },
+            reset = if color { RESET } else { "" },
+        );
+        return;
+    }
+
+    // Sections in normative order.
+    for section in &report.sections {
+        render_section_human(section, w, color);
+    }
+
+    // Footer: exit class summary.
+    let _ = writeln!(w);
+    let class_str = match report.exit_class {
+        super::report::ExitClass::Ok => "ok",
+        super::report::ExitClass::Warn => "warn",
+        super::report::ExitClass::Fail => "fail",
+        super::report::ExitClass::SelfError => "self_error",
+    };
+    let class_color = match report.exit_class {
+        super::report::ExitClass::Ok => GREEN,
+        super::report::ExitClass::Warn => YELLOW,
+        super::report::ExitClass::Fail | super::report::ExitClass::SelfError => RED,
+    };
+    let _ = writeln!(
+        w,
+        "{dim}exit class:{reset} {c}{class}{reset}",
+        dim = if color { DIM } else { "" },
+        c = if color { class_color } else { "" },
+        reset = if color { RESET } else { "" },
+        class = class_str,
+    );
+}
+
+fn render_section_human<W: Write>(section: &SectionReport, w: &mut W, color: bool) {
+    let bold = if color { BOLD } else { "" };
+    let reset = if color { RESET } else { "" };
+    let dim = if color { DIM } else { "" };
+    let cyan = if color { CYAN } else { "" };
+    let _ = writeln!(w, "{cyan}{bold}== {name} =={reset}", name = section.name);
+    if section.rows.is_empty() && section.partial_failures.is_empty() {
+        let _ = writeln!(w, "  {dim}(no checks){reset}");
+    }
+    for row in &section.rows {
+        let (tag, tag_color) = match row.kind {
+            RowKind::Ok => ("[OK]  ", GREEN),
+            RowKind::Warn => ("[WARN]", YELLOW),
+            RowKind::Fail => ("[FAIL]", RED),
+            RowKind::Info => ("[?]   ", CYAN),
+        };
+        let c = if color { tag_color } else { "" };
+        let _ = writeln!(
+            w,
+            "  {c}{tag}{reset} {label} — {msg}",
+            label = row.label,
+            msg = row.message,
+        );
+        if let Some(fix) = &row.fix {
+            let _ = writeln!(w, "    → {cmd}", cmd = fix.command);
+            if let Some(desc) = &fix.description {
+                let _ = writeln!(w, "      {dim}{desc}{reset}");
+            }
+        }
+    }
+    for pf in &section.partial_failures {
+        let _ = writeln!(
+            w,
+            "  {dim}(partial: {label} — {msg}){reset}",
+            label = pf.label,
+            msg = pf.message,
+        );
+    }
+    let _ = writeln!(w);
+}
+
+/// Render the report as JSON (`doctor-v0`). Pretty-printed for
+/// readability; agents that need to consume programmatically should
+/// parse the JSON tree, not rely on field ordering.
+pub fn render_json<W: Write>(report: &DoctorReport, w: &mut W) {
+    // serde_json::to_writer_pretty is infallible on a struct that
+    // derives Serialize cleanly; the only real failure mode is
+    // stdout closure, which we can't recover from anyway.
+    let _ = serde_json::to_writer_pretty(&mut *w, report);
+    let _ = writeln!(w);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::report::{FixClass, FixSnippet, Row, SectionReport};
+
+    fn sample_report() -> DoctorReport {
+        let mut binary = SectionReport::new("binary");
+        binary.push(Row::ok("binary:on_path", "rts-daemon at /usr/local/bin/rts-daemon"));
+        let mut daemon = SectionReport::new("daemon");
+        daemon.push(
+            Row::warn("daemon:not_running", "no daemon socket for this workspace")
+                .with_fix(
+                    FixSnippet::new(FixClass::StartDaemon, "rts-daemon --workspace $PWD &"),
+                ),
+        );
+        DoctorReport::from_sections(vec![binary, daemon])
+    }
+
+    #[test]
+    fn human_render_is_stable_without_ansi() {
+        let r = sample_report();
+        let mut buf = Vec::new();
+        render_human(&r, &mut buf, false);
+        let s = String::from_utf8(buf).unwrap();
+        // Snapshot-stable: no wall-clock timestamps, no ANSI codes.
+        assert!(s.contains("rts-bench doctor"));
+        assert!(s.contains("== binary =="));
+        assert!(s.contains("[OK]"));
+        assert!(s.contains("== daemon =="));
+        assert!(s.contains("[WARN]"));
+        assert!(s.contains("rts-daemon --workspace $PWD &"));
+        assert!(s.contains("exit class: warn"));
+        // No ESC sequences in no-color mode.
+        assert!(!s.contains('\x1b'));
+    }
+
+    #[test]
+    fn human_render_emits_ansi_when_enabled() {
+        let r = sample_report();
+        let mut buf = Vec::new();
+        render_human(&r, &mut buf, true);
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains('\x1b'), "ANSI escape codes should appear in color mode");
+    }
+
+    #[test]
+    fn json_render_uses_doctor_v0_schema() {
+        let r = sample_report();
+        let mut buf = Vec::new();
+        render_json(&r, &mut buf);
+        let s = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed["schema_version"], "doctor-v0");
+        assert_eq!(parsed["exit_class"], "warn");
+        assert!(parsed["capabilities"].is_array());
+        assert_eq!(parsed["sections"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn json_render_handles_self_error() {
+        let r = DoctorReport::self_error("oh no");
+        let mut buf = Vec::new();
+        render_json(&r, &mut buf);
+        let s = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed["exit_class"], "self_error");
+        assert_eq!(parsed["error"], "oh no");
+    }
+}

--- a/crates/rts-bench/src/doctor/report.rs
+++ b/crates/rts-bench/src/doctor/report.rs
@@ -44,6 +44,7 @@ pub enum RowKind {
 
 impl RowKind {
     /// Wire-stable label, used in both human and JSON output.
+    #[allow(dead_code)] // public-API helper for downstream consumers (renderers serialize via serde).
     pub fn as_str(self) -> &'static str {
         match self {
             RowKind::Ok => "ok",
@@ -139,6 +140,7 @@ impl FixSnippet {
 /// the docs in `docs/doctor-schema.md` stay current.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[allow(dead_code)] // RegisterMcp / ReindexNeeded part of the documented taxonomy; reserved for U9 / future host rows.
 pub enum FixClass {
     /// rts binary missing from PATH or version mismatched.
     InstallBinary,
@@ -167,6 +169,7 @@ pub enum FixClass {
 /// emitted in this order in both human and JSON output, so snapshot
 /// tests stay stable regardless of section impl ordering inside
 /// `mod.rs::run`.
+#[allow(dead_code)] // documentation of the normative order; consumers cross-reference docs/doctor-schema.md.
 pub const SECTION_NAMES: &[&str] = &[
     "binary",
     "daemon",

--- a/crates/rts-bench/src/doctor/report.rs
+++ b/crates/rts-bench/src/doctor/report.rs
@@ -1,0 +1,333 @@
+//! Doctor report types — rows, sections, fix snippets, and the final
+//! aggregated `DoctorReport` (human + JSON renderable).
+//!
+//! Schema version (locked at v1 of the doctor surface):
+//!
+//! - `schema_version: "doctor-v0"`
+//! - `capabilities: [<additive capability strings>]`
+//!
+//! Future additive fields advertise via new capability strings, never
+//! a schema_version bump. See `docs/doctor-schema.md` (U10) for the
+//! full wire contract.
+
+use serde::Serialize;
+
+/// Doctor schema version. Locked at v1.
+pub const SCHEMA_VERSION: &str = "doctor-v0";
+
+/// Additive capability strings advertised by this doctor binary. Each
+/// new capability is an additive feature that consumers can branch on.
+/// Schema version bumps are reserved for breaking-shape changes.
+pub const CAPABILITIES: &[&str] = &[
+    // Initial release. Future additive capabilities (e.g. cross-version
+    // drift detection, --fix mode) extend this list.
+    "sections_v0",
+    "fix_snippets",
+    "host_detection_5x", // Claude Code, Cursor, Continue, Aider, Cline
+];
+
+/// Per-row severity. Rendering uses these as `[OK]` / `[WARN]` /
+/// `[FAIL]` / `[?]` prefixes in human mode; `kind` in JSON mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RowKind {
+    /// Healthy state; nothing to do.
+    Ok,
+    /// Non-fatal anomaly; exit code stays 0 unless a peer row is FAIL.
+    Warn,
+    /// Fatal anomaly; exit code goes to 1.
+    Fail,
+    /// Soft-detect result; "we looked but couldn't determine."
+    /// Renders as `[?]`. Never affects exit code on its own.
+    Info,
+}
+
+impl RowKind {
+    /// Wire-stable label, used in both human and JSON output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RowKind::Ok => "ok",
+            RowKind::Warn => "warn",
+            RowKind::Fail => "fail",
+            RowKind::Info => "info",
+        }
+    }
+}
+
+/// One observable signal in a section's report. The `label` is the
+/// row's stable identifier (e.g. `claude_code:user_scope`,
+/// `daemon:reachable`); the `message` is the freeform human-readable
+/// summary; the `fix` is optional and only set on WARN / FAIL rows
+/// when doctor has a copy-pasteable recovery action.
+#[derive(Clone, Debug, Serialize)]
+pub struct Row {
+    pub kind: RowKind,
+    pub label: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix: Option<FixSnippet>,
+}
+
+impl Row {
+    pub fn ok(label: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            kind: RowKind::Ok,
+            label: label.into(),
+            message: message.into(),
+            fix: None,
+        }
+    }
+    pub fn warn(label: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            kind: RowKind::Warn,
+            label: label.into(),
+            message: message.into(),
+            fix: None,
+        }
+    }
+    pub fn fail(label: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            kind: RowKind::Fail,
+            label: label.into(),
+            message: message.into(),
+            fix: None,
+        }
+    }
+    pub fn info(label: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            kind: RowKind::Info,
+            label: label.into(),
+            message: message.into(),
+            fix: None,
+        }
+    }
+    pub fn with_fix(mut self, fix: FixSnippet) -> Self {
+        self.fix = Some(fix);
+        self
+    }
+}
+
+/// A copy-pasteable one-line fix attached to a WARN or FAIL row. U9
+/// plumbs every section's WARN/FAIL paths through `FixClass` so the
+/// taxonomy stays closed; ad-hoc strings are discouraged.
+#[derive(Clone, Debug, Serialize)]
+pub struct FixSnippet {
+    pub class: FixClass,
+    /// Shell command the user can paste verbatim. Should be a single
+    /// line. Multi-step fixes use `description` to explain context.
+    pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl FixSnippet {
+    pub fn new(class: FixClass, command: impl Into<String>) -> Self {
+        Self {
+            class,
+            command: command.into(),
+            description: None,
+        }
+    }
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+}
+
+/// Closed taxonomy of fix actions. U9 may extend; do not add ad-hoc
+/// variants in section files — open a PR against this enum first so
+/// the docs in `docs/doctor-schema.md` stay current.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FixClass {
+    /// rts binary missing from PATH or version mismatched.
+    InstallBinary,
+    /// Daemon not running for this workspace; user should start it.
+    StartDaemon,
+    /// Stale socket file with no live daemon behind it.
+    RemoveStaleSocket,
+    /// rts not registered with the named agent host's MCP config.
+    RegisterMcp,
+    /// MCP config references a binary path that doesn't exist or isn't
+    /// executable.
+    FixMcpBinaryPath,
+    /// PreToolUse hook file present but not executable.
+    MakeHookExecutable,
+    /// Hook file content marker is out of date vs doctor's version.
+    UpdateHook,
+    /// Daemon pinned to a different workspace than `$PWD`.
+    MoveWorkspace,
+    /// Index is empty or stale; trigger a re-index.
+    ReindexNeeded,
+    /// Host config file present but unparseable (JSON/YAML syntax).
+    FixConfigSyntax,
+}
+
+/// All section names in their normative render order. Sections are
+/// emitted in this order in both human and JSON output, so snapshot
+/// tests stay stable regardless of section impl ordering inside
+/// `mod.rs::run`.
+pub const SECTION_NAMES: &[&str] = &[
+    "binary",
+    "daemon",
+    "mcp_registration",
+    "hook",
+    "workspace_index",
+];
+
+/// One section's collected rows plus any partial-failure annotations.
+/// Sections that hit a recoverable parse/config error annotate the
+/// failure here without aborting the run (and without producing a
+/// FAIL row when the failure was on a *peer* tool's surface — e.g.,
+/// "Aider config is malformed YAML" is doctor's concern but should
+/// not fail doctor's exit code).
+#[derive(Clone, Debug, Serialize)]
+pub struct SectionReport {
+    pub name: &'static str,
+    pub rows: Vec<Row>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub partial_failures: Vec<PartialFailure>,
+}
+
+impl SectionReport {
+    pub fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            rows: Vec::new(),
+            partial_failures: Vec::new(),
+        }
+    }
+    pub fn push(&mut self, row: Row) {
+        self.rows.push(row);
+    }
+    pub fn push_partial_failure(&mut self, label: impl Into<String>, message: impl Into<String>) {
+        self.partial_failures.push(PartialFailure {
+            label: label.into(),
+            message: message.into(),
+        });
+    }
+    pub fn max_kind(&self) -> RowKind {
+        self.rows
+            .iter()
+            .map(|r| r.kind)
+            .fold(RowKind::Ok, |acc, k| match (acc, k) {
+                (RowKind::Fail, _) | (_, RowKind::Fail) => RowKind::Fail,
+                (RowKind::Warn, _) | (_, RowKind::Warn) => RowKind::Warn,
+                (RowKind::Info, _) | (_, RowKind::Info) => RowKind::Info,
+                _ => RowKind::Ok,
+            })
+    }
+}
+
+/// Annotation for recoverable errors during a section run (e.g. one
+/// host's YAML couldn't be parsed). Renders as a footnote-style line
+/// under the section header.
+#[derive(Clone, Debug, Serialize)]
+pub struct PartialFailure {
+    pub label: String,
+    pub message: String,
+}
+
+/// Aggregate exit-class for the whole run, mapping to the documented
+/// exit-code contract: ok/warn → 0, fail → 1, self_error → 2.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExitClass {
+    Ok,
+    Warn,
+    Fail,
+    /// Doctor panicked or its own I/O failed. Exit 2.
+    SelfError,
+}
+
+/// Final aggregated report — the top-level JSON envelope and the
+/// in-memory structure the human renderer walks.
+#[derive(Clone, Debug, Serialize)]
+pub struct DoctorReport {
+    pub schema_version: &'static str,
+    pub capabilities: &'static [&'static str],
+    pub sections: Vec<SectionReport>,
+    pub exit_class: ExitClass,
+    /// Set only on self-error (exit 2). Carries a freeform message
+    /// describing what went wrong inside doctor itself.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl DoctorReport {
+    /// Build a report from the dispatched section results. Computes
+    /// `exit_class` by max-severity-row across all sections.
+    pub fn from_sections(sections: Vec<SectionReport>) -> Self {
+        let mut max = RowKind::Ok;
+        for s in &sections {
+            let k = s.max_kind();
+            max = match (max, k) {
+                (RowKind::Fail, _) | (_, RowKind::Fail) => RowKind::Fail,
+                (RowKind::Warn, _) | (_, RowKind::Warn) => RowKind::Warn,
+                _ => RowKind::Ok,
+            };
+        }
+        let exit_class = match max {
+            RowKind::Fail => ExitClass::Fail,
+            RowKind::Warn => ExitClass::Warn,
+            _ => ExitClass::Ok,
+        };
+        Self {
+            schema_version: SCHEMA_VERSION,
+            capabilities: CAPABILITIES,
+            sections,
+            exit_class,
+            error: None,
+        }
+    }
+
+    /// Self-error envelope. Used when doctor itself panicked or
+    /// failed to initialize its context. Sections list is empty;
+    /// the JSON shape stays parseable.
+    pub fn self_error(message: impl Into<String>) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            capabilities: CAPABILITIES,
+            sections: Vec::new(),
+            exit_class: ExitClass::SelfError,
+            error: Some(message.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_report_is_ok() {
+        let r = DoctorReport::from_sections(vec![]);
+        assert_eq!(r.exit_class, ExitClass::Ok);
+        assert_eq!(r.schema_version, "doctor-v0");
+    }
+
+    #[test]
+    fn warn_row_yields_warn_exit_class() {
+        let mut s = SectionReport::new("binary");
+        s.push(Row::warn("binary:version", "version drift detected"));
+        let r = DoctorReport::from_sections(vec![s]);
+        assert_eq!(r.exit_class, ExitClass::Warn);
+    }
+
+    #[test]
+    fn any_fail_row_yields_fail_exit_class() {
+        let mut s1 = SectionReport::new("binary");
+        s1.push(Row::ok("binary:on_path", "ok"));
+        let mut s2 = SectionReport::new("daemon");
+        s2.push(Row::fail("daemon:stale_socket", "stale socket file"));
+        let r = DoctorReport::from_sections(vec![s1, s2]);
+        assert_eq!(r.exit_class, ExitClass::Fail);
+    }
+
+    #[test]
+    fn self_error_has_error_envelope() {
+        let r = DoctorReport::self_error("panic inside daemon section");
+        assert_eq!(r.exit_class, ExitClass::SelfError);
+        assert_eq!(r.error.as_deref(), Some("panic inside daemon section"));
+    }
+}

--- a/crates/rts-bench/src/doctor/workspace_section.rs
+++ b/crates/rts-bench/src/doctor/workspace_section.rs
@@ -1,0 +1,16 @@
+//! `workspace_index` section — per-workspace index health: pinned-path
+//! match against `$PWD`, cold-walk completion, index generation, file
+//! count. Reads `ctx.daemon_stats` populated by `daemon_section`. U6
+//! implements.
+
+use super::ctx::Ctx;
+use super::report::{Row, SectionReport};
+
+pub fn run(_ctx: &Ctx) -> SectionReport {
+    let mut s = SectionReport::new("workspace_index");
+    s.push(Row::info(
+        "workspace_index:placeholder",
+        "workspace_index section not yet implemented",
+    ));
+    s
+}

--- a/crates/rts-bench/src/doctor/workspace_section.rs
+++ b/crates/rts-bench/src/doctor/workspace_section.rs
@@ -67,7 +67,9 @@ fn classify(stats: &JsonValue, workspace_path: &Path, s: &mut SectionReport) {
     // doctor is reporting against a workspace the daemon doesn't
     // believe it's serving. Check it first so even if we can't read
     // other fields we still flag this.
-    let pinned = stats.get("pinned_workspace_path").and_then(JsonValue::as_str);
+    let pinned = stats
+        .get("pinned_workspace_path")
+        .and_then(JsonValue::as_str);
 
     let canonical_pwd = workspace_path
         .canonicalize()
@@ -84,9 +86,7 @@ fn classify(stats: &JsonValue, workspace_path: &Path, s: &mut SectionReport) {
             s.push(
                 Row::fail(
                     "workspace_index:pinned_path_mismatch",
-                    format!(
-                        "daemon pinned to {pinned_str}, doctor running in {canonical_pwd_str}"
-                    ),
+                    format!("daemon pinned to {pinned_str}, doctor running in {canonical_pwd_str}"),
                 )
                 .with_fix(
                     FixSnippet::new(
@@ -141,9 +141,10 @@ fn classify(stats: &JsonValue, workspace_path: &Path, s: &mut SectionReport) {
         .and_then(JsonValue::as_u64);
 
     let pinned_matches = pinned.map(|p| p == canonical_pwd_str).unwrap_or(false);
-    let any_fail = s.rows.iter().any(|r| {
-        matches!(r.kind, super::report::RowKind::Fail)
-    });
+    let any_fail = s
+        .rows
+        .iter()
+        .any(|r| matches!(r.kind, super::report::RowKind::Fail));
 
     if pinned_matches && !in_progress && !any_fail {
         // Happy-path OK row.
@@ -177,7 +178,9 @@ fn classify(stats: &JsonValue, workspace_path: &Path, s: &mut SectionReport) {
 /// for the fix-snippet command so workspaces with spaces in the path
 /// don't produce a broken paste-and-run line.
 fn shell_escape(s: &str) -> String {
-    if s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '-' | '.' | '+' | ':')) {
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '-' | '.' | '+' | ':'))
+    {
         return s.to_string();
     }
     // Wrap in single quotes; embedded single quotes become `'\''`.
@@ -252,7 +255,11 @@ mod tests {
             "got rows: {:?}",
             r.rows
         );
-        let ok = r.rows.iter().find(|row| row.kind == RowKind::Ok).expect("OK row");
+        let ok = r
+            .rows
+            .iter()
+            .find(|row| row.kind == RowKind::Ok)
+            .expect("OK row");
         assert!(ok.message.contains("generation 7"));
         assert!(ok.message.contains("42 files"));
     }

--- a/crates/rts-bench/src/doctor/workspace_section.rs
+++ b/crates/rts-bench/src/doctor/workspace_section.rs
@@ -1,16 +1,340 @@
 //! `workspace_index` section — per-workspace index health: pinned-path
 //! match against `$PWD`, cold-walk completion, index generation, file
-//! count. Reads `ctx.daemon_stats` populated by `daemon_section`. U6
-//! implements.
+//! count. U6.
+//!
+//! Reads `ctx.daemon_stats` populated by `daemon_section`. This is the
+//! "consumer" side of the daemon round-trip: U5 fetches the bytes; U6
+//! interprets them into checklist rows. Decoupling the two lets the
+//! workspace_section be tested with synthetic `serde_json::json!({...})`
+//! fixtures without standing up a daemon.
+//!
+//! Row taxonomy (see plan §U6):
+//!
+//! - No workspace at $PWD → `[WARN] no rts workspace at $PWD`, skip rest.
+//! - `ctx.daemon_stats` is None → `[WARN] no daemon stats available`,
+//!   skip rest. This happens when the daemon was unreachable; U5's
+//!   `[WARN] daemon not running` row already explains why.
+//! - `pinned_workspace_path` ≠ canonicalize($PWD) → `[FAIL]` +
+//!   `FixClass::MoveWorkspace`.
+//! - `cold_walk_completed_at_ms` is null → `[WARN] indexing in progress`.
+//! - Everything healthy → `[OK] index generation N, M files`.
+
+use std::path::Path;
+
+use serde_json::Value as JsonValue;
 
 use super::ctx::Ctx;
-use super::report::{Row, SectionReport};
+use super::report::{FixClass, FixSnippet, Row, SectionReport};
 
-pub fn run(_ctx: &Ctx) -> SectionReport {
+pub fn run(ctx: &Ctx) -> SectionReport {
     let mut s = SectionReport::new("workspace_index");
-    s.push(Row::info(
-        "workspace_index:placeholder",
-        "workspace_index section not yet implemented",
-    ));
+
+    // 1. No workspace at $PWD → single WARN row, skip inner checks.
+    let workspace_path = match ctx.workspace_path.as_deref() {
+        Some(p) => p,
+        None => {
+            s.push(Row::warn(
+                "workspace_index:no_workspace",
+                "no rts workspace at $PWD — index checks skipped",
+            ));
+            return s;
+        }
+    };
+
+    // 2. Daemon unreachable (or section didn't populate stats) →
+    //    single WARN row. The reason was already explained by U5's
+    //    `daemon` section, so we keep the message terse here.
+    let stats = match ctx.daemon_stats.as_ref() {
+        Some(v) => v,
+        None => {
+            s.push(Row::warn(
+                "workspace_index:no_daemon_stats",
+                "daemon unreachable — see daemon section for details",
+            ));
+            return s;
+        }
+    };
+
+    classify(stats, workspace_path, &mut s);
     s
+}
+
+/// Decode `stats` (the `result` object from `Daemon.Stats v2` or the
+/// `Workspace.Status` fallback) into rows. Split out for unit-testing
+/// against synthetic JSON fixtures without going through `Ctx::build`.
+fn classify(stats: &JsonValue, workspace_path: &Path, s: &mut SectionReport) {
+    // Pinned-path mismatch is the most consequential failure mode —
+    // doctor is reporting against a workspace the daemon doesn't
+    // believe it's serving. Check it first so even if we can't read
+    // other fields we still flag this.
+    let pinned = stats.get("pinned_workspace_path").and_then(JsonValue::as_str);
+
+    let canonical_pwd = workspace_path
+        .canonicalize()
+        .unwrap_or_else(|_| workspace_path.to_path_buf());
+    let canonical_pwd_str = canonical_pwd.to_string_lossy().into_owned();
+
+    if let Some(pinned_str) = pinned {
+        // Compare as canonicalized paths. The daemon already
+        // canonicalizes when computing `pinned_workspace_path`, so we
+        // canonicalize the doctor side to match. macOS's `/var` →
+        // `/private/var` resolution is handled by both sides doing the
+        // same canonicalize() call.
+        if pinned_str != canonical_pwd_str {
+            s.push(
+                Row::fail(
+                    "workspace_index:pinned_path_mismatch",
+                    format!(
+                        "daemon pinned to {pinned_str}, doctor running in {canonical_pwd_str}"
+                    ),
+                )
+                .with_fix(
+                    FixSnippet::new(
+                        FixClass::MoveWorkspace,
+                        format!(
+                            "rts-daemon --workspace {} &",
+                            shell_escape(&canonical_pwd_str)
+                        ),
+                    )
+                    .with_description(
+                        "restart rts-daemon pinned to this workspace, or cd to the pinned path",
+                    ),
+                ),
+            );
+            // Continue with the other fields — they're still informative.
+        }
+    } else {
+        // No pinned_workspace_path → either we got a v1 Daemon.Stats
+        // response or a Workspace.Status response (which doesn't carry
+        // pinned_workspace_path either). Either way, surface a WARN
+        // so the user knows we couldn't verify path agreement.
+        s.push(Row::warn(
+            "workspace_index:pinned_path_unknown",
+            "pinned workspace path not reported (pre-daemon_stats_v2 daemon)",
+        ));
+    }
+
+    // Cold-walk completion. `cold_walk_completed_at_ms` is `null`
+    // until the writer's ColdWalkComplete commit lands. A null value
+    // means "still indexing"; an absent field means "daemon doesn't
+    // expose it" (pre-v2). Treat both as WARN with slightly
+    // different messages.
+    let cold_walk = stats.get("cold_walk_completed_at_ms");
+    let in_progress = match cold_walk {
+        None => false, // field absent — covered by pinned_path_unknown above
+        Some(v) if v.is_null() => true,
+        Some(_) => false,
+    };
+    if in_progress {
+        s.push(Row::warn(
+            "workspace_index:indexing",
+            "indexing in progress — cold walk not yet complete",
+        ));
+    }
+
+    // index_generation + file count. v2 carries `index_generation`;
+    // Workspace.Status carries it too. Either source is fine.
+    let index_gen = stats.get("index_generation").and_then(JsonValue::as_u64);
+    let file_count = stats
+        .get("file_count")
+        .or_else(|| stats.get("files_indexed"))
+        .and_then(JsonValue::as_u64);
+
+    let pinned_matches = pinned.map(|p| p == canonical_pwd_str).unwrap_or(false);
+    let any_fail = s.rows.iter().any(|r| {
+        matches!(r.kind, super::report::RowKind::Fail)
+    });
+
+    if pinned_matches && !in_progress && !any_fail {
+        // Happy-path OK row.
+        let gen_str = index_gen
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "?".to_string());
+        let count_str = file_count
+            .map(|n| format!("{n} files"))
+            .unwrap_or_else(|| "file count unknown".to_string());
+        s.push(Row::ok(
+            "workspace_index:healthy",
+            format!("index generation {gen_str}, {count_str}"),
+        ));
+    } else if !any_fail && index_gen.is_some() && !in_progress {
+        // No FAILs (e.g. pinned_path_unknown is just a WARN) but we
+        // still have an index_generation — surface it as an OK
+        // informational row so the user sees the index count even
+        // when we couldn't verify pinned-path agreement.
+        let gen_str = index_gen.unwrap();
+        let count_str = file_count
+            .map(|n| format!("{n} files"))
+            .unwrap_or_else(|| "file count unknown".to_string());
+        s.push(Row::ok(
+            "workspace_index:generation",
+            format!("index generation {gen_str}, {count_str}"),
+        ));
+    }
+}
+
+/// Single-quote a shell argument the same way `printf %q` would. Used
+/// for the fix-snippet command so workspaces with spaces in the path
+/// don't produce a broken paste-and-run line.
+fn shell_escape(s: &str) -> String {
+    if s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '-' | '.' | '+' | ':')) {
+        return s.to_string();
+    }
+    // Wrap in single quotes; embedded single quotes become `'\''`.
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doctor::report::RowKind;
+    use serde_json::json;
+
+    fn ctx_with(stats: Option<JsonValue>, workspace: Option<std::path::PathBuf>) -> Ctx {
+        Ctx {
+            workspace_path: workspace,
+            home: None,
+            doctor_version: "0.0.0-test",
+            color_enabled: false,
+            daemon_stats: stats,
+            socket_path: None,
+        }
+    }
+
+    #[test]
+    fn workspace_section_warns_when_no_workspace_path() {
+        let ctx = ctx_with(None, None);
+        let r = run(&ctx);
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0].kind, RowKind::Warn);
+        assert!(r.rows[0].message.contains("no rts workspace"));
+    }
+
+    #[test]
+    fn workspace_section_warns_when_daemon_stats_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = ctx_with(None, Some(tmp.path().to_path_buf()));
+        let r = run(&ctx);
+        assert_eq!(r.rows.len(), 1);
+        assert_eq!(r.rows[0].kind, RowKind::Warn);
+        assert!(r.rows[0].message.contains("daemon unreachable"));
+    }
+
+    #[test]
+    fn workspace_section_ok_when_pinned_path_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path().canonicalize().unwrap();
+        let pinned = ws.to_string_lossy().into_owned();
+        let stats = json!({
+            "uptime_ms": 1000,
+            "version": "0.6.0",
+            "pinned_workspace_path": pinned,
+            "workspace_id": "deadbeef".repeat(4),
+            "index_generation": 7,
+            "cold_walk_completed_at_ms": 1234567890u64,
+            "file_count": 42,
+        });
+        let ctx = ctx_with(Some(stats), Some(ws));
+        let r = run(&ctx);
+        // No FAIL rows; at least one OK row with the index generation.
+        assert!(
+            !r.rows.iter().any(|row| row.kind == RowKind::Fail),
+            "got rows: {:?}",
+            r.rows
+        );
+        let ok = r.rows.iter().find(|row| row.kind == RowKind::Ok).expect("OK row");
+        assert!(ok.message.contains("generation 7"));
+        assert!(ok.message.contains("42 files"));
+    }
+
+    #[test]
+    fn workspace_section_fails_when_pinned_path_mismatches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path().canonicalize().unwrap();
+        let stats = json!({
+            "pinned_workspace_path": "/some/other/workspace",
+            "workspace_id": "deadbeef".repeat(4),
+            "index_generation": 3,
+            "cold_walk_completed_at_ms": 999u64,
+        });
+        let ctx = ctx_with(Some(stats), Some(ws.clone()));
+        let r = run(&ctx);
+        let fail = r
+            .rows
+            .iter()
+            .find(|row| row.kind == RowKind::Fail)
+            .expect("FAIL row for pinned-path mismatch");
+        assert_eq!(fail.label, "workspace_index:pinned_path_mismatch");
+        assert!(fail.message.contains("/some/other/workspace"));
+        let fix = fail.fix.as_ref().expect("FAIL row carries a fix");
+        assert_eq!(fix.class, FixClass::MoveWorkspace);
+        assert!(fix.command.contains("rts-daemon --workspace"));
+    }
+
+    #[test]
+    fn workspace_section_warns_when_cold_walk_in_progress() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path().canonicalize().unwrap();
+        let pinned = ws.to_string_lossy().into_owned();
+        let stats = json!({
+            "pinned_workspace_path": pinned,
+            "index_generation": 1,
+            "cold_walk_completed_at_ms": JsonValue::Null,
+        });
+        let ctx = ctx_with(Some(stats), Some(ws));
+        let r = run(&ctx);
+        let warn = r
+            .rows
+            .iter()
+            .find(|row| row.label == "workspace_index:indexing")
+            .expect("WARN row for in-progress cold walk");
+        assert_eq!(warn.kind, RowKind::Warn);
+        assert!(warn.message.contains("indexing in progress"));
+    }
+
+    #[test]
+    fn workspace_section_warns_when_pinned_path_field_absent() {
+        // Pre-v2 daemon: Workspace.Status fallback gives us
+        // index_generation but no pinned_workspace_path.
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path().canonicalize().unwrap();
+        let stats = json!({
+            "index_generation": 2,
+            "file_count": 11,
+        });
+        let ctx = ctx_with(Some(stats), Some(ws));
+        let r = run(&ctx);
+        let warn = r
+            .rows
+            .iter()
+            .find(|row| row.label == "workspace_index:pinned_path_unknown")
+            .expect("WARN row for missing pinned_workspace_path");
+        assert_eq!(warn.kind, RowKind::Warn);
+        // Even without a pinned-path check, we still surface the
+        // generation so the user sees the index data.
+        let ok = r
+            .rows
+            .iter()
+            .find(|row| row.label == "workspace_index:generation")
+            .expect("OK generation row");
+        assert!(ok.message.contains("generation 2"));
+        assert!(ok.message.contains("11 files"));
+    }
+
+    #[test]
+    fn shell_escape_quotes_paths_with_spaces() {
+        assert_eq!(shell_escape("/Users/n/foo"), "/Users/n/foo");
+        assert_eq!(shell_escape("/Users/n/with space"), "'/Users/n/with space'");
+        assert_eq!(shell_escape("/path/with'quote"), "'/path/with'\\''quote'");
+    }
 }

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -19,6 +19,7 @@ use serde_json::json;
 
 mod baseline;
 mod corpus;
+mod doctor;
 mod footprint;
 mod latency;
 mod mcp_runner;
@@ -148,6 +149,35 @@ enum Cmd {
     /// example. Each query has `text` (the natural-language query)
     /// and `expected_top_k` (hand-graded list of symbol names that
     /// should appear in the top-K results).
+    /// Read-only first-run health check. Inspects rts install state
+    /// (binary version, daemon reachability, MCP registration in 5
+    /// agent hosts, hook file presence) and per-workspace index state
+    /// (daemon PID, pinned-workspace path, index generation, cold-walk
+    /// completion). Prints an OK/WARN/FAIL checklist with copy-pasteable
+    /// fix snippets for every failing row.
+    ///
+    /// Exit codes are a documented public API:
+    /// - 0 — no FAIL rows (any WARN allowed)
+    /// - 1 — at least one FAIL row
+    /// - 2 — doctor itself failed (panic, unreadable own binary)
+    ///
+    /// Plan: docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md
+    Doctor {
+        /// Output format. `human` (default) renders a checklist with
+        /// inline fix snippets and ANSI when stdout is a TTY and
+        /// `NO_COLOR` is unset. `json` produces a machine-readable
+        /// document with `schema_version: "doctor-v0"` for agent
+        /// consumption (e.g. agent-bench preflight).
+        #[arg(long, value_enum, default_value_t = doctor::DoctorOutput::Human)]
+        output: doctor::DoctorOutput,
+        /// Disable ANSI color even on a TTY. `NO_COLOR=1` env var has
+        /// the same effect.
+        #[arg(long)]
+        no_color: bool,
+        /// Workspace path to inspect. Defaults to the current directory.
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+    },
     Semantic {
         /// Path to a TOML corpus file.
         #[arg(long)]
@@ -500,6 +530,22 @@ async fn main() -> Result<()> {
             dry_run,
         } => run_footprint(synth_loc, out, dry_run).await,
         Cmd::Query { output, sub } => run_query(sub, output).await,
+        Cmd::Doctor {
+            output,
+            no_color,
+            workspace,
+        } => {
+            // doctor::run returns the process exit code (0/1/2 per the
+            // documented contract); we plumb it through std::process::exit
+            // because anyhow::Result<()> from main only gives us 0/1.
+            let code = doctor::run(doctor::DoctorArgs {
+                output,
+                no_color,
+                workspace,
+            })
+            .await;
+            std::process::exit(code);
+        }
         Cmd::Semantic {
             corpus,
             workspace,

--- a/crates/rts-daemon/src/methods/daemon.rs
+++ b/crates/rts-daemon/src/methods/daemon.rs
@@ -84,6 +84,12 @@ const DAEMON_CAPABILITIES: &[&str] = &[
     // uptime. Mainly for honest dogfood reflection ("am I actually
     // using this?") — agents can self-report rather than guess.
     "daemon_stats",
+    // v0.6 — Daemon.Stats v2: response includes `pinned_workspace_path`,
+    // `workspace_id`, `index_generation`, and `cold_walk_completed_at_ms`
+    // when a workspace is mounted. Lets `rts-bench doctor` answer
+    // "is the daemon pinned to this $PWD?" and "is indexing done?"
+    // in a single round-trip. Old clients ignore the new fields.
+    "daemon_stats_v2",
 ];
 
 /// `Daemon.Ping` — heartbeat + capability advertisement (protocol-v0 §4.1, §7.1).
@@ -104,25 +110,41 @@ pub async fn ping(
     }))
 }
 
-/// `Daemon.Stats` — per-session call counters (v0.5.7+).
+/// `Daemon.Stats` — per-session call counters + workspace metadata
+/// (v0.5.7+, extended to v2 in v0.6+).
 ///
 /// Returns the per-method call-count snapshot from
 /// `state.call_counters` plus session-level context (uptime, daemon
 /// version, total RPC count). The Stats RPC itself is counted, so
 /// querying stats twice in a row shows `Daemon.Stats: 2`.
 ///
-/// Wire shape:
+/// **v2 fields (capability `daemon_stats_v2`, v0.6+):** when a
+/// workspace is mounted, the response additionally carries
+/// `pinned_workspace_path` (UTF-8 canonical path the daemon is
+/// pinned to), `workspace_id` (16-char hex blake3 fingerprint),
+/// `index_generation` (bumps on every committed write), and
+/// `cold_walk_completed_at_ms` (Unix-epoch ms when the writer's
+/// `ColdWalkComplete` flush committed, or `null` if not yet). These
+/// fields let `rts-bench doctor` answer "is the daemon pinned to
+/// this $PWD?" and "is indexing done?" in a single round-trip. Old
+/// clients ignore the additional fields; pre-v2 daemons omit them.
+///
+/// Wire shape (v2):
 /// ```jsonc
 /// {
 ///   "uptime_ms":  12345,
-///   "version":    "0.5.7",
+///   "version":    "0.6.0",
 ///   "total_calls": 89,
 ///   "calls": {
 ///     "Index.FindSymbol":  3,
 ///     "Index.Grep":        47,
-///     "Index.FindCallers": 0,
 ///     ...
-///   }
+///   },
+///   // v2 fields, present only when a workspace is mounted:
+///   "pinned_workspace_path":     "/Users/n/RustroverProjects/rust_tree_sitter",
+///   "workspace_id":              "8a8a68f7b4c3...",
+///   "index_generation":          1247,
+///   "cold_walk_completed_at_ms": 1748462100123
 /// }
 /// ```
 ///
@@ -134,18 +156,63 @@ pub async fn ping(
 /// Cross-session aggregation should happen client-side from
 /// per-session snapshots.
 ///
-/// Performance: one relaxed-load per counter field plus a JSON
-/// serialize. Sub-microsecond on modern hardware; safe to call from
-/// a hot agent loop.
+/// Performance: one relaxed-load per counter field, one workspace
+/// mutex lock for the v2 fields, plus a JSON serialize. Sub-
+/// microsecond on modern hardware; safe to call from a hot agent loop.
 pub async fn stats(
     _params: serde_json::Value,
     state: &Arc<DaemonState>,
 ) -> Result<serde_json::Value, ProtocolError> {
+    use std::sync::atomic::Ordering::Relaxed;
     let uptime_ms = state.uptime().as_millis() as u64;
-    Ok(serde_json::json!({
+
+    // v2 fields. Only emitted when a workspace is mounted — old clients
+    // and pre-mount Stats calls both see the v1 shape via field absence.
+    let (pinned_path, workspace_id, index_gen, cold_walk_at_ms) = match state
+        .workspace
+        .lock()
+    {
+        Ok(guard) => match guard.as_ref() {
+            Some(mounted) => {
+                let pinned = mounted.canonical.path.to_string_lossy().into_owned();
+                let ws_id = mounted.fingerprint.id_str().to_string();
+                let generation = state.index_generation.load(Relaxed);
+                let cold_walk = state.cold_walk_completed_at_ms.load(Relaxed);
+                (Some(pinned), Some(ws_id), Some(generation), cold_walk)
+            }
+            None => (None, None, None, 0),
+        },
+        Err(_) => (None, None, None, 0),
+    };
+
+    // `cold_walk_completed_at_ms: null` when 0 (not yet completed); a
+    // real timestamp otherwise. Distinguishes "indexing in progress"
+    // from "indexing done" for the agent reading this.
+    let cold_walk_value = if cold_walk_at_ms == 0 {
+        serde_json::Value::Null
+    } else {
+        serde_json::Value::Number(cold_walk_at_ms.into())
+    };
+
+    let mut body = serde_json::json!({
         "uptime_ms":   uptime_ms,
         "version":     env!("CARGO_PKG_VERSION"),
         "total_calls": state.call_counters.total(),
         "calls":       state.call_counters.snapshot(),
-    }))
+    });
+
+    // v2 fields are added only when a workspace is mounted; pre-mount
+    // Stats responses keep the v1 shape exactly.
+    if let (Some(path), Some(id), Some(generation)) = (pinned_path, workspace_id, index_gen) {
+        let obj = body.as_object_mut().expect("body is an object");
+        obj.insert("pinned_workspace_path".into(), serde_json::Value::String(path));
+        obj.insert("workspace_id".into(), serde_json::Value::String(id));
+        obj.insert(
+            "index_generation".into(),
+            serde_json::Value::Number(generation.into()),
+        );
+        obj.insert("cold_walk_completed_at_ms".into(), cold_walk_value);
+    }
+
+    Ok(body)
 }

--- a/crates/rts-daemon/src/methods/daemon.rs
+++ b/crates/rts-daemon/src/methods/daemon.rs
@@ -168,10 +168,7 @@ pub async fn stats(
 
     // v2 fields. Only emitted when a workspace is mounted — old clients
     // and pre-mount Stats calls both see the v1 shape via field absence.
-    let (pinned_path, workspace_id, index_gen, cold_walk_at_ms) = match state
-        .workspace
-        .lock()
-    {
+    let (pinned_path, workspace_id, index_gen, cold_walk_at_ms) = match state.workspace.lock() {
         Ok(guard) => match guard.as_ref() {
             Some(mounted) => {
                 let pinned = mounted.canonical.path.to_string_lossy().into_owned();
@@ -205,7 +202,10 @@ pub async fn stats(
     // Stats responses keep the v1 shape exactly.
     if let (Some(path), Some(id), Some(generation)) = (pinned_path, workspace_id, index_gen) {
         let obj = body.as_object_mut().expect("body is an object");
-        obj.insert("pinned_workspace_path".into(), serde_json::Value::String(path));
+        obj.insert(
+            "pinned_workspace_path".into(),
+            serde_json::Value::String(path),
+        );
         obj.insert("workspace_id".into(), serde_json::Value::String(id));
         obj.insert(
             "index_generation".into(),

--- a/crates/rts-daemon/src/state.rs
+++ b/crates/rts-daemon/src/state.rs
@@ -90,6 +90,15 @@ pub struct DaemonState {
     /// write; later phases expose this via `Workspace.Status.index_generation`.
     /// Currently always 0 (no writer yet).
     pub index_generation: AtomicU64,
+    /// Unix-epoch milliseconds when the writer's `ColdWalkComplete` flush
+    /// committed. `0` means "not yet" — either no workspace mounted, or
+    /// the cold walk hasn't drained its first batch yet.
+    ///
+    /// Surfaced via `Daemon.Stats v2` (capability `daemon_stats_v2`) so
+    /// `rts-bench doctor` and the agent-bench harness can distinguish
+    /// "index ready" from "indexing in progress" without polling
+    /// `Workspace.Status.progress.phase`.
+    pub cold_walk_completed_at_ms: AtomicU64,
     /// File-watcher health for `Workspace.Status.watcher_status` (§7.4).
     watcher_status: AtomicU8,
     /// Single-slot memoization cache for `Index.Outline`. Keyed by
@@ -405,6 +414,7 @@ impl DaemonState {
             mount_refcount: AtomicU32::new(0),
             started_at: Instant::now(),
             index_generation: AtomicU64::new(0),
+            cold_walk_completed_at_ms: AtomicU64::new(0),
             watcher_status: AtomicU8::new(WatcherStatus::NoWatcher as u8),
             outline_cache: OutlineCache::new(),
             symbol_pagerank_cache: SymbolPagerankCache::new(),

--- a/crates/rts-daemon/src/writer.rs
+++ b/crates/rts-daemon/src/writer.rs
@@ -169,6 +169,22 @@ async fn run(
                         );
                         cold_walk_in_progress = false;
                         last_durability_flush = Instant::now();
+                        // v0.6 Daemon.Stats v2 (`daemon_stats_v2`
+                        // capability): stamp the cold-walk completion
+                        // time once the batch is durable. Read by
+                        // doctor + agent-bench preflight to tell
+                        // "indexing in progress" from "index ready"
+                        // without polling Workspace.Status. Set after
+                        // the flush so a reader observing a non-zero
+                        // value is guaranteed the index is committed.
+                        let now_ms = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_millis() as u64)
+                            .unwrap_or(0);
+                        state.cold_walk_completed_at_ms.store(
+                            now_ms,
+                            std::sync::atomic::Ordering::Relaxed,
+                        );
                     }
                     Some(WatchEvent::Rescan) => {
                         // Kernel watch buffer overflowed; index state may be

--- a/crates/rts-daemon/tests/daemon_stats_v2_round_trip.rs
+++ b/crates/rts-daemon/tests/daemon_stats_v2_round_trip.rs
@@ -172,9 +172,7 @@ async fn daemon_stats_v2_emits_workspace_fields_post_mount() -> anyhow::Result<(
             break;
         }
         if Instant::now() >= deadline {
-            anyhow::bail!(
-                "cold_walk_completed_at_ms never populated within 5s; last r={r:?}"
-            );
+            anyhow::bail!("cold_walk_completed_at_ms never populated within 5s; last r={r:?}");
         }
         tokio::time::sleep(Duration::from_millis(75)).await;
     }

--- a/crates/rts-daemon/tests/daemon_stats_v2_round_trip.rs
+++ b/crates/rts-daemon/tests/daemon_stats_v2_round_trip.rs
@@ -1,0 +1,241 @@
+//! End-to-end test for v0.6 `Daemon.Stats v2` workspace-metadata fields.
+//!
+//! Asserts:
+//! 1. `Daemon.Ping` advertises the new `daemon_stats_v2` capability.
+//! 2. **Pre-mount** `Daemon.Stats` keeps the v1 shape — none of the v2
+//!    fields are present. This is the backward-compat invariant from
+//!    PR 001 plan AC1.
+//! 3. **Post-mount** `Daemon.Stats` carries
+//!    `pinned_workspace_path`, `workspace_id`, `index_generation`,
+//!    and `cold_walk_completed_at_ms`.
+//! 4. `pinned_workspace_path` matches the canonical workspace path
+//!    (modulo macOS NFC + symlink-resolution differences).
+//! 5. `cold_walk_completed_at_ms` is `null` immediately after Mount,
+//!    becomes a Unix-epoch-ms timestamp once the writer's
+//!    `ColdWalkComplete` flush commits.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(5), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn daemon_stats_v2_emits_workspace_fields_post_mount() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // Seed one Rust file so the writer has something to index and
+    // therefore something to flush at cold-walk completion.
+    std::fs::write(workspace.path().join("hub.rs"), "pub fn hello() {}\n")?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    // 1. Ping advertises `daemon_stats_v2`.
+    let pong = round_trip(&mut stream, "1", "Daemon.Ping", json!({})).await?;
+    let caps = pong["result"]["capabilities"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let cap_strs: Vec<&str> = caps.iter().filter_map(|v| v.as_str()).collect();
+    assert!(
+        cap_strs.contains(&"daemon_stats_v2"),
+        "expected daemon_stats_v2 capability; got {cap_strs:?}"
+    );
+
+    // 2. Pre-mount Stats keeps the v1 shape — none of the v2 fields
+    //    are present. Backward-compat invariant.
+    let stats_pre = round_trip(&mut stream, "2", "Daemon.Stats", json!({})).await?;
+    let r_pre = &stats_pre["result"];
+    assert!(r_pre["uptime_ms"].as_u64().is_some(), "uptime_ms missing");
+    assert!(r_pre["version"].as_str().is_some(), "version missing");
+    assert!(
+        r_pre.get("pinned_workspace_path").is_none(),
+        "pre-mount Stats must NOT include pinned_workspace_path; got {r_pre:?}"
+    );
+    assert!(
+        r_pre.get("workspace_id").is_none(),
+        "pre-mount Stats must NOT include workspace_id"
+    );
+    assert!(
+        r_pre.get("index_generation").is_none(),
+        "pre-mount Stats must NOT include index_generation"
+    );
+    assert!(
+        r_pre.get("cold_walk_completed_at_ms").is_none(),
+        "pre-mount Stats must NOT include cold_walk_completed_at_ms"
+    );
+
+    // 3. Mount the workspace.
+    let mount = round_trip(
+        &mut stream,
+        "3",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount failed: {mount:?}");
+
+    // 4. Post-mount Stats carries all four v2 fields. Poll briefly to
+    //    let the writer's ColdWalkComplete flush land before asserting
+    //    on cold_walk_completed_at_ms.
+    let mut stats_post = serde_json::Value::Null;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut id: u32 = 100;
+    loop {
+        id += 1;
+        stats_post = round_trip(&mut stream, &id.to_string(), "Daemon.Stats", json!({})).await?;
+        let r = &stats_post["result"];
+        let cold_walk = &r["cold_walk_completed_at_ms"];
+        if cold_walk.is_number() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "cold_walk_completed_at_ms never populated within 5s; last r={r:?}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+
+    let r_post = &stats_post["result"];
+    let pinned = r_post["pinned_workspace_path"]
+        .as_str()
+        .expect("pinned_workspace_path should be present and a string");
+    assert!(
+        !pinned.is_empty(),
+        "pinned_workspace_path must not be empty"
+    );
+
+    // The pinned path should be the canonicalized workspace temp dir.
+    // We compare end-substrings rather than equality because macOS
+    // canonicalize() resolves `/var` → `/private/var` and the test
+    // tempdir is under /var on macOS.
+    let workspace_str = workspace.path().to_string_lossy();
+    let workspace_basename = workspace
+        .path()
+        .file_name()
+        .and_then(|n| n.to_str())
+        .expect("temp dir has a name");
+    assert!(
+        pinned.ends_with(workspace_basename),
+        "pinned_workspace_path={pinned} should end with {workspace_basename} (workspace={workspace_str})"
+    );
+
+    let workspace_id = r_post["workspace_id"]
+        .as_str()
+        .expect("workspace_id should be present");
+    // `WorkspaceFingerprint::id_str()` returns the leading 16 bytes of
+    // blake3(dev_id ‖ inode ‖ canonical_path) rendered as 32 hex chars.
+    assert_eq!(
+        workspace_id.len(),
+        32,
+        "workspace_id should be 32-char hex (16-byte truncation); got {workspace_id:?}"
+    );
+    assert!(
+        workspace_id.chars().all(|c| c.is_ascii_hexdigit()),
+        "workspace_id should be lowercase hex; got {workspace_id:?}"
+    );
+
+    let index_generation = r_post["index_generation"].as_u64();
+    assert!(
+        index_generation.is_some(),
+        "index_generation should be a u64; got {:?}",
+        r_post["index_generation"]
+    );
+
+    let cold_walk_ms = r_post["cold_walk_completed_at_ms"]
+        .as_u64()
+        .expect("cold_walk_completed_at_ms should be a u64 once the walk finishes");
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    assert!(
+        cold_walk_ms > 0 && cold_walk_ms <= now_ms,
+        "cold_walk_completed_at_ms={cold_walk_ms} should be a sane Unix-epoch-ms (now={now_ms})"
+    );
+
+    Ok(())
+}

--- a/docs/brainstorms/2026-05-18-index-grep-v2-requirements.md
+++ b/docs/brainstorms/2026-05-18-index-grep-v2-requirements.md
@@ -1,0 +1,92 @@
+---
+date: 2026-05-18
+topic: index-grep-v2
+---
+
+# `Index.Grep` v2 — multiline regex + structural queries + within-symbol scope
+
+## Problem Frame
+
+The current `grep` MCP tool is the only `rg`-shaped surface in rts. It's the agent's natural successor to `Bash rg`, and the *enclosing-qualified-name* it returns per match is the unique reason agents reach for it instead of `rg`.
+
+But three known shortcomings make agents drop back to `Bash rg` mid-session:
+
+- **No multiline.** Patterns that need to match across `\n` (a function signature on three lines; an SQL fragment with embedded newlines; a multi-line error message) silently fail in v1.
+- **No structural matching.** "Find every `impl` block containing an `unsafe fn`" requires `rg` + manual filtering, or two MCP calls + an intersection. `rg` is faster than rts at that point.
+- **No within-symbol scope.** "Find every `panic!` *inside* `fn parse_request`" requires a `grep` + a `find_symbol` + a byte-range intersection the agent has to compute by hand.
+
+These leaks are measurable: every `Bash rg` invocation in an agent-bench trajectory after the workspace is indexed is a v2 candidate. Closing them tightens the value-prop without expanding the tool surface (one tool, three new params).
+
+## Requirements
+
+- **R1.** `Index.Grep` gains three optional input parameters, fully composable with each other and with the existing literal/regex `text`/`pattern` inputs:
+  - `multiline: bool` (default `false`)
+  - `structural_query: string` (a raw tree-sitter S-expression query)
+  - `within_symbol: string` (a qualified-name match scope)
+- **R2.** When `multiline: true`, the regex engine treats indexed file bytes as one logical buffer per file (i.e., `.` and `[^x]` match `\n`; `(?s)` flags are honored). Single-line semantics remain the default; existing callers are unaffected.
+- **R3.** `structural_query` accepts a **raw tree-sitter S-expression query string**, in the same form used internally for `@reference.call` patterns today. The query MAY include named captures (`@name`); when present, captures are returned in the response.
+- **R4.** `structural_query` requires a `language` parameter: either a single language identifier (`"rust"`) or a list (`["rust", "typescript"]`). All 12 indexed languages are eligible. The daemon validates the query against each named grammar at request time and returns a structured error if the query is malformed for that grammar.
+- **R5.** `within_symbol` is a **qualified-name match scope**. When set, returned matches are filtered to those whose byte range lies entirely inside the def-byte-range of the named symbol(s). Exact semantics for the parameter shape (single name, glob, list, fully-qualified path) is a planning-time decision (see Deferred questions). The minimum v1 behavior: accept a single exact qualified name.
+- **R6.** All three parameters compose freely:
+  - `multiline + within_symbol` — multi-line regex inside one function
+  - `structural_query + within_symbol` — structural match inside one function
+  - `multiline + structural_query` — structural match with regex-based capture predicates (`#match? @name "regex"`)
+  - all three together — bounded multi-line structural search
+- **R7.** Response shape is a superset of the v1 grep response. Existing fields (`file`, `line`, `enclosing_qualified_name`, `kind`, span info) are preserved verbatim. Structural matches additionally carry a `captures` map: `{capture_name: [{start: {line, col}, end: {line, col}, text: string}]}`, one entry per named capture in the query. Non-structural (literal/regex) matches do not populate `captures`.
+- **R8.** Backward compatibility: every existing call to `Index.Grep` (literal `text`, regex `pattern`, no new params) returns byte-for-byte the same response in v2 as in v1. The wire shape grows; no existing field changes meaning.
+- **R9.** Errors on malformed input return a structured error envelope, not an empty result set. A malformed S-expr query, an unknown language, an unknown `within_symbol` name, and an unparseable regex are each distinguishable in the error code.
+- **R10.** Per-method telemetry from `Daemon.Stats` (#104) distinguishes v2 calls: a v2 call counts under `Index.Grep` for the existing counter AND under a new `Index.Grep.structural` / `Index.Grep.scoped` / `Index.Grep.multiline` sub-counter so we can measure adoption of each new capability independently.
+
+## Success Criteria
+
+- **SC1.** A v1 agent-bench trajectory replayed against v2 reaches the same answer in fewer turns at least once (typical case: "find every panic in module X" goes from `grep` + `find_symbol` + `read_symbol` to one `grep` call with `within_symbol`).
+- **SC2.** At least one agent-bench task per language family has at least one structural-query example in the chosen trajectory after v2 ships (proxy for "structural is actually used, not just shipped").
+- **SC3.** The README's *"What it gives your agent"* table grows a one-line v2 note under `grep` describing the new params, without changing the row count.
+- **SC4.** No regression in `Index.Grep` p95 latency on the unchanged path (literal/regex, no new params). The new sub-counters in `Daemon.Stats` make a regression visible.
+
+## Scope Boundaries
+
+- **Out of scope (v1):** named-pattern catalog (`fn_with_attr`, `impl_containing`, etc.). Raw S-expression queries only; sugar can be a v2.1 add-on informed by which raw queries agents actually run.
+- **Out of scope (v1):** structural query *across* the entire workspace as a single denormalized graph. v1 runs the query per-file (over the parsed-tree cache) and unions results.
+- **Out of scope (v1):** replacing `find_symbol`. Structural grep is for ad-hoc patterns; `find_symbol` remains the canonical "where is X defined" tool.
+- **Out of scope (v1):** unifying grep + structural into a single `query` tool with sugar (the rejected challenger option). v2 keeps `Index.Grep` as the one entry point; the new params are additive.
+- **Out of scope (v1):** structural queries on *non*-indexed languages or auto-detection across all 12 grammars. Language is a required input.
+- **Out of scope (v1):** rewriting / refactoring based on captures. v2 is read-only retrieval; transforms live in a future `Index.RenamePreview`-shaped tool (ideation idea #6).
+- **Out of scope (v1):** persisted-result caching across daemon restarts. Cache lives in memory for the daemon lifetime; planning may revisit if structural queries are slow.
+
+## Key Decisions
+
+- **One tool, additive params over three sibling tools or a unified `query` tool.** Backward compatible; preserves existing schema discoverability; agents that already reach for `grep` automatically get the new capabilities once they learn the new fields. Sibling tools would inflate the tool surface; a unified `query` tool would force every existing caller to relearn.
+- **Raw S-expression queries over a named-pattern catalog.** Matches what's already used internally; maximum expressiveness; ships fast. The "named-pattern sugar later" challenger remains valid as a v2.1, gated on observed usage.
+- **Fully composable params, captures returned.** The composition produces a small, predictable matrix: 2 (multiline yes/no) × 2 (structural yes/no) × 2 (within_symbol yes/no) = 8 modes, all behaving like the union of independent filters. Captures are the only structural-only field, returned only when relevant.
+- **Required `language` for structural queries.** Avoids silent-fail when a query syntactically targets a grammar that isn't loaded. Makes the failure mode legible: "you asked for `impl_item` and we don't have a Java grammar with that node."
+- **Per-capability sub-counters in `Daemon.Stats`.** Without these, we can't tell whether v2 is *actually* being used after it ships. The sub-counters cost ~50 LOC; the alternative is shipping v2 blind to adoption.
+
+## Dependencies / Assumptions
+
+- All 12 indexed languages already have parsed trees in the daemon's per-file tree-sitter cache. (Call-edge precision differs across 6 vs 6; that's orthogonal.)
+- The tree-sitter query API exposed by the upstream `tree-sitter` crate supports running compiled queries against cached trees without re-parsing. Confirm at planning.
+- The current `Index.Grep` response already carries enough span info to support intersection with a symbol's byte range; `within_symbol` filtering is a post-pass over existing match coordinates.
+- `Daemon.Stats` (#104) is the canonical surface for adoption telemetry; protocol-v0 evolution rules govern how the new sub-counters are exposed.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+*(none — all product-level decisions are made)*
+
+### Deferred to Planning
+
+- **[Affects R2]** **[Technical]** Multi-line regex resource budget: max bytes scanned per file? Max DFA size? Wall-clock timeout? Default `(?s)` flag or require explicit opt-in? Pick concrete numbers in planning informed by the regex crate's `RegexBuilder::dfa_size_limit`.
+- **[Affects R5]** **[Product]** Exact shape of `within_symbol`: single exact qualified name (v1 minimum), or also accept `["name1", "name2"]`, `pattern: "fn_*"`, `qualified_path: "module::Type::method"`? Recommend exact-name v1, glob/list as a separate enhancement.
+- **[Affects R5]** **[Technical]** Within-symbol intersection semantics: match must be *entirely* inside the def byte range (strict), or *overlap* with it (lenient)? Strict is unambiguous; lenient is more forgiving for matches that span the closing brace.
+- **[Affects R3, R7]** **[Technical]** Predicate support in S-expressions: do we accept `#match?`, `#eq?`, `#not-match?`, custom predicates? `tree-sitter` supports a defined set; document which v1 supports.
+- **[Affects R4]** **[Technical]** Pre-validation of the S-expr query: validate at request time (per-grammar `Query::new`) and return a structured error before scanning, vs validate-and-scan in one pass. Pre-validation costs ~100µs per query but gives much better error messages.
+- **[Affects R7]** **[Product]** Capture position units: line/column (consistent with v1 match coordinates), byte offsets (consistent with tree-sitter native), or both? Recommend line/column for parity with v1, byte offsets as an optional `--position-units bytes` flag.
+- **[Affects R6]** **[Technical]** Result truncation: large structural queries can return thousands of captures. v2 needs explicit truncation rules and a `truncated: bool` flag. Pick limits (rows, total bytes, per-capture text length) in planning.
+- **[Affects R7]** **[Technical]** Does the literal/regex grep path *also* accept the optional `language` filter (for parity, e.g., "grep `panic!` only in Rust files")? Lightweight to add; consistent with the structural path. Recommend yes.
+- **[Affects R4]** **[Technical]** Grammar-version invalidation: if a tree-sitter grammar version bumps, the structural-query node names may change. How does the daemon surface "your query syntax is valid against an older grammar version"? Probably out of scope for v1 but worth a one-line note.
+
+## Next Steps
+
+→ Continue brainstorming idea #4 (Persisted cold-mount index) next, per the ideation queue. After brainstorm #3 lands, run `/ce:plan` on each of the three in turn.

--- a/docs/brainstorms/2026-05-18-persisted-cold-mount-requirements.md
+++ b/docs/brainstorms/2026-05-18-persisted-cold-mount-requirements.md
@@ -1,0 +1,111 @@
+---
+date: 2026-05-18
+topic: persisted-cold-mount
+---
+
+# Persisted cold-mount index
+
+## Problem Frame
+
+The daemon walks the workspace once on startup (~1 s on 10k LOC, ~6 s on 100k) and watches for changes after that. The watcher keeps the index live during a session, but the daemon idles out after 10 minutes (per README) and gets re-spawned on the next agent invocation — paying the full cold-walk cost again.
+
+For a 100k LOC workspace, that's a ~6 s delay before the *first* query of every session can be answered. It's the only user-perceived latency in rts. The daemon already uses redb as its persistence engine; the data is shaped right, the schema is versioned (`SCHEMA_VERSION` bumped to 3 in #103). What's missing is reuse of that on-disk state across daemon restarts: today the daemon walks from zero whether the index existed five seconds ago or never.
+
+A persisted cold-mount index reuses the post-cold-walk redb snapshot, validates that it's still relevant via a composite fingerprint, and re-parses only files whose `(mtime, size)` changed since the snapshot was written. The target effect: *"open editor, ask question"* feels instant for the first query of every session, not just the second.
+
+## Requirements
+
+- **R1.** The daemon persists its post-cold-walk redb state to an XDG cache directory keyed by a stable hash of the canonical workspace path: `${XDG_CACHE_HOME:-~/.cache}/rts/<blake3(canonical_workspace_path)>/snapshot.redb`. On macOS, resolves to `~/Library/Caches/rts/<hash>/snapshot.redb` (exact path resolution deferred to planning).
+- **R2.** On daemon startup with a non-empty cache directory:
+  1. Open the snapshot file and read its header.
+  2. Verify the snapshot's stored fingerprint matches the current fingerprint (see R3).
+  3. On match: enter **rehydrate path** (R4).
+  4. On mismatch or read error: enter **cold-walk path** (existing behavior), logging the reason for the bypass.
+- **R3.** The fingerprint is a single composite value covering everything that could invalidate cached state:
+  - `SCHEMA_VERSION` (redb table layout)
+  - daemon binary version (semver string or `git describe`)
+  - the version of every tree-sitter grammar crate currently linked
+  - hash of the workspace's effective `.gitignore` content (including parent-dir/global gitignores)
+  Any drift triggers a full cold walk.
+- **R4.** The **rehydrate path** behaves as follows:
+  1. Open the redb snapshot in-place (no copy).
+  2. Scan the workspace and compute `(mtime, size)` for each file the snapshot claims to know about.
+  3. Re-parse and re-index only files whose `(mtime, size)` differs from the snapshot, plus files present on disk but absent from the snapshot.
+  4. Drop snapshot entries for files no longer present on disk.
+  5. Start the watcher as today.
+- **R5.** Snapshot writes happen at exactly two points:
+  - Immediately after the initial cold-walk completes (first write).
+  - On graceful daemon shutdown (SIGTERM, idle-timeout, or explicit stop).
+  Live edits between these two points are NOT flushed to the snapshot file in real time. The in-memory redb table is the source of truth between writes; if the daemon dies ungracefully (SIGKILL, panic), the snapshot at most loses session-window edits, which are re-derivable from the workspace on next startup.
+- **R6.** Snapshot writes are atomic: write to `snapshot.redb.tmp` in the same directory, fsync, then `rename` to `snapshot.redb`. A reader that opens during the write window sees either the old snapshot or the new one — never a torn file.
+- **R7.** The snapshot file has a small header (or sidecar manifest, choice deferred to planning) carrying:
+  - magic bytes / format identifier
+  - fingerprint (R3)
+  - write timestamp
+  - per-table checksum (blake3 of the serialized table contents)
+  At load time, the daemon verifies the per-table checksum. A mismatch causes the snapshot to be discarded (cold-walk path) AND the cache directory cleared so subsequent startups don't retry the broken snapshot.
+- **R8.** Snapshot file permissions are `0600` (owner-only) and the cache directory is `0700`. The daemon's existing `umask(0077)` invariant already enforces this; planning confirms.
+- **R9.** First-query latency on a healthy rehydrate: target **p95 < 100 ms** on a 100k LOC workspace where no files changed between sessions. This is the user-perceived metric; if the snapshot is good but rehydrate is slow, the feature has failed its purpose.
+- **R10.** `Daemon.Stats` (#104) exposes a new field, `mount_source`, with one of these values from the most recent startup:
+  - `cold_walk` — no snapshot present
+  - `rehydrate` — snapshot rehydrated successfully
+  - `cold_walk_after_invalidation:<reason>` — snapshot present but invalidated (schema, grammar, gitignore, checksum)
+  This lets agent-bench, `rts-bench doctor` (separate brainstorm), and operators see whether the snapshot is doing its job.
+- **R11.** When the user explicitly wants a clean rebuild, `rts-daemon --reset-snapshot` clears the cache directory before starting. Single flag; no subcommand. Existing daemon flags remain unchanged.
+
+## Success Criteria
+
+- **SC1.** On a 100k LOC workspace, the *second* daemon startup of a session sequence (i.e., the one that finds a valid snapshot) reaches "first query answerable" in **p95 < 100 ms**, versus ~6 s today. Cold walk on first-ever startup of a workspace is unchanged.
+- **SC2.** A deliberate `SCHEMA_VERSION` bump or grammar-version bump invalidates the snapshot transparently: the next daemon startup logs the invalidation reason, performs a full cold walk, writes a new snapshot, and subsequent startups rehydrate from the new snapshot. No user intervention needed.
+- **SC3.** The README's *Status* / *Quick start* section gains a one-line claim: *"Daemon startup: ~6 s cold-walk on first session, sub-100 ms thereafter (persisted snapshot)."*
+- **SC4.** In the agent-bench harness, per-task wall-clock latency for tasks that share a workspace with a previous task drops measurably (the cold-mount tax is gone for tasks 2-N). Visible in the JSON output without harness changes.
+
+## Scope Boundaries
+
+- **Out of scope (v1):** real-time mirroring of redb edits to the snapshot file (rejected challenger). Doubles write amplification for a marginal `kill -9` recovery benefit; the live-edit path is fast enough that a re-walk after ungraceful exit is acceptable.
+- **Out of scope (v1):** in-tree cache location (`<workspace>/.rts-cache/`). Adds gitignore pressure and multi-user-on-shared-workspace foot-guns. XDG cache is canonical for this v1; a configurable cache dir is a possible v2.
+- **Out of scope (v1):** snapshot sharing across machines (rsync, scp, dotfile sync). Workspace-path-keyed snapshots are machine-local by design; cross-machine sharing involves canonical-path mapping and clock-skew handling that doesn't belong in v1.
+- **Out of scope (v1):** snapshot garbage collection. Old snapshots accumulate one per workspace; a `rts-bench doctor`-adjacent pruning command is a separate feature.
+- **Out of scope (v1):** snapshot compression. redb is already compact for this workload; zstd-on-disk adds CPU at every read for marginal disk savings. Revisit if snapshots get large in practice.
+- **Out of scope (v1):** multi-daemon coordination on the same snapshot. The existing per-workspace daemon model already enforces one daemon per workspace; if a second daemon tries to write, the second one loses (atomic rename semantics). Cross-process locking on the snapshot file is a v2 if it becomes a problem.
+- **Out of scope (v1):** snapshot for multi-workspace daemons (federated index). Tracked separately under ideation idea #8 (rejected, deferred to its own round).
+- **Out of scope (v1):** an MCP-callable "reset snapshot" command. The CLI flag `--reset-snapshot` is the only knob; agents don't get to clear the cache.
+
+## Key Decisions
+
+- **Full redb snapshot over per-file parse cache or "just the file list."** The post-cold-walk redb is the most expensive thing to rebuild (PageRank closure, call graph, enclosing-name resolution). Caching just parsed trees would still pay the graph-build cost on every startup. Caching just the file list saves ~10% of cold-walk. Snapshotting the whole redb captures the full investment.
+- **XDG cache, machine-local over in-tree.** Cleaner: no repo pollution, no `.gitignore` churn, no multi-user-on-shared-workspace conflicts. Lost on `mv`/`rsync` of the workspace, which triggers a one-time cold walk — acceptable cost for the operational clarity.
+- **Single composite fingerprint over per-language invalidation.** One hash, one decision: "do these bytes still apply to this state of the world?" Per-language is more efficient on a grammar bump but introduces per-table-per-language version tracking. The cost of a full re-walk after a grammar bump is bounded (one cold walk per grammar bump per workspace, paid once); the cost of getting per-language invalidation wrong is silent corruption.
+- **Write at cold-walk-done + graceful shutdown; checksum-verify on load.** Two writes per daemon lifetime; no write amplification on live edits; ungraceful exit at worst loses one session's incremental updates, which are re-derivable from disk. Checksum verification turns "I trust the cache" into a per-load assertion.
+- **`mount_source` telemetry.** Without it, we can't tell whether the snapshot is doing its job. The agent-bench harness and `doctor` both want to know. Costs one field in `Daemon.Stats`.
+
+## Dependencies / Assumptions
+
+- The daemon's redb backing store is currently a *temporary* on-disk file (or in-memory) that doesn't survive restarts. The brainstorm assumes the work is to *promote* this to a stable, hashable location — not to invent persistence from scratch. (To confirm at planning by reading `crates/rts-daemon/src/store/mod.rs`.)
+- redb's file format is stable enough across patch versions to be cached on disk and read back later. Major redb version bumps are part of the daemon binary version in the fingerprint.
+- All linked tree-sitter grammars expose a version string (or compile-time `version()` callable) that we can capture into the fingerprint. Most tree-sitter language crates do; verify per-grammar at planning.
+- The `.gitignore` content hash is stable: parent-dir gitignores and global gitignores (e.g., `~/.config/git/ignore`) are part of the effective file list, so their content goes into the fingerprint.
+- `Daemon.Stats` is the canonical surface for the new `mount_source` field; protocol-v0 evolution rules govern how it's exposed.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+*(none — all product-level decisions are made)*
+
+### Deferred to Planning
+
+- **[Affects R1]** **[Technical]** Exact cache path resolution on macOS: strict XDG (`$XDG_CACHE_HOME` then `~/.cache`) or platform-native (`~/Library/Caches`)? Other rust tooling on macOS is split; pick one and document it.
+- **[Affects R3]** **[Needs research]** How does each linked tree-sitter grammar crate expose its version? Some have `tree_sitter_LANG::LANGUAGE_VERSION`, others have `Cargo.toml` versions only. The fingerprint needs a uniform source per grammar.
+- **[Affects R3]** **[Technical]** `.gitignore` content hashing: include parent-dir ancestors? Include the global gitignore? Order-sensitive (concatenation order matters)? Whitespace-normalized? Recommend strict bytewise concatenation in walk order, no normalization.
+- **[Affects R7]** **[Technical]** Snapshot header layout: in-line at the start of the redb file (custom magic + offset), or sidecar `snapshot.meta` JSON next to `snapshot.redb`? Sidecar is simpler to evolve; in-line is harder to corrupt independently.
+- **[Affects R4]** **[Technical]** Rehydrate-path file-list scan: do we walk the workspace top-down (like cold walk) or iterate the snapshot's known files and stat each? The first finds new files faster; the second is incremental in the steady state. Likely both, run in parallel.
+- **[Affects R5]** **[Technical]** Atomic write on filesystems where rename-over-existing isn't atomic (some FUSE, some network FS): is there a fallback? Accept that snapshot reuse on non-atomic FS is best-effort and falls back to cold walk on checksum mismatch.
+- **[Affects R9]** **[Technical]** Concrete rehydrate-path latency budget breakdown: redb open (≈5 ms?), header verify (≈1 ms), stat scan of 10k files (≈50 ms?), incremental re-parse of changed files (variable). Quantify in planning so SC1 is testable.
+- **[Affects R5]** **[Technical]** Snapshot-on-shutdown timing: bound how long graceful shutdown will wait for the snapshot write. If it takes >2 s, abort the write (next startup will cold-walk). Don't hang daemon shutdown on slow disk.
+- **[Affects R3]** **[Product]** Daemon binary version in the fingerprint: full semver (any patch bump invalidates), or just major.minor? Patch bumps usually don't change on-disk shape, but they sometimes fix indexer bugs that re-parsed files would benefit from. Lean toward full version for safety; profile if it's actually costly.
+- **[Affects R10]** **[Product]** Is `mount_source` exposed in the `rts-bench doctor` workspace-state section (brainstorm #1)? Strongly recommend yes — doctor is the natural place to see "your snapshot is fresh / stale / missing."
+
+## Next Steps
+
+→ All three queued brainstorms are now drafted (`rts-doctor`, `index-grep-v2`, `persisted-cold-mount`). Recommended order for `/ce:plan`: doctor first (lowest complexity, fastest to ship and gives field signal for the other two), then `index-grep-v2` (largest value-prop win, real adoption-shifter), then persisted cold-mount (deepest invariants, benefits from doctor's `mount_source` surface).

--- a/docs/brainstorms/2026-05-18-rts-doctor-requirements.md
+++ b/docs/brainstorms/2026-05-18-rts-doctor-requirements.md
@@ -1,0 +1,93 @@
+---
+date: 2026-05-18
+topic: rts-doctor
+---
+
+# `rts doctor` — first-run health check
+
+## Problem Frame
+
+The #1 first-run failure pattern for rts is silent. A user installs the binary, registers the MCP server, opens their agent — and nothing visible happens. Possible silent failures:
+
+- daemon binary missing from `$PATH`
+- daemon not running (or running but pinned to a different workspace)
+- MCP not registered to the right scope (user vs project vs local in Claude Code; analogous splits in Cursor/Continue)
+- `.mcp.json` present but malformed or pointing at a stale binary
+- PreToolUse hook (`.claude/hooks/rts-nudge.sh`) missing or non-executable
+- index never finished cold-walk; `find_symbol` returns empty
+- workspace path mismatch — daemon happily indexes the wrong directory
+
+Today the user grep-debugs the README, tails the daemon log, runs `ps` and `lsof`, and eventually files an issue. Adoption ceiling = *"users patient enough to debug a silent install."*
+
+`rts doctor` is the cheapest possible investment past that ceiling: one subcommand that names every install signal and prints a copy-pasteable fix for anything broken.
+
+## Requirements
+
+- **R1.** `rts-bench doctor` is a new subcommand on the existing `rts-bench` binary. Runs offline. No network calls.
+- **R2.** Doctor is **read-only**. It never writes to a user config file, never restarts the daemon, never installs anything. Side-effect-free except for `stderr`/`stdout`.
+- **R3.** Doctor reports two signal classes per run:
+  - **Install state** — binary version, daemon binary on `$PATH`, MCP registration in each supported agent host, hook file present + executable.
+  - **Workspace state** — for the workspace at `$PWD`: daemon PID (or "not running"), workspace path the daemon is pinned to, index generation, last-completed-cold-walk timestamp, file count indexed.
+- **R4.** Doctor covers all 5 advertised agent hosts: Claude Code, Cursor, Continue, Aider, Cline. Claude Code / Cursor / Continue use **hard detection** (canonical config-file paths). Aider / Cline use **soft detection** (best-effort: look for known config locations and CLI invocation patterns). Soft-detection results are labelled `?` in the checklist and never fail the run on their own.
+- **R5.** Default output is a **human checklist**, grouped by section, with one row per signal. Each row is `[OK]`, `[WARN]`, or `[FAIL]`. Every `WARN` and `FAIL` is followed on the next line by a copy-pasteable one-line fix command (or, when no single command suffices, a short fix description + a link to the relevant section of `docs/install.md`).
+- **R6.** `rts-bench doctor --json` produces machine-readable output: a single JSON object with the same signals, designed for agent consumption and for future automation. Shape stable across patch releases; documented in `docs/protocol-v0.md` or a sibling `docs/doctor-schema.md`.
+- **R7.** Exit code semantics:
+  - `0` — no `FAIL` rows (any `WARN` rows allowed).
+  - `1` — any `FAIL` row.
+  - `2` — doctor itself failed (couldn't read its own binary, panicked, etc.).
+- **R8.** Doctor's **own latency budget** is `<500 ms p95` on a healthy install (no daemon spawn, no cold walk). It probes the daemon over the existing protocol-v0 socket; it does not start a daemon to ask one question.
+- **R9.** When the daemon is reachable, doctor uses one round-trip for workspace state. Choice of RPC (existing `Daemon.Stats` vs a new `Daemon.Ping`) is a planning-time decision (see Deferred questions). When the daemon is unreachable, doctor reports the install signals it can determine statically and flags the workspace section as `[WARN] daemon not running`.
+- **R10.** Doctor's checklist is grouped into named sections so the JSON shape and the human shape carry the same structure. Sections: `binary`, `daemon`, `mcp_registration`, `hook`, `workspace_index`. Each section header is independently runnable for testing.
+
+## Success Criteria
+
+- **SC1.** A new user with a clean machine and a broken install (e.g., MCP not registered) runs `rts-bench doctor`, copies the suggested fix, runs it, re-runs doctor, and sees all `[OK]`. End-to-end without consulting the README.
+- **SC2.** On a healthy install the human output fits in one terminal screen (~30 lines) and the run completes in under 500 ms p95.
+- **SC3.** The `--json` output is consumed by at least one downstream surface within 30 days of doctor shipping (the obvious candidate is the agent-bench harness's preflight in `agent-bench/`).
+- **SC4.** The README's *"Status"* section gains a single line: *"`rts-bench doctor` diagnoses install state across all five supported agents."*
+
+## Scope Boundaries
+
+- **Out of scope (v1):** `--fix` mode that applies recommended changes. Doctor is diagnostic-only in v1; `--fix` is a separate later proposal.
+- **Out of scope (v1):** behavioral state. Per-method call counters, nudge-fire log, recent error rate. These live in `daemon-stats` (#104) and the auto-dump-on-shutdown (#105) and stay there.
+- **Out of scope (v1):** cross-version drift detection. The known "Claude Code spawned a pre-#104 rts-mcp at session start" version-skew bug is a real signal class but stays a separate brainstorm.
+- **Out of scope (v1):** network probes, telemetry upload, calling out to GitHub for the latest version. Offline-only.
+- **Out of scope (v1):** subsuming `rts install`. Doctor diagnoses; an install subcommand (if it ever ships) is a separate brainstorm.
+- **Out of scope (v1):** "deep" workspace audits — per-file parse error rates, per-language coverage, grammar version mismatches. Surface area too big for v1.
+
+## Key Decisions
+
+- **Read-only over diagnostic + opt-in `--fix`** — auto-fix touches user config files; risk/reward is wrong for v1 when the failure surface is still being mapped. Defer `--fix` until field data tells us which fixes are universally safe.
+- **All 5 agent hosts at v1, with soft-detect labelling for Aider/Cline** — matches what the README advertises. Soft-detect is honest: doctor reports what it could and couldn't determine, rather than silently skipping.
+- **Lean signal classes (install + workspace only)** — behavioral and version-drift signals are real but live in separate, already-shipped surfaces. Keeping doctor narrow makes the "all-OK" case unambiguous.
+- **Human checklist + inline fix snippets as default; `--json` flag** — humans read the failure context inline with the suggested fix, agents consume `--json`. One subcommand, two audiences, neither one has to read the other's format.
+- **Subcommand on `rts-bench`** — lowest packaging cost. A future thin `rts` binary that re-exports common subcommands is its own decision.
+- **Exit `0` on `WARN`, `1` on `FAIL`** — lets CI gates differentiate "broken" from "imperfect."
+
+## Dependencies / Assumptions
+
+- Doctor reads (does not modify) `.mcp.json`, `~/.claude/settings.json`, `~/.cursor/`, `~/.continue/`, `.aider/`, `.cline/` — exact paths to be confirmed in planning.
+- Doctor assumes the protocol-v0 Unix socket convention from `rts-daemon` for reachability probes.
+- Soft-detect for Aider relies on `~/.aider.conf.yml` or `AIDER_CONFIG`; soft-detect for Cline relies on the VS Code extension's settings file location. Both are best-effort.
+- Doctor depends on `Daemon.Stats` (or a new `Daemon.Ping`) being callable without a running mount. To confirm in planning.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+*(none — all product-level decisions are made)*
+
+### Deferred to Planning
+
+- **[Affects R3]** **[Technical]** What's the precise definition of "stale" for the index-freshness signal? Options: (a) `index_generation == git HEAD commit`, (b) "any unwatched file under workspace has mtime > last cold-walk", (c) a delta-LOC threshold. Likely (b) with explicit override.
+- **[Affects R4]** **[Needs research]** Per-host config file paths and MCP-scope conventions for each of Claude Code (user/project/local), Cursor, Continue, Aider, Cline. Some are documented; some require reading each tool's source or community docs.
+- **[Affects R9]** **[Technical]** Reachability probe: extend `Daemon.Stats` (cheap, already exists) or add a dedicated `Daemon.Ping`? Probe choice affects what we can report when the daemon is reachable but its workspace is wrong.
+- **[Affects R3]** **[Technical]** Workspace-mismatch detection: how does doctor identify that the running daemon is pinned to a *different* workspace than `$PWD`? Daemon currently emits its pinned-workspace path in `Daemon.Stats`; confirm this is exposed.
+- **[Affects R4]** **[Technical]** Claude Code MCP scope detection: rts may be registered in user/project/local scope. Doctor should report which scope and warn on multi-scope registration (the "two different rts versions wired up" foot-gun). Need to confirm the canonical lookup order.
+- **[Affects R5]** **[Product]** All-OK output format: still print every row, or collapse to a one-line `All checks passed (12 OK).`? Trade-off: discoverability vs noise. Lean toward "print every row but compact."
+- **[Affects R4]** **[Needs research]** Soft-detect criteria for Aider/Cline — what specifically counts as evidence that rts is wired up? File presence? CLI flag scan? Version pin in config? Document the criteria in planning so users know what doctor is and isn't checking.
+- **[Affects R6]** **[Technical]** JSON schema versioning: is the doctor JSON considered part of protocol-v0 (versioned with the daemon protocol), part of a new doctor-schema-v0, or unversioned? Recommend its own schema so doctor can evolve without bumping the daemon protocol.
+
+## Next Steps
+
+→ Continue brainstorming idea #3 (`Index.Grep` v2) next, then idea #4 (Persisted cold-mount index), per the ideation queue. After all three brainstorms land, run `/ce:plan` on each in turn.

--- a/docs/doctor-schema.md
+++ b/docs/doctor-schema.md
@@ -1,0 +1,235 @@
+# `rts-bench doctor` — schema & exit-code contract
+
+This document is the wire-shape contract for `rts-bench doctor`'s
+`--output json` mode plus its documented exit-code semantics. It is
+the consumer-facing surface for agent-bench preflights and any other
+machine consumer of doctor's output.
+
+The schema is versioned via the top-level `schema_version` field.
+**v1 ships as `doctor-v0`**. Additive evolution happens via the
+`capabilities[]` array; new fields advertise via new capability
+strings, never a `schema_version` bump. Breaking-shape changes would
+require a new `schema_version` (e.g. `doctor-v1`), which is not on the
+roadmap.
+
+## Exit-code contract
+
+| Code | Meaning |
+|------|---------|
+| `0`  | No `FAIL` rows in any section. Any number of `WARN` or `INFO` rows is allowed. Doctor's install + workspace state is considered healthy enough to use rts. |
+| `1`  | At least one `FAIL` row. User intervention required — the offending row's `fix.command` is a copy-pasteable starting point. |
+| `2`  | Doctor itself failed (panic, JSON serialization error, I/O failure on its own binary). Stdout still emits a valid JSON envelope when `--output json` is set; stderr carries the failure message. |
+
+**Reserved**: exit codes `>= 3` are reserved for future use. CI gates
+that consume `rts-bench doctor` MUST NOT depend on specific exit codes
+above `2`.
+
+## Top-level shape (`doctor-v0`)
+
+```jsonc
+{
+  "schema_version": "doctor-v0",
+  "capabilities": ["sections_v0", "fix_snippets", "host_detection_5x"],
+  "sections": [
+    { "name": "binary",            "rows": [...], "partial_failures": [...] },
+    { "name": "daemon",            "rows": [...], "partial_failures": [...] },
+    { "name": "mcp_registration",  "rows": [...], "partial_failures": [...] },
+    { "name": "hook",              "rows": [...], "partial_failures": [...] },
+    { "name": "workspace_index",   "rows": [...], "partial_failures": [...] }
+  ],
+  "exit_class": "ok",   // "ok" | "warn" | "fail" | "self_error"
+  "error": null         // present only when exit_class == "self_error"
+}
+```
+
+### `schema_version: string`
+
+Locked at `"doctor-v0"`. Future shape changes require a major bump.
+Additive changes do NOT bump this field; they advertise via
+`capabilities[]`.
+
+### `capabilities: string[]`
+
+Stable, ordered, growing-only set of feature flags. v1 ships with:
+
+- `sections_v0` — the 5-section layout in the order documented above
+- `fix_snippets` — each WARN/FAIL row may carry an inline `fix` block
+- `host_detection_5x` — covers Claude Code, Cursor, Continue, Aider, Cline
+
+Consumers branch on capability strings, not on doctor version numbers.
+
+### `sections: Section[]`
+
+Sections appear in this normative order in both human and JSON output:
+
+1. `binary` — doctor's own version, rts-daemon / rts-mcp on PATH, symlink resolution, cross-binary version drift
+2. `daemon` — per-workspace socket probe, `Daemon.Stats v2` round-trip, pre-v2 fallback
+3. `mcp_registration` — rts MCP entry presence across Claude Code, Cursor, Continue, Aider, Cline; cross-scope drift
+4. `hook` — `.claude/hooks/rts-nudge.sh` presence, executability, version-marker match
+5. `workspace_index` — pinned-workspace path match, cold-walk completion, index generation, file count
+
+### `exit_class: "ok" | "warn" | "fail" | "self_error"`
+
+Derived from the max-severity row across all sections (`fail` > `warn`
+> `ok`). `self_error` is set independently when doctor itself
+panicked or failed to initialize.
+
+### `error: string | null`
+
+Set only when `exit_class == "self_error"`. Carries a freeform
+human-readable description of the failure. Absent (or `null`)
+otherwise.
+
+## Section shape
+
+```jsonc
+{
+  "name": "<section-name>",
+  "rows": [Row, ...],
+  "partial_failures": [PartialFailure, ...]
+}
+```
+
+### `name: string`
+
+One of the five normative names above. Order-stable across runs.
+
+### `rows: Row[]`
+
+The section's observable findings. Order is implementation-defined
+but stable within a single doctor build.
+
+### `partial_failures: PartialFailure[]`
+
+Annotations for recoverable errors that didn't produce a row (e.g.
+*"the Continue config exists but the YAML failed to parse"*).
+Surfaced as `(partial: <label> — <message>)` lines in human output.
+The field is omitted entirely when empty.
+
+## Row shape
+
+```jsonc
+{
+  "kind": "ok",        // "ok" | "warn" | "fail" | "info"
+  "label": "section:check_name",
+  "message": "human-readable summary",
+  "fix": {             // optional; present on most WARN/FAIL rows
+    "class": "install_binary",
+    "command": "cargo install --path crates/rts-daemon",
+    "description": "optional context (1-2 sentences)"
+  }
+}
+```
+
+### `kind: "ok" | "warn" | "fail" | "info"`
+
+| Kind   | Human prefix | Affects exit code? |
+|--------|--------------|--------------------|
+| `ok`   | `[OK]`       | No — exit 0 |
+| `warn` | `[WARN]`     | No — exit 0; surfaces an anomaly worth fixing |
+| `fail` | `[FAIL]`     | Yes — exit 1 |
+| `info` | `[?]`        | No — soft-detect "we looked but couldn't determine" |
+
+### `label: string`
+
+Stable identifier of the form `<section>:<check_name>` (e.g.
+`binary:rts_daemon_on_path`, `daemon:reachable`,
+`mcp_registration:claude_code:user_scope`). Used by snapshot tests
+and by external tooling that wants to assert on specific checks.
+
+### `message: string`
+
+Human-readable summary. Stable across runs given the same input
+state, so snapshot tests can diff against goldens.
+
+### `fix: object | absent`
+
+Optional. Present on most `warn` and `fail` rows when doctor has a
+copy-pasteable recovery action. Absent on `ok` and `info` rows.
+
+#### `fix.class: string`
+
+Closed taxonomy. Current set (subject to additive extension):
+
+- `install_binary` — rts binary missing from PATH or version mismatched
+- `start_daemon` — daemon not running for this workspace
+- `remove_stale_socket` — socket file present but no live daemon
+- `register_mcp` — rts not registered with the named agent host
+- `fix_mcp_binary_path` — MCP config references a missing/non-executable binary
+- `make_hook_executable` — hook present but not executable
+- `update_hook` — hook content marker is out of date
+- `move_workspace` — daemon pinned to a different workspace than `$PWD`
+- `reindex_needed` — index empty or stale; trigger a re-index
+- `fix_config_syntax` — host config file present but unparseable
+
+Consumers should treat unknown `class` values as opaque labels.
+
+#### `fix.command: string`
+
+A single shell-line that the user can paste verbatim.
+
+#### `fix.description: string | absent`
+
+Optional context (1-2 sentences) for when the command alone is
+unclear. Absent when the command is self-explanatory.
+
+## PartialFailure shape
+
+```jsonc
+{
+  "label": "host:claude_code:user_scope",
+  "message": "could not parse ~/.claude.json: expected `,` at line 12"
+}
+```
+
+Surfaced under the section header in human output as
+`(partial: <label> — <message>)`. Does not affect exit code.
+
+## Self-error envelope
+
+When `exit_class == "self_error"`, the response shape collapses to:
+
+```jsonc
+{
+  "schema_version": "doctor-v0",
+  "capabilities": [...],
+  "sections": [],
+  "exit_class": "self_error",
+  "error": "panic in daemon_section: thread 'main' panicked at ..."
+}
+```
+
+The `sections` array is empty (the panic-handler captures whatever
+sections completed; v1 omits them for simplicity). The `error` field
+carries the panic message or initialization error.
+
+## Snapshot stability
+
+Both human and JSON output are designed for snapshot testing:
+
+- **No wall-clock timestamps** anywhere in the default output.
+  `cold_walk_completed_at_ms` (when present in workspace_index rows)
+  is *data*, not flake.
+- **Section order is normative** (see above).
+- **Row order within a section is stable** within a single doctor build.
+- **ANSI is disabled** by default when stdout is not a TTY, when
+  `NO_COLOR` is set, or when `--no-color` is passed.
+
+## Backward compatibility
+
+Doctor's response shape is purely additive going forward. Adding a
+new field to a `Row`, a new section, a new `fix.class` variant, or a
+new top-level field does NOT bump `schema_version`. A consumer that
+ignores unknown fields (the standard JSON parser default) will keep
+working across additive evolution.
+
+Removing or renaming a field WOULD require a `schema_version` bump.
+This is not planned.
+
+## See also
+
+- [`docs/install.md`](install.md) — per-agent install snippets
+- [`docs/protocol-v0.md`](protocol-v0.md) — daemon/MCP wire protocol;
+  `daemon_stats_v2` capability backs doctor's workspace_index section
+- Plan: [`docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md`](plans/2026-05-18-001-feat-rts-bench-doctor-plan.md)
+- Origin brainstorm: [`docs/brainstorms/2026-05-18-rts-doctor-requirements.md`](brainstorms/2026-05-18-rts-doctor-requirements.md)

--- a/docs/ideation/2026-05-17-what-else-after-phase-2-and-readme-ideation.md
+++ b/docs/ideation/2026-05-17-what-else-after-phase-2-and-readme-ideation.md
@@ -1,0 +1,149 @@
+---
+date: 2026-05-17
+topic: what-else-after-phase-2-and-readme
+focus: open-ended ("what else?")
+---
+
+# Ideation: What else? (round 9, post #94–#108)
+
+## Codebase Context
+
+**Project shape.** Rust 2024 / Cargo workspace, MSRV 1.85, resolver=3. Four crates: `rts-core` (tree-sitter wrapper, 12 grammars), `rts-daemon` (persistent per-workspace daemon, redb + notify), `rts-mcp` (rmcp 1.6 stdio bridge), `rts-bench` (operator CLI + bench harness). Sibling `agent-bench/` is a Python/uv SWE-bench-lite A/B harness landed in #107.
+
+**Shipped in the last 14 PRs (#94–#108).** Reference-graph correctness on cold-walk (#100) + live-edit (#103) paths. Per-session call counters via `Daemon.Stats` (#104) and auto-dump on shutdown (#105). PreToolUse hook nudging Bash grep → `mcp__rts__grep` in Claude Code (#106). agent-bench harness foundation: bridge + run loop + Wilson-CI reporter, 28 mock-API tests pass (#107). README rewrite from 403-line maintenance doc to 142-line pitch + new `docs/development.md` and `docs/demo.md` (#108 open).
+
+**What hasn't been addressed (the surface area for "what else?"):**
+
+- **Distribution friction**: no `brew install rts`, no `cargo install rts`, no `npx` wrapper, no `claude mcp add` one-liner that auto-downloads the binary. First-run failures (daemon not running, MCP not registered, stale index) are silent.
+- **Cross-agent reach**: the PreToolUse nudge only fires in Claude Code. Cursor / Continue / Aider / Cline are mentioned in README but get no nudge. Adoption ceiling = "users whose agent reaches for MCP AND that agent is Claude Code."
+- **Multi-line `Index.Grep`**: regex is single-line; multi-line patterns still need `rg`.
+- **Call-edge parity**: 6 of 12 indexed languages have regex-fallback call detection (Go/Java/PHP/Ruby/Swift/C#), not AST-precise.
+- **Cold-mount cost**: ~6s on 100k LOC, paid per session.
+- **Cross-session telemetry**: per-machine, per-session; no aggregation.
+- **`archive/` clutter**: 30k LOC of dead pre-pivot AI/security/SARIF analyzers in the repo's first-impression file tree.
+- **`docs/solutions/` doesn't exist**: every ideation/planning round restarts from zero institutional knowledge.
+- **Hook is one-directional**: only nudges *toward* rts; doesn't surface when rts returned a low-confidence answer that should fall back to `rg`.
+- **No "ask the index in English"**: every tool is structured; user must already know the surface.
+
+**Past learnings.** `docs/solutions/` is empty (confirmed via learnings-researcher). No retrospective notes exist — every ideation round restarts from zero. Worth scaffolding alongside one of the survivors.
+
+## Ranked Ideas
+
+### 1. `rts doctor` — first-run health check
+
+**Description:** A single CLI subcommand that diagnoses install state across all configured agents: binary version, daemon reachability, per-workspace daemon PIDs, MCP registration across Claude Code / Cursor / Continue / Aider / Cline, hook installation, index freshness. Prints a checklist with copy-pasteable one-line fixes.
+
+**Rationale:** The #1 first-run failure pattern today is silent: daemon not running, MCP not registered to the right scope, stale index, wrong workspace. Users currently grep through the README to debug. This is the cheapest possible investment in adoption beyond *"users whose agent reaches for MCP."*
+
+**Downsides:** Maintenance — each new agent host adds a config-detect path. Doesn't *create* new capability; it surfaces existing state.
+
+**Confidence:** 90%
+**Complexity:** Low
+**Status:** Explored (brainstorm queued 2026-05-18)
+
+### 2. agent-bench public leaderboard + Phase 2 PR-B baseline
+
+**Description:** Promote the audited 6-language corpus + Wilson-CI A/B harness from #107 into a versioned, citeable benchmark with `agent-bench run`, a published JSON results schema, and the first real Sonnet baseline committed to `bench-results/`. The benchmark becomes its own product surface — agent vendors can submit runs against a stable, public baseline.
+
+**Rationale:** Closes the 9-round *"are you regularly using it?"* loop with a number, not a vibe. Turns every future rts change into a measurable delta against a public baseline. The corpus across rust-log / ripgrep / chalk / cobra / gson / requests / dogfood-v3 is unique — no published benchmark has that shape today.
+
+**Downsides:** Real API spend (~$50-100/run Sonnet, $300+ Opus). Maintaining a leaderboard is its own commitment; if external submissions don't come, it's a stale page.
+
+**Confidence:** 75%
+**Complexity:** Medium
+**Status:** Unexplored
+
+### 3. `Index.Grep` v2 — multiline regex + structural queries + within-symbol scope
+
+**Description:** Three extensions to the same tool, shipped together:
+- `(?s)` multiline regex over the indexed bytes
+- new `Index.StructGrep` variant that takes a tree-sitter query and runs it over the parsed-tree cache (`@reference.call`-style structural search)
+- `within_symbol: "fn_name"` filter on the existing literal grep, intersecting byte-range-of-def with the byte-range-of-match
+
+Combines two raw ideas (P7 multi-line + structural; U4 symbol-scoped) into one coherent tool upgrade.
+
+**Rationale:** Multi-line regex is the #1 reason agents bail from rts back to `rg` mid-session — known leak in the value proposition. Structural grep is the unique moat over `rg`: *"find every impl block containing an unsafe fn"* is a one-tool-call answer, not a grep-then-filter. Symbol-scoped grep makes refactor-shaped searches sub-second.
+
+**Downsides:** Tree-sitter query string is a power-user API; needs good error messages on malformed queries. Multiline regex grows the DFA size cap; needs a budget.
+
+**Confidence:** 85%
+**Complexity:** Medium
+**Status:** Explored (brainstorm queued 2026-05-18)
+
+### 4. Persisted cold-mount index
+
+**Description:** Serialize the post-cold-walk redb index snapshot to `~/.cache/rts/<workspace-hash>/` and rehydrate on subsequent daemon startup, re-parsing only files whose mtime/size changed. Invalidate on schema-version bump or tree-sitter grammar version change.
+
+**Rationale:** Cold mount on 100k LOC takes ~6 s today and is paid every time the daemon goes idle (10 min default). Killing it makes *"open editor, ask question"* feel instant for the first query of a session — the only latency users perceive.
+
+**Downsides:** Cache invalidation is the perennial hard problem. mtime races; multi-machine workspaces (network FS) need a fingerprint that survives clock skew.
+
+**Confidence:** 80%
+**Complexity:** Medium
+**Status:** Explored (brainstorm queued 2026-05-18)
+
+### 5. Universal agent autowire + generic PreToolUse policy engine
+
+**Description:** Two paired changes:
+- `rts install --agent all` detects installed coding agents (Claude Code, Cursor, Continue, Aider, Cline, Zed AI, Windsurf) and writes per-agent MCP config + system-prompt injection where each supports it
+- Factor `.claude/hooks/rts-nudge.sh` into a tiny declarative tool-nudge engine driven by a TOML ruleset; rts becomes one rule among many
+
+Combines two raw ideas (P3 + L3) — same problem at two layers.
+
+**Rationale:** README promises Cursor / Continue / Aider / Cline support; only Claude Code has the active behavior nudge today. Each non-Claude agent is a silent loss. The generic policy engine lifts a pattern useful well beyond rts (don't grep `node_modules/`, prefer `rg` over plain grep, etc.).
+
+**Downsides:** Each agent has a different injection surface — what the nudge looks like in Cursor's rules vs Aider's system prompt is real engineering, not translation. Risk of building a hook framework that's worse than each agent's native config.
+
+**Confidence:** 70%
+**Complexity:** Medium-High
+**Status:** Unexplored
+
+### 6. Refactor Preview as a first-class query
+
+**Description:** A new read-only MCP tool `Index.RenamePreview(old, new)` returns the exact unified diff of every call site + def site that would change for a symbol rename, without touching disk. The daemon owns the textual edit semantics; the agent (or human) reviews the diff and decides whether to apply.
+
+**Rationale:** Refactors are the agent's most error-prone op today (grep-and-sed across 12 languages with locale-dependent boundary handling). Making refactor preview a graph query reframes rts from *"retrieval"* to *"retrieval + safe-edit preview."* On 6 AST-precise languages this is high-confidence; on the regex-fallback 6 we'd need a confidence score per site.
+
+**Downsides:** Boldest of the six — partially redefines what rts is. Agents may already do this through Edit/Write tools; the value is being *atomic + reviewable* per symbol, not per-file.
+
+**Confidence:** 60%
+**Complexity:** High
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason rejected |
+|---|---|---|
+| 1 | Blast Radius Heatmap | Overlaps `impact_of` which exposes BFS-with-rank already |
+| 2 | Reverse-PageRank `UpstreamOf` | Adjacent to `impact_of`; small marginal value |
+| 3 | Daemon-as-MCP-server (delete `rts-mcp`) | High-risk refactor; protocol-v0 boundary is load-bearing; zero user-facing win |
+| 4 | One daemon, many workspaces | Superseded by federated-index (A2) as the bigger play; both deferred |
+| 5 | Single `query` tool with intent routing | Speculative — agents call the right tool today; no evidence of the failure mode |
+| 6 | Auto-generated changelog fragments | Too small for ideation (10-min commit-msg hook) |
+| 7 | Continuous bench-on-save | Bench takes minutes, not seconds; wrong granularity for a watcher |
+| 8 | Workspace-of-workspaces (federated index) | Big & important but deserves its own ideation round; not actionable now |
+| 9 | `rts` pushes / subscriptions | Ahead of its time; MCP push channel + agent subscription model are immature |
+| 10 | Shared anonymous corpus + learned ranker | Privacy + infra leap; needs dedicated brainstorm before ideation can scope it |
+| 11 | Index everything non-code (OpenAPI / SQL / Protobuf) | Scope explosion; pick a single seam first |
+| 12 | HTTP + curl-able CLI | Distribution amplifier but `rts-bench query` already exposes CLI; HTTP is bigger lift. **Honorable mention.** |
+| 13 | Public `rts-protocol` crate | Premature — no external consumers yet |
+| 14 | `tree-sitter-callgraph` query pack | Premature for same reason |
+| 15 | `mcp-stdio` client libraries | One in-tree consumer doesn't justify lib extraction |
+| 16 | `changelogd` standalone tool | Off-mission for rts |
+| 17 | Decision-record schema for plans/brainstorms | Internal-only; useful but not a product improvement |
+| 18 | `rts ask` (English query gateway) | The hook + nudge cover most of this need; needs evidence first |
+| 19 | Bidirectional hook (low-confidence) | Useful but data-light; revisit after agent-bench gives empirical signal |
+| 20 | Delete `archive/` | Too small for ideation (one-line PR); on the obvious-cleanup pile |
+| 21 | Cross-session telemetry sink (`rts insights`) | Folds into #2 leaderboard |
+| 22 | Symbol Diff Between Refs | Folds into Commit-aware temporal index; deferred |
+| 23 | Dead-Code Frontier (standalone) | Folds into Symbol Profile API; weaker alone |
+| 24 | Doc-Coverage Report (standalone) | Same |
+| 25 | Multi-dim importance (standalone) | Folds into Symbol Profile API |
+| 26 | Symbol Profile API (synthesized C2) | Close call; lower leverage than the 6 chosen |
+| 27 | Commit-aware temporal index (synthesized C3) | Deferred; competes with the 6 for attention |
+| 28 | `docs/solutions/` scaffold (standalone) | Belongs alongside whatever ship next, not its own line item |
+
+## Session Log
+
+- 2026-05-17: Initial ideation — 35 raw candidates from 5 sub-agents across distinct frames (pain/friction, unmet need, inversion/removal, assumption-breaking, leverage/compounding); 3 cross-cutting combinations synthesized; 6 survivors after adversarial filter. Frames preserved: pain (P), unmet (U), inversion (I), assumption (A), leverage (L); combinations (C). User context: 9th round of *"what else?"* in a multi-day session that shipped #94–#108.
+- 2026-05-18: User selected three survivors for brainstorming: #1 (`rts doctor`), #3 (`Index.Grep` v2), #4 (Persisted cold-mount index). Brainstorm order: #1 first (lowest complexity, fastest to define), then #3 (largest value-prop win), then #4 (latency/UX). Each will produce its own `docs/brainstorms/2026-05-18-*-requirements.md`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -200,6 +200,52 @@ rm -f "$XDG_RUNTIME_DIR/rts/default.sock"            # Linux
 The daemon's `flock`-based PID file is authoritative; stale sockets
 without a live process are cleaned up at next bind.
 
+## Verifying your install
+
+After running any of the per-agent install snippets above, run
+`rts-bench doctor` to verify the install end-to-end:
+
+```sh
+rts-bench doctor
+```
+
+Doctor inspects five surfaces in a single sub-second run:
+
+1. **`binary`** — `rts-daemon` and `rts-mcp` on `$PATH`, version-drift
+   detection between them.
+2. **`daemon`** — per-workspace socket probe; one round-trip to the
+   daemon's `Daemon.Stats v2` RPC (gracefully degrades on pre-v2
+   daemons).
+3. **`mcp_registration`** — rts MCP entry presence across Claude Code,
+   Cursor, Continue, Aider, and Cline; cross-scope drift detection
+   (e.g. Claude Code user-scope and project-scope registering different
+   binaries).
+4. **`hook`** — `.claude/hooks/rts-nudge.sh` presence, executability,
+   version-marker match.
+5. **`workspace_index`** — pinned-workspace path match against `$PWD`,
+   cold-walk completion timestamp, index generation, file count.
+
+Each row is `[OK]`, `[WARN]`, or `[FAIL]`; every WARN/FAIL row carries
+a copy-pasteable one-line fix on the next line. Exit codes are a
+public contract — `0` means healthy (any WARNs allowed), `1` means at
+least one FAIL row, `2` means doctor itself failed.
+
+For machine-readable output (e.g. for an agent-bench preflight),
+`rts-bench doctor --output json` produces a versioned JSON document
+per the schema in [`doctor-schema.md`](doctor-schema.md).
+
+```sh
+# Exit-code-driven CI gate:
+rts-bench doctor || { echo "rts install is broken — see output above"; exit 1; }
+
+# Just check whether all 5 host detectors found rts:
+rts-bench doctor --output json \
+  | jq '.sections[] | select(.name=="mcp_registration") | .rows[] | select(.kind=="fail")'
+```
+
+`NO_COLOR=1` (or `--no-color`) disables ANSI; useful in pipelines and
+snapshot tests.
+
 ## Uninstalling
 
 The build produces no installed files outside the cargo target dir.
@@ -224,5 +270,7 @@ cargo clean
 
 - [docs/protocol-v0.md](protocol-v0.md) — daemon ↔ MCP wire-protocol
   spec.
+- [docs/doctor-schema.md](doctor-schema.md) — `rts-bench doctor`
+  `--output json` schema and exit-code contract.
 - [AGENTS.md](../AGENTS.md) — project structure + coding conventions.
 - [CHANGELOG.md](../CHANGELOG.md) — per-alpha release notes.

--- a/docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md
+++ b/docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md
@@ -1,0 +1,421 @@
+---
+title: "feat(rts-bench): rts-bench doctor — read-only first-run health check"
+type: feat
+status: active
+date: 2026-05-18
+origin: docs/brainstorms/2026-05-18-rts-doctor-requirements.md
+---
+
+# `rts-bench doctor` — read-only first-run health check
+
+## Overview
+
+Ship a new `rts-bench doctor` subcommand: a read-only diagnostic CLI that inspects rts install state across the user's machine and the current workspace, prints a sectioned OK/WARN/FAIL checklist with copy-pasteable one-line fixes for every failing row, and exposes the same data as machine-readable JSON for agent consumption.
+
+The user-facing contract is one sentence: *"if `rts-bench doctor` returns 0, your install is healthy; if it returns 1, the rows tell you exactly what to fix."*
+
+Doctor is **read-only**: it never writes to a user config file, never restarts the daemon, never installs anything. The diagnosis surface covers two signal classes — **install state** (binary version, daemon binary on PATH, MCP registration in 5 agent hosts, hook file present and executable) and **workspace state** (per-workspace daemon PID, pinned-workspace path, index generation, cold-walk completion timestamp, file count). Behavioral telemetry stays in `daemon-stats` (#104); version-drift detection stays out of scope.
+
+This plan also addresses three prerequisite gaps surfaced during research:
+
+1. `Daemon.Stats` does not currently expose the pinned workspace path, `index_generation`, or `cold_walk_completed_at_ms`. The plan extends `Daemon.Stats` additively, with a capability bump, before doctor's `workspace_index` section can be implemented in a single round-trip.
+2. The brainstorm's `--json` flag conflicts with the existing `rts-bench query --output [json|lines]` convention. Doctor uses `--output [human|json]`.
+3. Continue's config is YAML, not JSON; planning corrects this.
+
+## Problem Statement / Motivation
+
+The #1 first-run failure pattern for rts is silent. A user installs the binary, registers the MCP server, opens their agent, and nothing visible happens. Today the user grep-debugs the README, tails the daemon log, runs `ps` and `lsof`, and eventually files an issue. Adoption ceiling = *"users patient enough to debug a silent install."*
+
+Doctor is the cheapest possible investment past that ceiling: one subcommand that names every install signal and prints a copy-pasteable fix for anything broken. It's grounded in two existing surfaces — the rts-bench CLI (the operator-facing binary) and `Daemon.Stats` (#104) — and surfaces what's already true on disk rather than introducing new state.
+
+## Proposed Solution
+
+A new `Doctor` clap subcommand on `rts-bench` runs five independent diagnostic sections in stable order — `binary`, `daemon`, `mcp_registration`, `hook`, `workspace_index` — each emitting OK/WARN/FAIL rows with inline fix snippets. The default output is a human checklist; `--output json` produces a machine-readable shape stable across patch releases (`schema_version: "doctor-v0"`, additive `capabilities: []` array mirroring protocol-v0).
+
+The `daemon` section probes the workspace's per-workspace socket; on success, one round-trip to a v0.6+ `Daemon.Stats` (extended additively with `pinned_workspace_path`, `index_generation`, `cold_walk_completed_at_ms`) provides everything doctor needs for both `daemon` and `workspace_index`. Against a pre-v0.6 daemon, doctor degrades gracefully via the existing `Workspace.Status` RPC (two round-trips, with a `[WARN] daemon predates doctor — please upgrade` row).
+
+Per-host MCP registration is detected from canonical config-file paths documented in `docs/install.md`:
+
+| Host         | Detection class | Canonical path(s) |
+|--------------|-----------------|-------------------|
+| Claude Code  | Hard (multi-scope) | `~/.claude.json` (user), project `.mcp.json`, `~/.claude/settings.json` |
+| Cursor       | Hard            | `~/.cursor/mcp.json` |
+| Continue     | Hard            | `~/.continue/config.yaml`, project `./.continue/config.yaml` |
+| Aider        | Soft            | `~/.config/aider/mcp.json`, `./.aider/mcp.json`, `~/.aider.conf.yml` |
+| Cline        | Soft            | VS Code extension global state (path varies by OS); CLI-flag scan |
+
+Hook detection inspects `.claude/hooks/rts-nudge.sh` for presence, executability, and a content-version marker so an out-of-date hook is `[WARN]`-distinguishable from missing.
+
+## Technical Approach
+
+### Module layout
+
+A new `crates/rts-bench/src/doctor/` module tree, sibling of `latency.rs`/`footprint.rs`/`semantic.rs`/`corpus.rs`. The brainstorm's claim that doctor logic might be promotable to `rts-core` is rejected: `rts-core` is a pure parsing library with zero MCP/install-surface concepts. If `rts-mcp` or `rts-daemon` ever needs doctor's logic, extract then.
+
+```
+crates/rts-bench/src/doctor/
+├── mod.rs              // Doctor entry; section dispatch; exit-code computation
+├── report.rs           // RowKind (OK/WARN/FAIL); SectionReport; FixSnippet; section ordering
+├── render_human.rs     // ANSI-aware (NO_COLOR), no wall-clock timestamps, snapshot-stable
+├── render_json.rs      // schema_version + capabilities; serde shape locked at v0
+├── binary_section.rs   // binary version, daemon binary on PATH, symlink resolution
+├── daemon_section.rs   // per-workspace socket probe; Stats vs Workspace.Status fallback
+├── workspace_section.rs// index_generation, cold-walk timestamp, file count, workspace mismatch
+├── mcp_section.rs      // dispatches to per-host detectors below
+├── hooks/
+│   ├── mod.rs          // shared host trait + result types
+│   ├── claude_code.rs  // user-scope, project-scope, settings.json hook block
+│   ├── cursor.rs
+│   ├── continue_.rs    // YAML, NOT JSON; serde_yaml
+│   ├── aider.rs        // soft-detect
+│   └── cline.rs        // soft-detect
+└── nudge_hook.rs       // .claude/hooks/rts-nudge.sh presence + executability + version marker
+```
+
+### `Daemon.Stats` additive extension (prerequisite)
+
+`crates/rts-daemon/src/methods/daemon.rs:140-151` currently returns:
+
+```jsonc
+{ "uptime_ms": u64, "version": str, "total_calls": u64, "calls": { ... } }
+```
+
+Extend to (additive — old clients ignore unknown fields):
+
+```jsonc
+{
+  "uptime_ms": u64,
+  "version": str,
+  "total_calls": u64,
+  "calls": { ... },
+  // new in v0.6, gated on capability "daemon_stats_v2":
+  "pinned_workspace_path": str,
+  "workspace_id": str,
+  "index_generation": u64,
+  "cold_walk_completed_at_ms": u64 | null
+}
+```
+
+Capability string `"daemon_stats_v2"` added to the list at `crates/rts-daemon/src/methods/daemon.rs:18-87`. Doctor advertises that it requires `daemon_stats_v2`; if the daemon doesn't, doctor calls `Workspace.Status` instead (two round-trips, with a `[WARN]` advising upgrade).
+
+### Output rendering
+
+Human renderer is **snapshot-stable**: no wall-clock timestamps in default output, deterministic section ordering, `NO_COLOR` env var honored, `--no-color` flag for explicit control, and ANSI only when stdout is a TTY (via `IsTerminal`). The current rts-bench has no color library; this plan adds `anstream = "0.6"` to `rts-bench/Cargo.toml` (already a transitive clap dep — promote to direct).
+
+JSON renderer is **stable**: schema versioned with `schema_version: "doctor-v0"` and a top-level `capabilities: []` array. The schema is documented in a new `docs/doctor-schema.md`. Future additive fields require a new capability string, never a schema_version bump.
+
+### Exit codes
+
+Exit code is a documented public API. Reserved values:
+- `0` — no FAIL rows (any WARN allowed)
+- `1` — at least one FAIL row
+- `2` — doctor itself failed (panic, unreadable own binary, JSON-serialization error)
+- `>=3` — reserved for future use; CI gates must not depend on specific values above 2
+
+Doctor-self-failure (exit 2) emits valid JSON to stdout when `--output json` is set, with a single `{schema_version, capabilities, error: {code, message}}` shape; otherwise plain message to stderr.
+
+### Per-host detection
+
+Each host detector implements a tiny trait:
+
+```rust
+pub trait HostDetector {
+    fn host_name(&self) -> &'static str;
+    fn detection_class(&self) -> DetectionClass; // Hard | Soft
+    fn detect(&self, ctx: &Ctx) -> HostFinding;
+}
+
+pub struct HostFinding {
+    rows: Vec<Row>,           // OK/WARN/FAIL per registration scope discovered
+    rts_registered: Option<RegistrationDetail>,  // for cross-row analysis (multi-scope drift)
+    skipped_reason: Option<String>,              // "not installed", "permission denied"
+}
+```
+
+The trait pattern centralizes:
+- multi-scope handling (Claude Code user vs project vs local — flagged when multiple register at different binaries/versions: WARN, not FAIL)
+- malformed-config policy: serde parse error on a host config file is `[WARN] could not parse {path}: {reason}` (not FAIL) — doctor never fails the run because *another* tool's config is broken
+- "not installed" policy: a host's config dir doesn't exist → row is `[?] {host} not detected` for soft hosts, omitted for hard hosts (configurable later if needed)
+
+### System-Wide Impact
+
+- **Interaction graph.** Doctor reads file systems (config files, hook file, binary on PATH) and talks to the daemon via the existing protocol-v0 socket. It opens no new sockets, writes no files. The only side-effects are stdout/stderr.
+- **Error propagation.** Doctor's own errors (panic, malformed own JSON output) are exit `2` with a structured `error` envelope in JSON mode. Per-host parse errors are downgraded to WARN rows; host detection never aborts the run.
+- **State lifecycle.** No persistent state introduced. The Daemon.Stats extension is additive; old clients keep working unchanged.
+- **API surface parity.** The new `daemon_stats_v2` capability is announced in protocol-v0's capability list. `Workspace.Status` continues to expose the same fields it does today (unchanged).
+- **Integration test scenarios.**
+  - Daemon at v0.5.x (pre-`daemon_stats_v2`): doctor reports `[WARN] daemon predates daemon_stats_v2; using fallback path`.
+  - Daemon present, workspace mismatch: `workspace_index` section reports `[FAIL] daemon pinned to {other_path}, doctor running in {pwd}`.
+  - Cold-walk in progress: `[WARN] indexing in progress ({files_done}/{files_total})`.
+  - Stale socket file (PID dead, file remains): `[FAIL] socket exists but daemon unreachable; remove {socket_path}` with the `rm -f` fix snippet.
+  - Multi-scope MCP: Claude Code user-scope and project-scope both register rts at different binaries: `[WARN] multi-scope registration: user-scope=v0.5.6, project-scope=v0.5.5`.
+  - Malformed `.mcp.json`: `[WARN] .mcp.json present but unparseable: expected `,` at line 12`.
+  - `~/.cursor/mcp.json` missing entirely (Cursor not installed): row omitted (hard host).
+  - Aider config not detected: `[?] aider not detected (soft detect)`.
+  - Hook file present but `chmod -x`: `[WARN] hook not executable; run: chmod +x .claude/hooks/rts-nudge.sh`.
+  - $PWD outside any workspace: `workspace_index` section emits one row `[WARN] no rts workspace at $PWD` and skips inner checks.
+  - `--output json` with all OK: valid JSON to stdout, exit 0.
+  - `--output json` on doctor-self-failure: valid JSON `{error: ...}` to stdout, exit 2.
+
+## Implementation Units
+
+Units are ordered by dependency. Each unit lists Goal, Files, Approach, Patterns to follow, Execution note, Test scenarios, Verification.
+
+### U1 — `Daemon.Stats` v2 (additive extension + capability)
+
+- **Goal.** Extend `Daemon.Stats` with `pinned_workspace_path`, `workspace_id`, `index_generation`, `cold_walk_completed_at_ms`; announce capability `"daemon_stats_v2"`.
+- **Files.** `crates/rts-daemon/src/methods/daemon.rs` (response struct + capability list); `crates/rts-daemon/src/state.rs` (expose `pinned_workspace_path` and `cold_walk_completed_at_ms` on `MountedWorkspace`); `crates/rts-daemon/tests/wire_round_trip.rs` (add round-trip case for the new fields); `docs/protocol-v0.md` (document v2 fields under capability `daemon_stats_v2`).
+- **Approach.** Add fields to the existing `StatsResponse` struct (or wrap in `#[serde(flatten)]`-able extension struct). `pinned_workspace_path` reads from `MountedWorkspace.canonical.path`. `index_generation` mirrors `Workspace.Status`'s value. `cold_walk_completed_at_ms` is set once when `progress.phase` transitions to `"ready"`; stored as `Option<u64>` on `MountedWorkspace`.
+- **Patterns to follow.** `crates/rts-daemon/src/methods/workspace.rs:277,350,357` (where `index_generation` and `workspace_id` already surface); `crates/rts-daemon/src/methods/daemon.rs:18-87` (capability list pattern); the `#94`-era pattern for adding additive fields with capability gating.
+- **Execution note.** Characterization-first: add a round-trip test that captures the existing `Daemon.Stats` shape *before* extending. Confirms backward compatibility by construction.
+- **Test scenarios.**
+  - Round-trip: v2 response deserializes into the v1 shape with v1 fields preserved.
+  - Capability list includes `"daemon_stats_v2"`.
+  - `cold_walk_completed_at_ms` is `None` until cold-walk completes; populated when `progress.phase == "ready"`.
+- **Verification.** `cargo test -p rts-daemon` green; `docs/protocol-v0.md` updated; capability list grep returns the new string.
+
+### U2 — Doctor scaffolding + clap subcommand
+
+- **Goal.** New `Cmd::Doctor` variant with `--output [human|json]`, `--no-color`, exits 0/1/2 plumbed.
+- **Files.** `crates/rts-bench/src/main.rs` (add `Doctor` variant on `enum Cmd`; dispatch to `doctor::run`); `crates/rts-bench/src/doctor/mod.rs` (new; `pub fn run(args) -> anyhow::Result<ExitCode>`); `crates/rts-bench/src/doctor/report.rs` (Row, RowKind, SectionReport, FixSnippet types).
+- **Approach.** Mirror the `query` subcommand's clap derive style. `--output` uses a new `value_enum` `DoctorOutput { Human, Json }`. Top-level entry validates flags, dispatches to per-section detectors, aggregates `SectionReport`s, computes exit code by max-severity-row across all sections.
+- **Patterns to follow.** `crates/rts-bench/src/main.rs:34-187` (clap derive style, `value_enum`); `crates/rts-bench/src/main.rs:427` (`anyhow::Result<()>` from main, explicit `std::process::exit(N)` for non-error exit codes); `AGENTS.md` (tracing to stderr via `RTS_BENCH_LOG`).
+- **Execution note.** Test-first: write the smoke test (`doctor_runs_and_returns_zero_on_healthy_install`) before scaffolding so the dispatch wiring is exercised end-to-end.
+- **Test scenarios.**
+  - `cargo run -p rts-bench -- doctor --help` shows usage with the flag set.
+  - `doctor --output json` produces parseable JSON with `schema_version` and `capabilities` even before any sections are implemented (empty section list valid).
+  - Exit code is 0 on empty/all-OK and 1 when a section emits FAIL.
+- **Verification.** `cargo test -p rts-bench` green; manual smoke run produces stable, snapshot-friendly output.
+
+### U3 — Output rendering (human + JSON)
+
+- **Goal.** `render_human` and `render_json` produce stable output. NO_COLOR honored. Snapshot-friendly.
+- **Files.** `crates/rts-bench/src/doctor/render_human.rs`; `crates/rts-bench/src/doctor/render_json.rs`; `crates/rts-bench/Cargo.toml` (add direct `anstream = "0.6"` + `is-terminal = "0.4"` if not already transitively present).
+- **Approach.** Human renderer formats rows as `[OK]`/`[WARN]`/`[FAIL]` with optional ANSI when TTY + NO_COLOR unset; fix snippets render on the next line indented `  → `. JSON renderer serializes a fixed `DoctorReport { schema_version: "doctor-v0", capabilities: Vec<&'static str>, sections: Vec<Section>, exit_class: "ok"|"warn"|"fail" }`. No wall-clock timestamps; cold-walk-completed-at is data and lives in `workspace_index` row payloads.
+- **Patterns to follow.** Existing rts-bench output goes to stdout; logs to stderr (`main.rs:428-435`). Use `std::io::IsTerminal` for TTY detection. `serde_json::to_writer_pretty` for JSON.
+- **Execution note.** Test-first: snapshot tests against fixture `SectionReport`s. Use `insta` or hand-rolled string-equality if `insta` isn't already a dev-dep.
+- **Test scenarios.**
+  - Snapshot of human output with one FAIL + one WARN row matches golden file byte-for-byte.
+  - `NO_COLOR=1` strips ANSI even on a TTY.
+  - JSON output validates against a small JSON Schema fixture committed in `tests/fixtures/doctor-schema-v0.json`.
+- **Verification.** `cargo test -p rts-bench doctor::render` green; snapshot stability verified by running twice and diffing.
+
+### U4 — `binary` section
+
+- **Goal.** Reports doctor binary version + daemon/MCP binary discovery + symlink resolution.
+- **Files.** `crates/rts-bench/src/doctor/binary_section.rs`.
+- **Approach.** Doctor binary version from `env!("CARGO_PKG_VERSION")`. Probe `which rts-daemon` and `which rts-mcp` via `std::env::var_os("PATH")` + manual lookup (no shell-out — avoids the macOS `realpath -m` foot-gun from #106). Resolve symlinks with `std::fs::canonicalize`. If a found binary's `--version` differs from doctor's version, emit `[WARN] version drift: doctor=v0.6.0, daemon=v0.5.5`. Fix snippet: `cargo install --path crates/rts-daemon` or release-tarball curl line.
+- **Patterns to follow.** `crates/rts-bench/src/main.rs` (uses `which` crate indirectly? — confirm during implementation; if not present, use std-only PATH walk). The learnings researcher's BSD-vs-GNU note: do path work in Rust, not via shelling out.
+- **Execution note.** Pragmatic — small, leaf-node section. No test-first required.
+- **Test scenarios.**
+  - `rts-daemon` not on PATH: `[FAIL]` with install-from-release fix.
+  - Version drift between doctor and daemon: `[WARN]`.
+  - Symlinked binary resolves to a different version than what's on PATH: `[WARN]`.
+- **Verification.** Hand-run against a clean checkout + against a `PATH=/usr/bin` empty test.
+
+### U5 — `daemon` section
+
+- **Goal.** Reachability probe via per-workspace socket; `Daemon.Stats v2` round-trip; fallback to `Workspace.Status` against pre-`daemon_stats_v2` daemons.
+- **Files.** `crates/rts-bench/src/doctor/daemon_section.rs`.
+- **Approach.** Compute the per-workspace socket path the same way `rts-mcp` does (need to confirm: `ws-<16hex>.sock` per `crates/rts-daemon/src/main.rs`). If socket file absent → `[WARN] daemon not running for this workspace` + fix snippet (`rts-daemon --workspace $PWD &`). If socket exists, attempt connect with 1 s timeout. Stale socket (connect refused, PID dead) → `[FAIL] stale socket at {path}` + fix (`rm -f {path}`). On successful handshake, call `Daemon.Stats`; if response carries v2 fields, proceed in one round-trip; else fall back to `Workspace.Status` for `index_generation` and emit a `[WARN] daemon predates daemon_stats_v2`.
+- **Patterns to follow.** `crates/rts-bench/src/main.rs:1363-1412` (cold-gate poll loop — shows existing daemon-connect pattern); `crates/rts-daemon/src/methods/workspace.rs:117-137` (per-workspace state-dir resolution); `docs/protocol-v0.md` for framing.
+- **Execution note.** Test-first: integration test that spawns a daemon, points doctor at it, asserts on the row set.
+- **Test scenarios.**
+  - Socket absent: WARN + bootstrap fix.
+  - Socket present, connect refused: FAIL + rm fix.
+  - Daemon v0.5.x (no `daemon_stats_v2`): WARN about version + fallback to `Workspace.Status` succeeds.
+  - Daemon v0.6.x (has `daemon_stats_v2`): one round-trip, OK row.
+- **Verification.** Integration test green; manual run against a real daemon shows expected rows.
+
+### U6 — `workspace_index` section
+
+- **Goal.** Per-workspace index health: pinned-workspace path matches `$PWD`, cold walk completed, `index_generation`, file count.
+- **Files.** `crates/rts-bench/src/doctor/workspace_section.rs`.
+- **Approach.** Reuse the Daemon.Stats / Workspace.Status data fetched in U5 (passed via `Ctx`). If `pinned_workspace_path` ≠ `canonicalize($PWD)`: `[FAIL] daemon pinned to {pinned}, doctor running in {pwd}` + fix (`rts-daemon --workspace $PWD`). If `cold_walk_completed_at_ms` is `None`: `[WARN] indexing in progress ({files_done}/{files_total})`. If `index_generation > 0` and no FAILs: `[OK] index generation {n}, {file_count} files`. `$PWD` outside any workspace (no `.git` ancestor + no marker): one row `[WARN] no rts workspace at $PWD` and skip the rest of the section.
+- **Patterns to follow.** `crates/rts-bench/src/main.rs:844-873` (`detect_workspace_from`); the `--output lines` convention for line-based readable text.
+- **Execution note.** Test-first: scenarios above each get a test fixture.
+- **Test scenarios.** See above (workspace-mismatch, in-progress, OK, no-workspace).
+- **Verification.** `cargo test -p rts-bench doctor::workspace_section` green.
+
+### U7 — `mcp_registration` section + per-host detectors
+
+- **Goal.** Detect rts MCP registration across all 5 hosts. Hard hosts emit OK/WARN/FAIL per registration scope. Soft hosts emit `[?]` or `[OK]`. Multi-scope drift in Claude Code is `[WARN]`.
+- **Files.** `crates/rts-bench/src/doctor/mcp_section.rs`; `crates/rts-bench/src/doctor/hooks/{mod,claude_code,cursor,continue_,aider,cline}.rs`.
+- **Approach.** `HostDetector` trait per the System-Wide Impact section. Each detector reads its host's canonical config path(s), parses (JSON/YAML/JSONC), checks for an rts MCP entry, validates that the entry's binary path exists and is executable, returns `HostFinding`. The `mcp_section` orchestrator runs all five in parallel (`rayon::join` or `std::thread::scope`), collects findings, runs the cross-scope drift check on Claude Code, and emits rows. Continue uses `serde_yaml` (NOT `serde_json`).
+- **Patterns to follow.** `docs/install.md:60-144` (canonical per-host paths and config formats). Existing dependency on `serde_json` in workspace; add `serde_yaml = "0.9"` to `rts-bench/Cargo.toml`.
+- **Execution note.** Test-first per host: fixture config files in `crates/rts-bench/tests/fixtures/doctor/{host}/` covering (registered correctly, malformed, missing, binary path stale).
+- **Test scenarios.**
+  - Each host: registered correctly → OK; missing config dir → row omitted (hard) or `[?]` (soft); malformed config → `[WARN] could not parse {path}`; rts entry present but binary path missing → `[FAIL] {host}: binary {path} not found` + fix.
+  - Claude Code multi-scope drift: user-scope and project-scope register different binaries → `[WARN] multi-scope: user={v1}, project={v2}`.
+  - Aider and Cline soft-detect when their conventions aren't found → `[?]`.
+- **Verification.** `cargo test -p rts-bench doctor::hooks` green; fixture coverage matrix complete.
+
+### U8 — `hook` section
+
+- **Goal.** `.claude/hooks/rts-nudge.sh` presence, executability, version-marker match.
+- **Files.** `crates/rts-bench/src/doctor/nudge_hook.rs`; `.claude/hooks/rts-nudge.sh` (add a `# version: 0.6.0` comment marker at the top — single-line change; existing hook must remain otherwise identical).
+- **Approach.** Look for `<workspace>/.claude/hooks/rts-nudge.sh`. If absent → `[WARN] PreToolUse nudge hook not installed` + fix (`cp .claude/hooks/rts-nudge.sh.template ...` or one-line `curl`). If present but `!is_executable()` → `[WARN] hook not executable; chmod +x ...`. If present, executable, but version marker doesn't match doctor's binary version → `[WARN] hook is v{old}, doctor is v{new}; consider updating`.
+- **Patterns to follow.** `.claude/hooks/rts-nudge.sh` lines 1-15 (existing comments and contract); use `std::os::unix::fs::PermissionsExt`.
+- **Execution note.** Pragmatic; small.
+- **Test scenarios.** Absent, present-non-exec, present-exec-out-of-date, present-exec-up-to-date.
+- **Verification.** `cargo test -p rts-bench doctor::nudge_hook` green.
+
+### U9 — Fix-snippet taxonomy + final wiring
+
+- **Goal.** Every WARN/FAIL row has a fix snippet from a closed taxonomy (no ad-hoc strings). Section ordering normative. Doctor itself becomes panic-safe (exit 2 path tested).
+- **Files.** `crates/rts-bench/src/doctor/report.rs` (extend `FixSnippet` to an enum); cross-references to U4–U8.
+- **Approach.** `enum FixClass { InstallBinary, StartDaemon, RemoveStaleSocket, RegisterMcp { host: HostKind }, FixMcpBinaryPath, MakeHookExecutable, UpdateHook, MoveWorkspace, ReindexNeeded, FixYamlSyntax, ... }`. Each variant renders a one-line command + a short description. Doctor-self-failure (`catch_unwind` at the entry point) emits exit 2 with structured JSON when `--output json`.
+- **Patterns to follow.** `anyhow::Context` for error chaining; the existing `exit(2)` precedent at `crates/rts-bench/src/main.rs:592`.
+- **Execution note.** Test-first for the exit-2 path: simulate a panic in one section, assert exit code and JSON shape.
+- **Test scenarios.**
+  - Every FixClass variant has a rendered fix that's a runnable shell command (asserted via parse).
+  - Section ordering is fixed: `binary`, `daemon`, `mcp_registration`, `hook`, `workspace_index`.
+  - Panicking section → exit 2, JSON has `error` envelope, other sections still rendered.
+- **Verification.** `cargo test -p rts-bench doctor::report` green; doctor's exit-code table matches the documented contract.
+
+### U10 — `docs/doctor-schema.md`, changelog fragment, README/install.md cross-references
+
+- **Goal.** Documentation surface complete. Schema is a public artifact.
+- **Files.** `docs/doctor-schema.md` (new — the JSON schema for `--output json`, plus exit-code contract); `docs/install.md` (add a small "Verifying your install" section pointing at `rts-bench doctor`); `README.md` (one-line addition under "Status"); `changelog.d/<NNNN>-rts-bench-doctor.md` (per `AGENTS.md` v0.5.5+ convention).
+- **Approach.** `docs/doctor-schema.md` documents `schema_version: "doctor-v0"`, the `capabilities[]` array, the per-section row shape, the exit-code contract (0/1/2 with reserved values ≥3), and the JSON envelope for self-failure. Mention the snapshot stability rules.
+- **Patterns to follow.** `docs/protocol-v0.md` (capability list + per-method schema sections); the per-PR changelog.d/ fragment workflow (#93).
+- **Execution note.** Pragmatic; pure docs.
+- **Verification.** `mdformat` or equivalent passes; the cross-references resolve.
+
+## Requirements Trace
+
+| ID  | Requirement (from origin)                                                                                                | Satisfied by | Notes |
+|-----|---------------------------------------------------------------------------------------------------------------------------|--------------|-------|
+| R1  | `rts-bench doctor` subcommand, offline, no network                                                                        | U2           |       |
+| R2  | Read-only; no writes to user config                                                                                       | U2 (enforced by design — no writer module exists) | |
+| R3  | Two signal classes: install (binary, daemon path, MCP per host, hook) + workspace (PID, pinned path, index_gen, walk time, file count) | U4, U5, U6, U7, U8 | Pinned path requires U1 |
+| R4  | All 5 hosts; Aider/Cline soft-detect                                                                                       | U7           | Detection class explicit per host |
+| R5  | Human checklist with inline fix snippet per WARN/FAIL                                                                      | U3, U9       | Fix taxonomy in U9 |
+| R6  | `--output json` machine-readable; shape stable                                                                            | U3, U10      | `--json` reconciled to `--output json` |
+| R7  | Exit 0 (no FAIL), 1 (any FAIL), 2 (doctor itself failed)                                                                   | U2, U9       | Exit-class on report; panic-handler in U9 |
+| R8  | Doctor latency <500 ms p95 on healthy install                                                                              | U5, U6       | One round-trip when U1 lands; verified by manual bench |
+| R9  | Use one round-trip when daemon reachable; fall back when not                                                              | U1, U5       | Single round-trip requires U1 |
+| R10 | Sections grouped: `binary`, `daemon`, `mcp_registration`, `hook`, `workspace_index`; each independently testable          | U2, U4–U8    | Ordering documented in U10 |
+
+## Acceptance Criteria
+
+### Functional
+
+- [ ] **AC1.** `rts-bench doctor --help` shows the new subcommand with `--output [human|json]` and `--no-color` flags.
+- [ ] **AC2.** On a healthy install with v0.6+ daemon running for `$PWD`, `rts-bench doctor` exits 0 and renders five sections (`binary`, `daemon`, `mcp_registration`, `hook`, `workspace_index`) in that order, all `[OK]`.
+- [ ] **AC3.** With the daemon down, the `daemon` section emits `[WARN] daemon not running for this workspace` + a fix snippet that is itself runnable (`rts-daemon --workspace $PWD &`).
+- [ ] **AC4.** With a stale socket (file exists, PID dead), the `daemon` section emits `[FAIL] stale socket` and exits 1.
+- [ ] **AC5.** With the daemon pinned to a different workspace than `$PWD`, the `workspace_index` section emits `[FAIL] daemon pinned to {other}, doctor running in {pwd}` and exits 1.
+- [ ] **AC6.** With Claude Code's user-scope and project-scope both registering rts at different binary paths, `mcp_registration` emits `[WARN] multi-scope registration`.
+- [ ] **AC7.** With a malformed `.mcp.json`, `mcp_registration` emits `[WARN] could not parse {path}` and exits 0 (parse errors don't fail doctor).
+- [ ] **AC8.** With the hook file missing, `hook` emits `[WARN]` + install fix snippet.
+- [ ] **AC9.** With the hook present but `chmod -x`, `hook` emits `[WARN] not executable` + `chmod +x` fix snippet.
+- [ ] **AC10.** `rts-bench doctor --output json` produces a JSON document with `schema_version: "doctor-v0"`, `capabilities: []`, `sections: [...]`, and `exit_class` ∈ `{"ok","warn","fail"}`; the JSON validates against a committed schema fixture.
+- [ ] **AC11.** `NO_COLOR=1 rts-bench doctor` produces output free of ANSI codes; same applies for `--no-color`.
+- [ ] **AC12.** Doctor's human output is byte-stable across two consecutive runs against the same state (no wall-clock timestamps).
+- [ ] **AC13.** A simulated panic inside one section causes exit 2; with `--output json`, stdout is valid JSON with an `error` envelope and the remaining sections still render.
+- [ ] **AC14.** Against a pre-`daemon_stats_v2` daemon, doctor falls back to `Workspace.Status` and adds `[WARN] daemon predates daemon_stats_v2`.
+
+### Non-Functional
+
+- [ ] **AC15.** Doctor latency on a healthy v0.6+ daemon is `<500 ms p95` on a 100k LOC workspace, measured via `rts-bench bench` or an ad-hoc shell loop. One round-trip only.
+- [ ] **AC16.** No new transitive crate dependencies are added beyond `anstream`, `is-terminal`, and `serde_yaml`. Workspace `cargo tree` diff reviewed.
+
+### Quality Gates
+
+- [ ] **AC17.** `cargo test -p rts-bench` green; new tests cover every per-section scenario above.
+- [ ] **AC18.** `cargo test -p rts-daemon` green; U1's round-trip test asserts both v1-style and v2-style responses.
+- [ ] **AC19.** `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- [ ] **AC20.** `docs/doctor-schema.md` exists, links from `README.md` and `docs/install.md`, validates against the JSON fixture committed in `crates/rts-bench/tests/fixtures/doctor-schema-v0.json`.
+- [ ] **AC21.** A new `changelog.d/<NNNN>-rts-bench-doctor.md` fragment lands with the PR.
+
+## Success Metrics
+
+- **First-week:** README's "Status" line gets a one-line `rts-bench doctor` mention; at least one closed issue in 30 days that links a doctor output as the diagnosis path (replacing the "paste your `cat .mcp.json`" exchange).
+- **agent-bench preflight:** The harness (in `agent-bench/`) consumes `rts-bench doctor --output json` for preflight within 30 days; a failed preflight aborts a run instead of producing a wasted-API-cost trajectory.
+- **Latency:** p95 of `rts-bench doctor` on the rts-core workspace (~50k LOC) under 250 ms, p99 under 500 ms, sampled over 20 runs.
+
+## Dependencies & Risks
+
+- **U1 must land before U5/U6 can satisfy R9's one-round-trip goal.** If U1 slips, U5/U6 ship with the fallback path active and `[WARN] daemon predates daemon_stats_v2` is the default row — acceptable degradation, but the latency target may not be met.
+- **`docs/install.md` is the source of truth for per-host paths.** If `install.md` is wrong about Continue's YAML format or any other path, doctor will misdiagnose. The plan corrects Continue (YAML, not JSON); planning-time review of `install.md` for other drift is required before merging U7.
+- **Multi-scope Claude Code registration is a real foot-gun.** Doctor surfaces it as WARN, not FAIL, because both registrations may be intentional (e.g., user-scope as a default + project-scope override). Validate the policy choice with one or two real installs before locking the row text.
+- **VS Code extension state for Cline varies by OS and is undocumented in the canonical install.md path.** Soft-detect only; doctor never fails on Cline.
+- **The hook version marker (U8) is a new contract.** Adding `# version: x.y.z` to `.claude/hooks/rts-nudge.sh` must not change the hook's runtime semantics. The hook's existing "exit 0 ALWAYS" contract is preserved.
+- **`Daemon.Stats v2` capability gates real behavior.** A consumer that depends on `pinned_workspace_path` without checking `daemon_stats_v2` would crash on old daemons. Plan U1 + U5 ensures doctor checks the capability before reading the new fields.
+
+## Scope Boundaries
+
+The following are explicit non-goals for this PR:
+
+- **No `--fix` mode.** Doctor never applies a recommended action. (Deferred — separate proposal once field data informs which fixes are universally safe.)
+- **No behavioral telemetry in doctor.** Per-method call counts, nudge-fire log, recent error rate. Those live in `daemon-stats` (#104) and the auto-dump-on-shutdown (#105). Doctor's `daemon` section reports liveness/version only.
+- **No version-drift detection across rts-mcp ↔ daemon ↔ binary-on-PATH beyond the binary-section level.** The #104 version-skew detection is acknowledged as a future enhancement; doctor's U4 catches the simple `rts-mcp on PATH is not the version doctor expects` case but doesn't probe the runtime MCP child process attached to Claude Code.
+- **No Windows support.** Unix sockets only.
+- **No `--section` flag** for running individual sections; all-or-nothing in v1.
+- **No tooling to bootstrap `docs/solutions/`.** The learnings researcher recommended scaffolding it; do it in a separate small PR.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-18-rts-doctor-requirements.md](../brainstorms/2026-05-18-rts-doctor-requirements.md). Carried-forward decisions:
+  1. Read-only diagnostic (no `--fix`) — Key Decisions §1
+  2. All 5 agent hosts at v1, Aider/Cline soft-detect — Key Decisions §2
+  3. Install + workspace signal classes only — Key Decisions §3
+  4. Human checklist with inline fix snippet; `--json` (reconciled to `--output json` per repo convention) — Key Decisions §4
+  5. Subcommand on `rts-bench` — Key Decisions §5
+  6. Exit 0/1/2 contract — R7
+- **Research consolidations:**
+  - `crates/rts-bench/src/main.rs:34-187` — clap derive pattern, `value_enum` for `--output`
+  - `crates/rts-bench/src/main.rs:427` — `anyhow::Result` from main, explicit exit codes
+  - `crates/rts-bench/src/main.rs:844-873` — `detect_workspace_from`
+  - `crates/rts-bench/src/main.rs:1363-1412` — daemon cold-gate poll pattern
+  - `crates/rts-daemon/src/methods/daemon.rs:140-151` — current `Daemon.Stats` shape (gap: missing pinned_workspace_path / index_generation / cold_walk_completed_at_ms)
+  - `crates/rts-daemon/src/methods/daemon.rs:18-87` — capability list pattern
+  - `crates/rts-daemon/src/methods/workspace.rs:117-137` — `state_dir_for` (XDG-aware path precedent)
+  - `crates/rts-daemon/src/methods/workspace.rs:277,350,357` — `Workspace.Status` shape including `index_generation`
+  - `crates/rts-daemon/src/state.rs:68` — `MountedWorkspace.canonical.path`
+  - `docs/install.md:60-144` — per-host canonical paths (Continue is YAML, brainstorm guessed JSON)
+  - `docs/protocol-v0.md:155-218` — capability negotiation pattern
+  - `.claude/hooks/rts-nudge.sh:1-15` — existing hook contract
+- **Related PRs:**
+  - #104 (Daemon.Stats RPC + counters)
+  - #105 (rts-mcp auto-dump on shutdown)
+  - #106 (PreToolUse hook — BSD `realpath -m` foot-gun)
+  - #107 (agent-bench harness — natural consumer of doctor JSON for preflight)
+
+## Deferred to Implementation
+
+These were marked as planning-time decisions in the brainstorm and resolved here:
+
+- **All-OK output format (R5 outstanding):** Resolved — full row echo (every section, every row), no compact mode in v1. Snapshot stability requires consistent shape.
+- **Index-staleness definition (R3 outstanding):** Resolved — there is no "stale index" signal in v1. Doctor reports `index_generation` and `cold_walk_completed_at_ms` as data; deciding whether they indicate staleness is left to the user. Cleaner separation of concerns; revisit if doctor's signal-to-noise demands a derived flag.
+- **Soft-detect criteria for Aider/Cline (R4 outstanding):** Resolved — check for `~/.config/aider/mcp.json` and `~/.aider.conf.yml` for Aider; for Cline, check VS Code globalState path on each OS (best-effort, may return `[?]`).
+- **Reachability probe (R9 outstanding):** Resolved — extend `Daemon.Stats` with v2 fields (U1) rather than adding a separate `Daemon.Ping`. Keeps the surface small.
+- **Workspace-mismatch detection (R3 outstanding):** Resolved — compare `pinned_workspace_path` (from `Daemon.Stats v2`) against `canonicalize($PWD)`.
+- **MCP scope detection for Claude Code (R4 outstanding):** Resolved — check user-scope (`~/.claude.json`), project-scope (`./.mcp.json`), and the settings.json hook block; emit `[WARN]` on multi-scope binary drift.
+- **JSON schema versioning (R6 outstanding):** Resolved — `schema_version: "doctor-v0"` + additive `capabilities: []` array, documented in `docs/doctor-schema.md`.
+
+## Post-Deploy Monitoring & Validation
+
+- **What to monitor/search**
+  - Logs: doctor produces nothing persistent — stdout/stderr only. Monitor: GitHub issues filtered by `doctor` keyword; agent-bench preflight failures in `bench-results/`.
+- **Validation checks (queries/commands)**
+  - `rts-bench doctor` (manual run on the dev workspace; expect all OK after install)
+  - `rts-bench doctor --output json | jq '.schema_version, .exit_class'`
+  - `cargo test -p rts-bench doctor && cargo test -p rts-daemon`
+- **Expected healthy behavior**
+  - Exit 0, all sections OK, latency under 500 ms.
+- **Failure signal(s) / rollback trigger**
+  - Reports of doctor itself panicking (exit 2 spike). Rollback: revert the PR; no schema migrations to undo.
+- **Validation window & owner**
+  - 7-day window post-merge; author monitors.
+
+---
+
+## Plan Status
+
+- **Detail level:** MORE (standard plan)
+- **SpecFlow:** complete (11 edge cases surfaced and incorporated into AC2–AC14)
+- **Deepen:** not requested
+- **Source decisions trace:** complete
+- **Next:** `/ce:work` on this plan, or move to brainstorm #3's plan (`index-grep-v2-requirements.md`) next.

--- a/docs/plans/2026-05-18-002-feat-index-grep-v2-plan.md
+++ b/docs/plans/2026-05-18-002-feat-index-grep-v2-plan.md
@@ -1,0 +1,498 @@
+---
+title: "feat(daemon,mcp): Index.Grep v2 — multiline + structural + within-symbol"
+type: feat
+status: active
+date: 2026-05-18
+origin: docs/brainstorms/2026-05-18-index-grep-v2-requirements.md
+---
+
+# `Index.Grep` v2 — multiline regex + structural queries + within-symbol scope
+
+## Overview
+
+Extend the existing `Index.Grep` MCP tool with three optional, fully composable input parameters — `multiline`, `structural_query`, `within_symbol` — plus a required `language` companion for structural queries. The tool surface stays at one MCP entry; existing v1 callers see byte-identical response bytes on the unchanged code path; new capabilities are advertised additively via three new capability strings on `Daemon.Ping`.
+
+The shape is conservative: agent-supplied raw tree-sitter S-expression queries are validated via `rts_core::query::Query::new` at request time, compiled `Query` objects are cached in an LRU keyed on `(language, query_text)`, structural queries re-parse files on demand (no parsed-tree cache exists today — the brainstorm's premise was incorrect), captures are returned per-match (not globally keyed — also a brainstorm shape correction), and every new code path has explicit resource budgets (DFA size limit on multiline regex; wall-clock + result-row truncation on structural; predicate whitelist on query `#match?`).
+
+This plan addresses **five gaps the brainstorm missed**, surfaced by SpecFlow analysis and repository research:
+
+1. **No parsed-tree cache exists.** Writer parses transiently and discards. The plan re-parses on demand and caches the compiled `Query`, not the tree.
+2. **Captures shape was wrong** in the brainstorm (`{name: [...]}` top-level). They must be **per-match**.
+3. **`CallCounters` is a closed enum** (state.rs:159), not a string map. Sub-counters are additional hard-coded `AtomicU64` fields. Coordination with the doctor plan's `Daemon.Stats v2` (PR 001) is required.
+4. **Regex has no DFA size limits set today.** v2 sets explicit limits and adds a `REGEX_TOO_COMPLEX` error code.
+5. **`#match?` predicate inside a tree-sitter query re-injects regex DoS.** Plan ships a predicate whitelist with a shared compile budget.
+
+## Problem Statement / Motivation
+
+Three known shortcomings make agents drop back to `Bash rg` mid-session — measurable in every agent-bench trajectory where rts indexed the workspace but the agent still reached for `rg`:
+
+- **No multiline.** Patterns that need to match across `\n` (a function signature on three lines; an SQL fragment with embedded newlines; a multi-line error message) silently return zero hits in v1.
+- **No structural matching.** *"Find every `impl` block containing an `unsafe fn`"* requires `rg` + manual filtering, or two MCP calls + an intersection.
+- **No within-symbol scope.** *"Find every `panic!` inside `fn parse_request`"* requires a `grep` + a `find_symbol` + a byte-range intersection the agent computes by hand.
+
+Closing all three in one shipping unit tightens the value-prop without expanding the tool surface (one tool, three new optional params). Every existing v1 caller is unaffected; every new caller gets capabilities the v1 surface couldn't express.
+
+## Proposed Solution
+
+Three additive optional input fields on `GrepArgs` (rts-mcp side) and `GrepParams` (rts-daemon side):
+
+- `multiline: Option<bool>` (default `false`) — when set on the regex (`pattern`) path, configures `RegexBuilder::dot_matches_new_line(true).multi_line(true)` and treats indexed file bytes as one logical buffer per file. **No-op for the literal `text` path** (literal substring search is already byte-wise across newlines).
+- `structural_query: Option<String>` — a raw tree-sitter S-expression query string, evaluated against the parsed tree of every file matching the request's `language` filter. **Requires `language`.**
+- `within_symbol: Option<String>` — a qualified-name match scope; matches whose byte range lies entirely inside the def byte range of the named symbol are kept. v1 minimum: single exact qualified name. Multi-def resolution (overloaded names) is policy-gated with a cardinality cap.
+- `language: Option<Vec<String>>` — language filter applicable to *all* paths (literal, regex, structural). Required when `structural_query` is set; optional otherwise. Intersects with `file_glob` (AND semantics; see Cross-cutting Concerns).
+
+The response shape gains a per-match `captures` field, present only when `structural_query` produced a match:
+
+```jsonc
+{
+  // existing v1 fields preserved byte-for-byte on the unchanged path:
+  "file": "crates/rts-core/src/lib.rs",
+  "range": { "start_line": 42, "end_line": 47, "start_byte": 1024, "end_byte": 1180 },
+  "line_text": "    impl Foo for Bar {",
+  "enclosing_qualified_name": "rts_core::Foo",
+  "enclosing_kind": "impl",
+  "enclosing_def_range": { ... },
+  "rank_score": 1.247e-3,
+  // new in v2, present only on structural matches:
+  "captures": {
+    "fn": [{ "start": {"line": 43, "col": 8}, "end": {"line": 45, "col": 9}, "text": "..." }],
+    "name": [{ "start": {"line": 43, "col": 16}, "end": {"line": 43, "col": 24}, "text": "..." }]
+  }
+}
+```
+
+The daemon advertises three new capabilities on `Daemon.Ping`:
+- `index_grep_multiline`
+- `index_grep_structural`
+- `index_grep_within_symbol`
+
+A v2 client checks capabilities before sending v2 params. Old daemons silently ignore unknown input fields, but the calling agent should not assume the feature ran — capability negotiation is the contract.
+
+## Technical Approach
+
+### Module layout
+
+```
+crates/rts-daemon/src/methods/index.rs
+  Existing `pub async fn grep` (line ~1069-1367) — gains v2 param handling
+  `pick_innermost_def` (line 2294-2303) — unchanged, reused
+  NEW: `compose_filters` helper — assembles file-set / regex / structural pipeline
+
+crates/rts-daemon/src/methods/grep_v2/  (new submodule for new code)
+├── mod.rs              // entry; param-pipeline dispatcher; merges into existing handler
+├── compose.rs          // composition matrix; explicit per-cell semantics
+├── multiline.rs        // RegexBuilder wiring; dfa_size_limit; REGEX_TOO_COMPLEX
+├── structural.rs       // per-file parse + Query eval; captures collection
+├── within_symbol.rs    // find_symbol → def byte ranges → intersection filter
+├── query_cache.rs      // (language, query_text) → Arc<Query> LRU
+└── predicates.rs       // predicate whitelist + shared regex compile budget
+
+crates/rts-daemon/src/state.rs
+  CallCounters (159-180) — gains 3 new AtomicU64 sub-counters (closed enum extension)
+
+crates/rts-mcp/src/server.rs
+  GrepArgs (198-236) — gains 4 new Option<...> fields with #[serde(default)]
+  #[tool] grep description (605-630) — appended with v2 usage notes
+
+docs/protocol-v0.md
+  §7.8b Index.Grep — append v2 wire fields; document captures shape; document
+  new capabilities; document new error codes
+```
+
+### Composition matrix (binding decisions)
+
+The six input fields produce a 2⁶ matrix. Behavior of every meaningful cell is fixed here so the implementation isn't inventing semantics per branch:
+
+| `text` | `pattern` | `multiline` | `structural_query` | `within_symbol` | `language` | Behavior |
+|--------|-----------|-------------|--------------------|-----------------|------------|----------|
+| ✓      | ✗         | any         | ✗                  | optional        | optional   | v1 literal substring scan; `multiline` is no-op; `within_symbol`/`language` filter file set post-scan |
+| ✗      | ✓         | ✗           | ✗                  | optional        | optional   | v1 regex scan; `within_symbol`/`language` filter file set post-scan |
+| ✗      | ✓         | ✓           | ✗                  | optional        | optional   | regex with `dot_matches_new_line + multi_line` flags; whole-file buffer; explicit `dfa_size_limit` budget; **`REGEX_TOO_COMPLEX` on cap breach** |
+| ✗      | ✗         | any         | ✓                  | optional        | **required** | parsed-tree query over `language` file set; per-file re-parse; `Query` LRU-cached |
+| ✓      | ✗         | any         | ✓                  | optional        | **required** | **intersection**: file must contain the literal AND the structural query must match in that file; matches are structural hits whose enclosing match-range contains the literal |
+| ✗      | ✓         | any         | ✓                  | optional        | **required** | **intersection**: regex match per match-line + structural query match in same file; matches are structural hits whose line text matches the regex |
+| ✓      | ✓         | —           | —                  | —               | —          | **rejected as `INVALID_PARAMS`**: `text` and `pattern` are mutually exclusive in v1 already |
+| ✗      | ✗         | —           | ✗                  | —               | —          | **rejected as `INVALID_PARAMS`**: at least one of `text`/`pattern`/`structural_query` required |
+
+`within_symbol` always acts as a final post-pass filter: a match is retained only if `(match.start_byte, match.end_byte)` lies strictly inside the def byte range of any resolved symbol. Strict containment is chosen over lenient overlap (see Key Decisions).
+
+`language` is an OR set: if `language: ["rust","ts"]`, files with either language match. `file_glob ∩ language` is AND: a file must satisfy both. A structural query that doesn't compile against one of the requested languages produces a `partial_failures` warning array but does not fail the call as long as it compiled against at least one.
+
+### Validation, error codes, and the predicate whitelist
+
+New error codes (returned as protocol-v0 `INVALID_PARAMS` envelopes with structured `data`):
+
+| `data.code` | Trigger |
+|-------------|---------|
+| `MULTILINE_REQUIRES_REGEX` | `multiline: true` on the literal `text` path (rejected, not silently coerced) |
+| `STRUCTURAL_REQUIRES_LANGUAGE` | `structural_query` set, `language` missing |
+| `STRUCTURAL_QUERY_INVALID` | `Query::new(language, query_text)` failed; `data.error_message` carries the tree-sitter error |
+| `STRUCTURAL_QUERY_PREDICATE_NOT_ALLOWED` | query uses a predicate outside the whitelist |
+| `WITHIN_SYMBOL_NOT_FOUND` | `within_symbol` name resolves to zero defs |
+| `WITHIN_SYMBOL_TOO_MANY_DEFS` | `within_symbol` resolves to more than `WITHIN_SYMBOL_MAX_DEFS` (default: 16) defs — caller can opt in via `within_symbol_allow_overload: true` |
+| `REGEX_TOO_COMPLEX` | regex compile exceeded the configured `dfa_size_limit` / `size_limit` |
+| `STRUCTURAL_QUERY_TIMEOUT` | structural scan exceeded `STRUCTURAL_WALL_CLOCK_MS` (default: 5_000) |
+| `STRUCTURAL_QUERY_TRUNCATED` | not an error; emitted as a top-level `truncated: true` flag with metadata (rows seen, rows returned, capture-bytes total) |
+
+Predicate whitelist (v1):
+- `#eq?`, `#not-eq?` — string equality, no regex compile
+- `#match?`, `#not-match?` — regex compile against a *shared* daemon-wide regex budget; each predicate must compile under `PREDICATE_REGEX_DFA_LIMIT` (default: 256 KB, more conservative than the outer `dfa_size_limit`)
+- `#any-of?` — string membership
+- `#is?`, `#is-not?` — node-property test (no regex)
+
+Predicates not on the whitelist (`#contains?` variants from custom extensions, etc.) cause `STRUCTURAL_QUERY_PREDICATE_NOT_ALLOWED`. The whitelist is documented in `docs/protocol-v0.md`.
+
+### Resource budgets
+
+Constants live in a new `crates/rts-daemon/src/methods/grep_v2/limits.rs`:
+
+```rust
+pub const MULTILINE_DFA_SIZE_LIMIT: usize     = 32 * 1024 * 1024;  // 32 MB
+pub const MULTILINE_NFA_SIZE_LIMIT: usize     = 32 * 1024 * 1024;
+pub const REGEX_DFA_SIZE_LIMIT: usize         = 10 * 1024 * 1024;  // unchanged from default for v1 (single-line) path
+pub const PREDICATE_REGEX_DFA_LIMIT: usize    = 256 * 1024;        // 256 KB for #match? inside queries
+pub const STRUCTURAL_WALL_CLOCK_MS: u64       = 5_000;
+pub const STRUCTURAL_MAX_ROWS: usize          = 4_096;             // hard cap; mirrors existing MAX_LIMIT
+pub const STRUCTURAL_MAX_CAPTURE_BYTES: usize = 8 * 1024;          // per-capture text truncation
+pub const STRUCTURAL_MAX_CAPTURES_PER_MATCH: usize = 64;
+pub const WITHIN_SYMBOL_MAX_DEFS: usize       = 16;
+pub const QUERY_LRU_CAPACITY: usize           = 64;                // (language, query_text) entries
+```
+
+Capture text exceeding `STRUCTURAL_MAX_CAPTURE_BYTES` is truncated and the per-capture object gains `"truncated": true`. The response gains a top-level `truncated: true` + metadata when row limits or wall-clock hit.
+
+### The Query LRU
+
+Existing `cached_refs_query` (`crates/rts-daemon/src/language.rs:276-317`) is process-wide `OnceLock<Option<Query>>` per language — keyed on language only, suitable only for the built-in query strings. Agent-supplied queries need a different cache:
+
+```rust
+// crates/rts-daemon/src/methods/grep_v2/query_cache.rs
+pub struct QueryCache {
+    inner: Mutex<lru::LruCache<(Language, String), Arc<rts_core::query::Query>>>,
+}
+```
+
+LRU capacity = 64 entries (covers ~10 distinct queries across 6 languages with headroom). The cache lives on `DaemonState` next to `call_counters`. Eviction is by recency; no time-based eviction in v1. Grammar version drift invalidation is **out of scope for v1** (grammars are statically linked; no hot reload exists).
+
+### Telemetry coordination with the doctor plan (PR 001)
+
+PR 001 (`docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md`) adds **top-level fields** to `Daemon.Stats` (`pinned_workspace_path`, `index_generation`, `cold_walk_completed_at_ms`) and a `daemon_stats_v2` capability.
+
+This plan adds **three new fields to `CallCounters`**:
+- `index_grep_multiline: AtomicU64`
+- `index_grep_structural: AtomicU64`
+- `index_grep_within_symbol: AtomicU64`
+
+These appear in `CallCounters::snapshot()` as siblings of the existing `index_grep` field (not nested) — matches the existing closed-enum pattern; avoids restructuring the snapshot JSON; safe for old `--output json` consumers.
+
+**Bump policy:** each sub-counter increments only when its corresponding param is *set* (and `multiline` requires `pattern` to be set as well; `multiline: false` does NOT bump `index_grep_multiline`). The parent `index_grep` counter increments on every grep call. A call with all three new params therefore bumps four counters total (parent + 3 sub).
+
+**Coordination:** PRs 001 and 002 both modify `crates/rts-daemon/src/state.rs:159-180` (`CallCounters`) and `crates/rts-daemon/src/methods/daemon.rs:18-87` (capability list). The two PRs are sequenced: PR 001 lands first (smaller, lower-risk), then PR 002 rebases on top. Both add fields; neither removes any. A new capability `index_grep_v2` *also* advertises the bundle for clients that prefer a single check.
+
+### `content_version` propagation
+
+Existing matches carry `content_version` via the redb read txn snapshot. Captures inherit the same version implicitly: the per-file parse for structural queries happens **inside the same `defs_in_file` read txn** as the match-line lookup. No separate version tracking needed; the invariant is encoded by transaction boundary.
+
+### System-Wide Impact
+
+- **Interaction graph.** `Index.Grep` request → daemon `methods::dispatch` (bumps parent counter) → `grep_v2::compose` (param validation) → file walk (existing) → per-file `(read txn, optional re-parse, regex scan, structural query, within_symbol filter)` → response assembly → bump sub-counters. No new sockets, no writes to disk, no new RPCs.
+- **Error propagation.** Validation errors at request entry (`INVALID_PARAMS` envelope). Per-file errors during structural scan (parse failure on one file) are logged at `debug` and the file is skipped — the call succeeds with the files that parsed. Predicate compile errors fail the whole call with `STRUCTURAL_QUERY_PREDICATE_NOT_ALLOWED`. The existing literal/regex path's error envelopes are unchanged.
+- **State lifecycle.** No persistent state introduced. The Query LRU is in-memory only; cleared on daemon restart. Sub-counters are atomic-incremented; no race.
+- **API surface parity.** Three new capabilities + one bundle capability advertised on `Daemon.Ping`. JSON Schema for `Index.Grep` grows three optional input fields and one optional output field. rmcp's schema hash will change; clients that pin the hash for tool-cache invalidation will see the new schema and re-cache. R8 in the origin doc is interpreted as "response bytes on the unchanged input path are byte-identical," NOT "schema bytes are unchanged."
+- **Integration test scenarios.**
+  - v1 caller (no v2 params) — v2 daemon responds byte-for-byte identically.
+  - v2 `multiline: true` against a Rust file with a multi-line `fn` signature; expect a single match spanning multiple lines.
+  - v2 `structural_query: "(impl_item)"` + `language: ["rust"]` — expect every impl block as a match with the captured node text.
+  - v2 `structural_query` + `language: ["rust","ts"]` where query is valid only for Rust — expect Rust matches; `partial_failures: [{language: "ts", error: "..."}]` in response.
+  - v2 `within_symbol: "parse"` resolving to one def — expect matches inside that one byte range only.
+  - v2 `within_symbol: "new"` resolving to >16 defs — expect `WITHIN_SYMBOL_TOO_MANY_DEFS` error with the count.
+  - v2 `within_symbol: "new"` + `within_symbol_allow_overload: true` — expect union-of-byte-ranges filter.
+  - v2 adversarial multiline regex (`(?s).*` on a 4MB file) — expect `REGEX_TOO_COMPLEX` if the DFA limit breaches, else success.
+  - v2 query with `#match? @x "(.*a){50}"` predicate — expect `STRUCTURAL_QUERY_PREDICATE_NOT_ALLOWED` if it breaches the predicate regex budget.
+  - v2 structural query that returns >4096 rows — expect `truncated: true` in response with metadata.
+  - v2 structural query that runs longer than 5s — expect `STRUCTURAL_QUERY_TIMEOUT`.
+  - v2 capture text >8KB — per-capture `truncated: true`, response succeeds.
+  - v2 `text` + `structural_query` intersection — expect matches present in both filters only.
+
+## Implementation Units
+
+Ordered by dependency. U1 must coordinate with PR 001 (rts-doctor `Daemon.Stats v2`).
+
+### U1 — `GrepArgs`/`GrepParams` schema extension + capability advertisement
+
+- **Goal.** Add four optional input fields (`multiline`, `structural_query`, `within_symbol`, `language`) to both rts-mcp `GrepArgs` and rts-daemon `GrepParams`; advertise four new capabilities (`index_grep_multiline`, `index_grep_structural`, `index_grep_within_symbol`, `index_grep_v2`).
+- **Files.** `crates/rts-mcp/src/server.rs:198-236` (`GrepArgs`); `crates/rts-daemon/src/methods/index.rs:116-146` (`GrepParams`); `crates/rts-daemon/src/methods/daemon.rs:18-87` (capability list); `docs/protocol-v0.md` (§7.8b append + appendix entry).
+- **Approach.** Add fields with `#[serde(default)] Option<...>`; `JsonSchema` derives the schema additively. Capability list grows by four `&str` entries. Test: round-trip a v1 request (no new fields) and confirm response bytes match.
+- **Patterns to follow.** Existing optional-field extension pattern on `FindSymbolArgs` (`server.rs:27`), `ReadSymbolArgs` (`server.rs:158`); `pre_filter_count` precedent for optional response fields (`docs/protocol-v0.md` §7.4).
+- **Execution note.** Characterization-first: capture the v1 grep response shape in a frozen golden fixture before changing anything.
+- **Test scenarios.**
+  - Round-trip: v1 request returns response with no new fields, byte-equal to the frozen golden.
+  - Capability list contains all four new strings.
+  - JSON Schema for `Index.Grep` deserializes cleanly via `schemars`.
+- **Verification.** `cargo test -p rts-mcp -p rts-daemon` green; `docs/protocol-v0.md` lints clean; capability grep returns 4 new entries.
+
+### U2 — Composition matrix + validation + error codes
+
+- **Goal.** All `INVALID_PARAMS` envelope cases enumerated in the composition matrix table emit the correct `data.code`. Mutually-exclusive combos rejected. Required-when-X combos enforced.
+- **Files.** `crates/rts-daemon/src/methods/grep_v2/mod.rs` (new); `crates/rts-daemon/src/methods/grep_v2/compose.rs` (new); `crates/rts-daemon/src/methods/index.rs` (entry point wires through `grep_v2::validate` before reaching the existing handler).
+- **Approach.** Implement `pub fn validate(params: &GrepParams) -> Result<ValidatedGrepCall, GrepError>` that returns an enum representing the matrix cell to execute. Errors carry `data.code` per the error-code table.
+- **Patterns to follow.** Existing `INVALID_PARAMS` envelope shape (`crates/rts-daemon/src/methods/*.rs`); the `pre_filter_count` optional-output precedent for the eventual `truncated` flag.
+- **Execution note.** Test-first: write the matrix-cell tests before implementing `validate`. The matrix is the spec; tests are derived from it.
+- **Test scenarios.**
+  - Each of the 8 rows in the composition matrix produces the expected pass/reject result with the documented error code.
+  - `text + pattern` both set → `INVALID_PARAMS { code: "PATTERN_AND_TEXT_BOTH_SET" }` (existing v1 behavior preserved).
+  - `structural_query` without `language` → `STRUCTURAL_REQUIRES_LANGUAGE`.
+  - `multiline: true` with `text` set → `MULTILINE_REQUIRES_REGEX`.
+- **Verification.** `cargo test -p rts-daemon grep_v2::compose` green; error-code grep returns documented strings in docs.
+
+### U3 — Multiline regex path
+
+- **Goal.** When `multiline: true` is set with `pattern`, regex compile uses `dot_matches_new_line(true).multi_line(true)`; explicit `dfa_size_limit`/`size_limit`; `REGEX_TOO_COMPLEX` on cap breach; whole-file buffer scan.
+- **Files.** `crates/rts-daemon/src/methods/grep_v2/multiline.rs` (new); `crates/rts-daemon/src/methods/index.rs:152-231` (`GrepScanner` enum gains a `MultilineRegex` variant).
+- **Approach.** New `GrepScanner::MultilineRegex(regex::bytes::Regex)` built via `RegexBuilder::new(text).dot_matches_new_line(true).multi_line(true).size_limit(MULTILINE_*).build()`. Existing line-iteration scan path replaced with whole-buffer scan for this variant; match coordinates translated back to `(start_line, end_line)` via existing line-offset cache (or built per-file on first multiline hit).
+- **Patterns to follow.** `crates/rts-daemon/src/methods/index.rs:1126-1136` (regex compile site); `crates/rts-daemon/src/methods/index.rs:152-231` (scanner enum).
+- **Execution note.** Test-first: adversarial regex cases (`(?s).*`, `(a*)*`) before the implementation; verify they return `REGEX_TOO_COMPLEX` not `OutOfMemory`.
+- **Test scenarios.**
+  - Multi-line `fn` signature spanning 3 lines: matched as one record.
+  - Adversarial `(?s).*` against a 4 MB file: returns `REGEX_TOO_COMPLEX` (not OOM, not hang).
+  - `multiline: false` (default): behavior matches v1 exactly.
+- **Verification.** `cargo test -p rts-daemon grep_v2::multiline` green; latency on a healthy v1 case unchanged (no regression).
+
+### U4 — `within_symbol` filter
+
+- **Goal.** When `within_symbol` is set, post-filter matches to those whose byte range lies inside any resolved def byte range. Cardinality cap with structured error.
+- **Files.** `crates/rts-daemon/src/methods/grep_v2/within_symbol.rs` (new); `crates/rts-daemon/src/methods/index.rs` (call site after match collection, before sort).
+- **Approach.** Call `store.find_symbol(name)` (existing API at `crates/rts-daemon/src/store/mod.rs:995-1035`). If zero defs → `WITHIN_SYMBOL_NOT_FOUND`. If >`WITHIN_SYMBOL_MAX_DEFS` and `within_symbol_allow_overload != Some(true)` → `WITHIN_SYMBOL_TOO_MANY_DEFS`. Else: union the byte ranges per-file; filter matches by `(start_byte, end_byte) ⊆ def_range` (strict containment). Filtering is per-file (no cross-file ranges).
+- **Patterns to follow.** `crates/rts-daemon/src/methods/index.rs:2294-2303` (`pick_innermost_def`); `crates/rts-daemon/src/store/mod.rs:995-1035` (`find_symbol`).
+- **Execution note.** Test-first: zero-def, one-def, overloaded-name-rejected, overloaded-name-allowed scenarios before the implementation.
+- **Test scenarios.**
+  - Single def: only matches inside that def are returned.
+  - Zero defs: `WITHIN_SYMBOL_NOT_FOUND`.
+  - 17 defs, no opt-in: `WITHIN_SYMBOL_TOO_MANY_DEFS { def_count: 17 }`.
+  - 17 defs with `within_symbol_allow_overload: true`: matches across union returned.
+  - Match on the def's closing brace boundary: strict containment (excluded by default).
+- **Verification.** `cargo test -p rts-daemon grep_v2::within_symbol` green.
+
+### U5 — Query LRU + predicate whitelist + structural execution
+
+- **Goal.** Run agent-supplied tree-sitter S-expression queries against per-file parsed trees with caching, predicate whitelisting, wall-clock budget, and row/byte truncation.
+- **Files.** `crates/rts-daemon/src/methods/grep_v2/query_cache.rs` (new — LRU keyed on `(Language, String)`); `crates/rts-daemon/src/methods/grep_v2/predicates.rs` (new — whitelist + budget); `crates/rts-daemon/src/methods/grep_v2/structural.rs` (new — per-file parse + query execution + capture extraction); `crates/rts-daemon/src/state.rs` (add `query_cache: Mutex<QueryCache>` to `DaemonState`); `crates/rts-daemon/Cargo.toml` (add `lru = "0.12"`).
+- **Approach.** On first call with a given `(language, query_text)`: `rts_core::query::Query::new(language, query_text)` to validate + compile; walk the query's predicates and reject anything not on the whitelist; insert `Arc<Query>` into the LRU. Per file in scope: re-parse via existing `ParserPool::parse_and_extract` (`writer.rs:656`), then `QueryCursor::new().matches(&query, tree.root_node(), file_bytes)`; collect captures into per-match `captures` map. Wall-clock checked between files (not mid-file).
+- **Patterns to follow.** `crates/rts-core/src/query.rs:11,19,45,80,109` (`Query` wrapper); `crates/rts-daemon/src/refs.rs:54-115` (existing query execution); `crates/rts-daemon/src/language.rs:276-317` (existing OnceLock cache pattern — model for LRU).
+- **Execution note.** Test-first: predicate whitelist (`#match?` allowed, `#contains?` rejected); query LRU hit/miss; cross-file timeout.
+- **Test scenarios.**
+  - First call: query compiles, cache miss, miss counter increments.
+  - Second call with same `(language, query_text)`: cache hit.
+  - Query with disallowed predicate: `STRUCTURAL_QUERY_PREDICATE_NOT_ALLOWED`.
+  - Query with `#match? @x "(.*a){50}"`: `STRUCTURAL_QUERY_PREDICATE_NOT_ALLOWED` (predicate regex budget breach).
+  - Query against `language: ["rust","ts"]` with TS-incompatible syntax: response includes `partial_failures: [{language:"ts", error:"..."}]` but Rust results returned.
+  - 100k LOC workspace with `(_) @x`: returns `STRUCTURAL_QUERY_TIMEOUT` (not hang).
+  - >4096 matching nodes: `truncated: true` + `rows_seen / rows_returned` metadata.
+- **Verification.** `cargo test -p rts-daemon grep_v2::structural` green; cross-language partial failures behave as documented.
+
+### U6 — Capture serialization + per-match `captures` field
+
+- **Goal.** Each structural match carries its own `captures` map (per-match, not top-level). Capture text is truncated at `STRUCTURAL_MAX_CAPTURE_BYTES`. Position units are `{line, col}`.
+- **Files.** `crates/rts-daemon/src/methods/grep_v2/structural.rs` (capture assembly); `crates/rts-daemon/src/methods/index.rs:1302-1323` (response shape: add per-match `captures` field, present-when-relevant).
+- **Approach.** Define `pub struct CapturePayload { start: LineCol, end: LineCol, text: String, truncated: bool }`. Per `Query::matches`, iterate captures, slice byte range from file content, compute `{line,col}` via the existing line-offset cache; if `text.len() > STRUCTURAL_MAX_CAPTURE_BYTES`, truncate and set `truncated: true`. Serialize as `serde_json::Map`, attach to the existing match record only when the call had `structural_query`.
+- **Patterns to follow.** Existing response-record assembly (`crates/rts-daemon/src/methods/index.rs:1302-1323`); existing byte-to-line conversion utilities in `crates/rts-core/`.
+- **Execution note.** Test-first: snapshot one expected response for `(impl_item)` query against a seeded Rust file.
+- **Test scenarios.**
+  - Single-capture query: response has `captures.fn` with one entry.
+  - Multi-capture query (`@fn @name`): response has both keys with their respective entries.
+  - Capture text >8KB: `truncated: true` in the capture object.
+  - Non-structural call: response has NO `captures` field (absent, not empty).
+  - Capture spanning across line boundaries: `start.line` < `end.line`, computed correctly.
+- **Verification.** `cargo test -p rts-daemon grep_v2::structural::captures` green; response snapshot matches a committed fixture.
+
+### U7 — Sub-counter telemetry
+
+- **Goal.** Three new sub-counters in `CallCounters`; correctly bumped per-call by which v2 params were set; visible in `Daemon.Stats` snapshot.
+- **Files.** `crates/rts-daemon/src/state.rs:159-180` (add `index_grep_multiline`, `index_grep_structural`, `index_grep_within_symbol` `AtomicU64` fields); `crates/rts-daemon/src/state.rs:187-208` (`snapshot()` includes them); `crates/rts-daemon/src/state.rs:212-231` (`total()` includes them); `crates/rts-daemon/src/methods/index.rs` (after validation, bump the relevant counters based on which params were set).
+- **Approach.** Bump policy: each sub-counter bumps when its corresponding param is *set and active* (e.g., `multiline: false` does NOT bump). Bumps happen after validation but before the heavy work, so failed structural validation still counts toward `index_grep_structural` (visibility into rejection rates). Document this in `docs/protocol-v0.md`.
+- **Patterns to follow.** `crates/rts-daemon/src/state.rs:159-180` (existing `CallCounters`); `crates/rts-daemon/src/methods/mod.rs:46-124` (dispatch site is unsuitable for sub-counter bumps — they happen inside `grep`).
+- **Execution note.** Coordination with PR 001: this unit must NOT touch top-level `Daemon.Stats` fields (those are owned by PR 001). Only the sub-counter fields.
+- **Test scenarios.**
+  - Call with only `structural_query`: `index_grep_structural` += 1, other sub-counters unchanged.
+  - Call with all three new params: all three sub-counters and parent `index_grep` += 1 each.
+  - Call with `multiline: false`: only parent `index_grep` += 1.
+- **Verification.** `cargo test -p rts-daemon` (existing `daemon_stats_round_trip.rs` pattern) extended to cover sub-counters; `cargo test -p rts-daemon grep_v2::telemetry` green.
+
+### U8 — Docs (`docs/protocol-v0.md` updates + tool description string + agent guidance)
+
+- **Goal.** Documentation surface complete: protocol-v0 §7.8b updated; new capabilities + error codes documented; appendix F log entry; rmcp tool description string updated with v2 usage notes.
+- **Files.** `docs/protocol-v0.md` (§7.8b Index.Grep — append v2 section; Appendix F — additive entry for v2; §9 error codes — add new codes); `crates/rts-mcp/src/server.rs:605-630` (`#[tool(description=...)]` for `grep`); `AGENTS.md` (the "use rts, not grep" cheatsheet — add a paragraph about v2 capabilities); `changelog.d/<NNNN>-index-grep-v2.md` (fragment per v0.5.5+ convention).
+- **Approach.** Pure docs. Tool description gets ~3 lines on v2 usage. Protocol doc gets the wire shape, capabilities, error codes, predicate whitelist, resource budgets.
+- **Patterns to follow.** Appendix F precedent (per-alpha additive log entries); `pre_filter_count` doc entry as the optional-output template.
+- **Execution note.** Pragmatic.
+- **Verification.** Docs lint clean; cross-references resolve; one round-trip test asserts the appendix F entry's listed capabilities all appear in the daemon's runtime capability list.
+
+### U9 — Latency baseline + benchmark fixture
+
+- **Goal.** A reproducible benchmark capturing v1 grep latency on a known workspace, run twice (before/after the v2 PR) to assert no regression on the unchanged code path.
+- **Files.** `crates/rts-daemon/benches/grep_baseline.rs` (new — uses criterion or hand-rolled timing); `crates/rts-bench/tests/grep_latency_test.rs` (new — invoked via integration test, asserts p95 < some budget).
+- **Approach.** Seeded 1000-file workspace; run `Index.Grep` 100 times against the same literal pattern; record p50/p95/p99 latency. The same script runs against pre-PR and post-PR daemon binaries; output committed under `bench-results/grep-v1-baseline.json`.
+- **Patterns to follow.** Existing `crates/rts-bench/tests/` integration-test pattern (tempdir + spawn daemon).
+- **Execution note.** Pragmatic.
+- **Verification.** Two run-and-diff scripts return same numbers ±10% between pre-PR and post-PR builds on the unchanged path; structural and multiline paths add their own numbers (no comparison — net new).
+
+## Requirements Trace
+
+| ID  | Requirement (from origin) | Satisfied by | Notes |
+|-----|---------------------------|--------------|-------|
+| R1  | Three optional input params (`multiline`, `structural_query`, `within_symbol`), fully composable | U1, U2 | Composition matrix is the binding spec |
+| R2  | `multiline: true` flips multi_line + dot_matches_new_line | U3 | No-op on literal path (composition matrix) |
+| R3  | Raw tree-sitter S-expression query | U5 | Predicate whitelist is the safety wrapper |
+| R4  | Required `language` param for structural; per-grammar validation | U2, U5 | Partial-failures shape documented |
+| R5  | `within_symbol` qualified-name match; def-byte-range filter | U4 | Strict containment; cardinality-capped |
+| R6  | All three params fully composable | U2 | Matrix-cell tests |
+| R7  | Captures returned per-match in `captures: {name: [...]}` | U6 | Brainstorm top-level shape corrected to per-match |
+| R8  | Backward compat byte-for-byte on unchanged path | U1, U9 | Frozen golden + baseline bench |
+| R9  | Structured error envelope; distinguishable codes | U2, U4, U5 | 9 codes documented |
+| R10 | Sub-counters in `Daemon.Stats` | U7 | Sibling fields, not nested |
+
+## Acceptance Criteria
+
+### Functional
+
+- [ ] **AC1.** A v1 caller (no v2 params) receives a response byte-identical to the frozen v1 golden.
+- [ ] **AC2.** `multiline: true` + `pattern` matches across `\n` on a fixture file; `multiline: false` (default) does not.
+- [ ] **AC3.** `multiline: true` + `text` (literal) returns `INVALID_PARAMS { code: "MULTILINE_REQUIRES_REGEX" }`.
+- [ ] **AC4.** `structural_query` without `language` returns `STRUCTURAL_REQUIRES_LANGUAGE`.
+- [ ] **AC5.** Malformed `structural_query` (e.g., `"(unbalanced"`) returns `STRUCTURAL_QUERY_INVALID` with the tree-sitter error in `data.error_message`.
+- [ ] **AC6.** `structural_query` with a disallowed predicate (`#contains?`) returns `STRUCTURAL_QUERY_PREDICATE_NOT_ALLOWED`.
+- [ ] **AC7.** `structural_query` with `#match? @x "(.*a){50}"` (catastrophic predicate regex) returns `STRUCTURAL_QUERY_PREDICATE_NOT_ALLOWED` due to the predicate budget cap.
+- [ ] **AC8.** `structural_query` valid against `language: ["rust"]` returns matches with per-match `captures` keyed by capture name.
+- [ ] **AC9.** `structural_query` valid against Rust but invalid against TS in `language: ["rust","ts"]` returns Rust matches + `partial_failures: [{language:"ts", error: ...}]`.
+- [ ] **AC10.** `within_symbol: "name"` resolving to zero defs returns `WITHIN_SYMBOL_NOT_FOUND`.
+- [ ] **AC11.** `within_symbol: "new"` resolving to >16 defs (default) returns `WITHIN_SYMBOL_TOO_MANY_DEFS { def_count }` unless `within_symbol_allow_overload: true`.
+- [ ] **AC12.** `within_symbol: "parse"` resolving to one def keeps only matches whose byte range is strictly inside the def byte range.
+- [ ] **AC13.** Adversarial multiline regex (`(?s).*` on a 4 MB file) returns `REGEX_TOO_COMPLEX`, never OOM.
+- [ ] **AC14.** Structural query returning >4096 matches sets `truncated: true` with `{rows_seen, rows_returned}` metadata.
+- [ ] **AC15.** Structural query running >5s returns `STRUCTURAL_QUERY_TIMEOUT`.
+- [ ] **AC16.** A capture whose text exceeds 8 KB has `truncated: true` in the capture object; the response still succeeds.
+- [ ] **AC17.** Repeated calls with the same `(language, query_text)` show LRU hits in a sub-counter or debug log (low priority — informational).
+- [ ] **AC18.** `Daemon.Ping` advertises `index_grep_multiline`, `index_grep_structural`, `index_grep_within_symbol`, and the bundle `index_grep_v2`.
+- [ ] **AC19.** `Daemon.Stats` includes three new sub-counter fields, correctly bumped by call shape.
+- [ ] **AC20.** Composition: `structural_query + text` returns only matches where both filters apply (intersection).
+- [ ] **AC21.** Composition: `structural_query + within_symbol` returns only structural matches whose match-range is inside the named symbol's def range.
+- [ ] **AC22.** `content_version` is consistent across the match line and its captures (same redb txn snapshot).
+
+### Non-Functional
+
+- [ ] **AC23.** v1 grep latency p95 on the seeded 1000-file benchmark is unchanged ±10% versus pre-PR baseline (no regression on unchanged path).
+- [ ] **AC24.** Query LRU caps at 64 entries; eviction is recency-ordered.
+- [ ] **AC25.** New crate deps limited to `lru = "0.12"` on rts-daemon. No new deps on rts-mcp or rts-core.
+
+### Quality Gates
+
+- [ ] **AC26.** `cargo test --workspace` green; coverage of all 22 functional ACs.
+- [ ] **AC27.** `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- [ ] **AC28.** `docs/protocol-v0.md` updated with the v2 wire fields, capabilities, error codes, predicate whitelist, resource budgets.
+- [ ] **AC29.** A `changelog.d/<NNNN>-index-grep-v2.md` fragment lands.
+- [ ] **AC30.** AGENTS.md's "use rts, not grep" cheatsheet gains a paragraph about v2 capabilities.
+
+## Success Metrics
+
+- **First-week:** AGENTS.md cheatsheet updated; one example using structural query in a real PR description.
+- **agent-bench Phase 2 PR-B:** The v2 capabilities show up in trajectories — sub-counter visibility in `Daemon.Stats` confirms agents actually call the new modes. Target: at least 5% of `Index.Grep` calls use at least one v2 param within 30 days of merging.
+- **Tool-use ratio:** Measurable reduction in `Bash rg` calls per task on the agent-bench corpus, attributable to the multi-line / structural / scoped capabilities. Wilson-CI 95% over n≥30 tasks.
+- **Latency stability:** p95 of v1-shape grep on the seeded benchmark unchanged within ±10% pre/post merge.
+
+## Dependencies & Risks
+
+- **PR 001 (rts-doctor) must land first or merge atomically.** Both modify `CallCounters` and the capability list in `methods/daemon.rs`. The plan sequences PR 001 → PR 002.
+- **`lru` crate addition.** A new dep on rts-daemon. Minimal, well-maintained (~10k downloads/day on crates.io). Plan validates the dep tree post-merge.
+- **Tree-sitter 0.26 pin.** Predicate set documented for 0.26. A future tree-sitter upgrade may require predicate whitelist re-validation. Documented in `docs/protocol-v0.md` as a known maintenance item.
+- **regex version skew.** Workspace has `regex = "1"` (daemon) and `"1.10"` (core). v2 features (`dfa_size_limit`, `multi_line`) require `1.5+`; both are satisfied. Plan recommends pinning workspace-wide to `1.10` in a separate small PR (out of this scope).
+- **Brainstorm shape correction risks contention.** R7's top-level `{name: [...]}` shape would have produced collisions; this plan corrects to per-match. If any external consumer prototyped against the brainstorm shape, they'll need to update. No external consumers exist today.
+- **Predicate whitelist may be too restrictive.** v1 whitelist deliberately covers the common cases (`#eq?`, `#match?`, etc.). If observed agent usage demands more, expand in a follow-up PR; do NOT widen pre-emptively (DoS surface).
+- **Per-file re-parse cost on large workspaces.** A 100k LOC workspace with a structural query that runs against every file may approach the 5s wall-clock budget. The truncation + timeout responses are the safety valve. A future PR can add a per-call parsed-tree cache if observed usage demands it.
+
+## Scope Boundaries
+
+The following are explicit non-goals for this PR:
+
+- **No named-pattern catalog** (e.g., `fn_with_attr`, `impl_containing`). Raw S-expression queries only. A v2.1 catalog can be informed by observed agent queries.
+- **No structural query as a denormalized graph.** v1 runs the query per-file and unions results; no cross-file structural matching.
+- **No rewriting / refactoring based on captures.** v2 is read-only; transforms live in a future `Index.RenamePreview`-shaped tool (ideation idea #6).
+- **No structural queries on `Index.FindCallers`, `Index.ImpactOf`, etc.** v2 is `Index.Grep`-only.
+- **No persisted-result cache.** Query LRU is in-memory; cleared on daemon restart.
+- **No hot grammar reload / grammar-version invalidation.** Grammars are statically linked at daemon build time. A grammar bump requires a daemon binary rebuild.
+- **No streaming response.** Structural results are buffered, truncated at the row cap, and returned as a single response. A future v2.x can add streaming if needed.
+- **No `--output lines` parity for the new fields in `rts-bench query grep`.** The CLI exposes the v1 line shape only; new fields are JSON-only via the MCP path.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-18-index-grep-v2-requirements.md](../brainstorms/2026-05-18-index-grep-v2-requirements.md). Carried-forward decisions:
+  1. Single tool, additive params — Key Decisions §1
+  2. Raw S-expression queries — Key Decisions §2
+  3. Fully composable; captures returned — Key Decisions §3 (per-match shape corrected by this plan)
+  4. Required `language` for structural queries — Key Decisions §4
+  5. Sub-counters for v2 capabilities — Key Decisions §5
+- **Research consolidations:**
+  - `crates/rts-mcp/src/server.rs:198-236` — `GrepArgs` (extension surface)
+  - `crates/rts-mcp/src/server.rs:605-630` — `#[tool]` grep description
+  - `crates/rts-daemon/src/methods/index.rs:116-146` — `GrepParams`
+  - `crates/rts-daemon/src/methods/index.rs:152-231` — `GrepScanner` enum (extends to MultilineRegex)
+  - `crates/rts-daemon/src/methods/index.rs:1069-1367` — current grep handler
+  - `crates/rts-daemon/src/methods/index.rs:1302-1323` — response record (extends with `captures`)
+  - `crates/rts-daemon/src/methods/index.rs:2294-2303` — `pick_innermost_def`
+  - `crates/rts-daemon/src/store/mod.rs:995-1035` — `find_symbol` (within_symbol's resolution path)
+  - `crates/rts-daemon/src/store/schema.rs:159-168` — `DefSite { start, end, ... }`
+  - `crates/rts-daemon/src/language.rs:67-317` — per-language queries + OnceLock cache pattern
+  - `crates/rts-daemon/src/refs.rs:54-115` — existing tree-sitter Query execution
+  - `crates/rts-core/src/query.rs:11-109` — `Query` wrapper
+  - `crates/rts-daemon/src/state.rs:159-180` — `CallCounters` (closed enum extension)
+  - `crates/rts-daemon/src/methods/daemon.rs:18-87` — capability list
+  - `docs/protocol-v0.md` §7.4 (`pre_filter_count`) — optional-output precedent
+  - `docs/protocol-v0.md` §7.8b — current `Index.Grep` spec
+  - `docs/protocol-v0.md` §3.6 — `content_version` propagation rule
+- **Related PRs / plans:**
+  - **PR 001** (`docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md`) — Daemon.Stats v2 + capability; must land first or merge atomically.
+  - #104 (Daemon.Stats RPC + counters)
+  - #107 (agent-bench harness — measures whether v2 capabilities shift agent tool-use ratio)
+
+## Deferred to Implementation
+
+All 9 brainstorm-deferred questions resolved here:
+
+- **[Affects R2]** Multi-line resource budget: `dfa_size_limit = 32 MB`, `size_limit = 32 MB`, no wall-clock timeout (covered by overall daemon request timeout). `(?s)` is implicit when `multiline: true` (combined with `(?m)`).
+- **[Affects R5]** `within_symbol` shape: single exact qualified name in v1; opt-in `within_symbol_allow_overload: true` to union N defs; otherwise capped at `WITHIN_SYMBOL_MAX_DEFS = 16`.
+- **[Affects R5]** `within_symbol` intersection: strict containment (match range ⊆ def range).
+- **[Affects R3, R7]** Predicate whitelist: `#eq?`, `#not-eq?`, `#match?`, `#not-match?`, `#any-of?`, `#is?`, `#is-not?`. Documented in protocol-v0.
+- **[Affects R4]** Pre-validation: `Query::new` at request time; LRU caches the compiled `Query`. Malformed query yields `STRUCTURAL_QUERY_INVALID` with the tree-sitter error message.
+- **[Affects R7]** Capture position units: `{line, col}` (consistent with v1 match coordinates). Byte offsets not exposed in v1.
+- **[Affects R6]** Result truncation: `STRUCTURAL_MAX_ROWS = 4096`; capture text truncation at `STRUCTURAL_MAX_CAPTURE_BYTES = 8 KB`; top-level `truncated: true` + metadata.
+- **[Affects R7]** `language` filter on literal/regex path: yes (parity); intersected with `file_glob`.
+- **[Affects R4]** Grammar-version invalidation: out of scope for v1 (no hot reload).
+
+## Post-Deploy Monitoring & Validation
+
+- **What to monitor/search**
+  - Logs: daemon `tracing` output at `info` for v2 calls (counter bumps) and at `warn` for resource-cap breaches.
+  - Metrics/Dashboards: `Daemon.Stats` sub-counter values across sessions; agent-bench trajectory tool-use ratio (`mcp__rts__grep` count).
+- **Validation checks (queries/commands)**
+  - Manual: `cargo test --workspace`
+  - Round-trip: a fixture trajectory replays against the v2 daemon and produces identical v1-shape responses on the unchanged path.
+  - Bench: `cargo bench -p rts-daemon grep_baseline` shows ±10% on v1 path.
+- **Expected healthy behavior**
+  - Sub-counters show non-zero values once an agent uses v2.
+  - No regression in v1 latency.
+  - Adversarial inputs return structured errors, not panics/OOM.
+- **Failure signal(s) / rollback trigger**
+  - Spike in `STRUCTURAL_QUERY_TIMEOUT` or `REGEX_TOO_COMPLEX` errors → tighten budgets or revert.
+  - Any panic in `grep_v2::*` → revert (no schema migrations).
+- **Validation window & owner**
+  - 14-day window post-merge; author monitors agent-bench tool-use ratio.
+
+---
+
+## Plan Status
+
+- **Detail level:** MORE (standard plan)
+- **SpecFlow:** complete (composition matrix, edge cases, brainstorm shape corrections all incorporated)
+- **Deepen:** not requested
+- **Source decisions trace:** complete; 9 brainstorm-deferred questions resolved; 5 brainstorm assumptions corrected based on research
+- **Coordination:** sequences after PR 001 (doctor)
+- **Next:** `/ce:plan` on `docs/brainstorms/2026-05-18-persisted-cold-mount-requirements.md`, then `/ce:work` on the three plans in order.

--- a/docs/plans/2026-05-18-003-feat-persisted-cold-mount-plan.md
+++ b/docs/plans/2026-05-18-003-feat-persisted-cold-mount-plan.md
@@ -1,0 +1,530 @@
+---
+title: "feat(daemon): persisted cold-mount via redb META fingerprint + mtime reconciliation"
+type: feat
+status: active
+date: 2026-05-18
+origin: docs/brainstorms/2026-05-18-persisted-cold-mount-requirements.md
+---
+
+# Persisted cold-mount — trust the existing on-disk redb across daemon restarts
+
+## Overview
+
+The rts daemon already writes its index to a per-workspace on-disk redb file at the canonical state path (`state_dir_for(fingerprint) → ${XDG_STATE_HOME:-~/.local/state}/rts/<workspace_id>/db.redb` on Linux; `~/Library/Caches/rts/<workspace_id>/db.redb` on macOS). The cold-walk re-runs every daemon startup not because the redb is empty, but because **`InitialWalkHandle::spawn` fires unconditionally** at `crates/rts-daemon/src/methods/workspace.rs:145-213`.
+
+This plan does not introduce a new cache. It teaches the existing on-disk state to be trusted across daemon restarts by:
+
+1. Extending the existing redb `META` table with a **composite fingerprint** (schema_version + daemon_binary_version + grammar_versions + gitignore_content_hash) stored as **per-part columns** plus a combined hash for fast comparison.
+2. **Conditionally skipping `InitialWalkHandle::spawn`** when META's fingerprint matches the current fingerprint and FILES is non-empty.
+3. Running an **mtime/size reconciliation pass** over the FILES table to re-parse only changed files since the last shutdown.
+4. Adding a `mount_source` field to `Daemon.Stats v2` (extends PR 001's `daemon_stats_v2` capability) with diagnostic values like `rehydrate`, `cold_walk`, or `cold_walk_after_invalidation:grammar:rust:0.23→0.24`.
+5. Adding cache-effectiveness counters (`rehydrate_attempts`, `rehydrate_successes`, `rehydrate_invalidations_by_reason{...}`) so SC1's *"sub-100 ms first-query"* claim is observable in production.
+
+The plan reframes five brainstorm assumptions surfaced by research:
+
+| Brainstorm wording | Reality |
+|--------------------|---------|
+| "Serialize the redb snapshot to `~/.cache/rts/<workspace-hash>/`" | Already persisted at `state_dir_for(...)` (XDG_STATE_HOME on Linux, Library/Caches on macOS). Don't relocate. |
+| "Write the snapshot atomically at cold-walk-done + on shutdown" | redb writes continuously and ACID-ly. Only the *fingerprint* is the snapshot atom; the data is already on disk. |
+| "Cache key = `blake3(canonical_workspace_path)`" | Existing `WorkspaceFingerprint` is `blake3(dev_id ‖ inode ‖ canonical_path)[:16]`. Reuse it. |
+| "Single composite fingerprint" | Per-part columns + a combined hash is strictly better (diagnostic `cold_walk_after_invalidation:<reason>` requires per-part). |
+| "Snapshot covers all redb tables" | Trivially true — the redb file is already on disk. The plan just learns to trust it. |
+
+## Problem Statement / Motivation
+
+Cold mount on 100k LOC takes ~6 s today and is paid every time the daemon goes idle (10 min `RTS_IDLE_SHUTDOWN_SECS` default). The cold-walk is the only user-perceived latency in rts — the first query of every session feels slow. The fix lives in a small region of the daemon (the post-mount initial-walk branch); the surrounding infrastructure (per-workspace state_dir, blake3 workspace fingerprint, redb META table, SCHEMA_VERSION rebuild path) is already in place and correct.
+
+The reframed plan also closes the SpecFlow-surfaced operational gap: today, "the daemon mounted instantly" and "the daemon did a full cold walk" are indistinguishable from outside. The new `mount_source` field makes the cache effectiveness observable.
+
+## Proposed Solution
+
+The implementation has **four shipping surfaces**, each small and reviewable:
+
+### 1. Per-part fingerprint in `META`
+
+Extend the existing META table (`crates/rts-daemon/src/store/schema.rs:13-130`) with five new keys:
+
+```rust
+META::META_DAEMON_BINARY_VERSION     -> str   // e.g., "0.6.0+sha:abc1234"
+META::META_GRAMMAR_VERSIONS          -> str   // JSON: {"rust":"0.23.1","python":"0.23.0",...}
+META::META_GITIGNORE_CONTENT_HASH    -> str   // blake3(effective_gitignore_bytes)[:16]
+META::META_FINGERPRINT_COMBINED      -> str   // blake3(all parts)[:16]
+META::META_RECONCILIATION_IN_PROGRESS -> bool // sentinel for kill-during-reconciliation
+```
+
+The combined hash is the fast-path check. The per-part columns let `mount_source` carry diagnostic-quality invalidation reasons.
+
+### 2. Conditional cold-walk skip
+
+At `crates/rts-daemon/src/methods/workspace.rs:145-213`, where `InitialWalkHandle::spawn` is unconditionally called, add a pre-check:
+
+```rust
+let mount_source = match (
+    fingerprints_match(&store, &current_fingerprint)?,
+    store.files_count()? > 0,
+    store.reconciliation_was_in_progress()?,
+) {
+    (true, true, false) => MountSource::Rehydrate,
+    (false, true, _)    => MountSource::ColdWalkAfterInvalidation(reason),
+    (_, _, true)        => MountSource::ColdWalkAfterCrash,  // killed mid-reconciliation
+    (_, false, _)       => MountSource::ColdWalk,            // first mount or empty redb
+};
+
+match mount_source {
+    MountSource::Rehydrate => {
+        spawn_mtime_reconciliation(...);  // new path
+        // skip InitialWalkHandle::spawn
+    }
+    _ => {
+        store.wipe_data_tables()?;  // preserve META across wipe
+        InitialWalkHandle::spawn(...);  // existing path
+    }
+}
+state.set_mount_source(mount_source);
+```
+
+`store.wipe_data_tables()` is a new method that clears all data tables but preserves META so we can write the *new* fingerprint after cold-walk completion.
+
+### 3. mtime/size reconciliation worker
+
+A new `crates/rts-daemon/src/reconciliation.rs` module. On Rehydrate, before the watcher starts processing live events:
+
+1. Set `META_RECONCILIATION_IN_PROGRESS = true` (atomic in a redb txn).
+2. Walk the workspace via the existing `ignore::WalkBuilder` (matches the cold-walk semantics at `watcher.rs:299-307`).
+3. For each file encountered:
+   - If in FILES with matching (mtime, size): no-op
+   - If in FILES with differing (mtime, size): emit a synthetic `WatchEvent::FileChanged` to the existing writer pipeline
+   - If not in FILES: emit `WatchEvent::FileAdded`
+4. For each file in FILES not seen during the walk: emit `WatchEvent::FileDeleted`
+5. After all events drain through the writer, write the *new* fingerprint to META and clear `META_RECONCILIATION_IN_PROGRESS`.
+
+The watcher runs in parallel from step 2 onward (matching the cold-walk-today behavior where the watcher runs alongside the initial walk).
+
+mtime+size is the v1 invariant. **Known limitation:** patterns that preserve mtime (`git checkout`, `cp -p`, `sed -i` on some platforms, `touch -r`) can leave the rehydrate path with a stale index for affected files. A `RTS_REHYDRATE_PARANOID=1` env var enables content-hash verification (compute blake3 on (mtime, size) match; mismatch → re-parse) — added in v1 as opt-in; default-off for cost.
+
+### 4. `Daemon.Stats v2` `mount_source` field + cache counters
+
+Extends PR 001's `daemon_stats_v2` capability:
+
+```jsonc
+{
+  // From PR 001:
+  "pinned_workspace_path": str,
+  "workspace_id": str,
+  "index_generation": u64,
+  "cold_walk_completed_at_ms": u64 | null,
+  // Added by PR 003:
+  "mount_source": "cold_walk" | "rehydrate" | "cold_walk_after_invalidation:<reason>" | "cold_walk_after_crash",
+  "rehydrate_attempts_total": u64,
+  "rehydrate_successes_total": u64,
+  "rehydrate_invalidations_by_reason": { "<reason>": u64, ... }
+}
+```
+
+PR 003 ships after PR 001 and PR 002 (the doctor and grep v2 plans). All three share the `daemon_stats_v2` capability.
+
+## Technical Approach
+
+### Module layout
+
+```
+crates/rts-daemon/build.rs                  // NEW: emit GRAMMAR_VERSIONS from Cargo.toml
+crates/rts-daemon/src/fingerprint.rs        // NEW: composite fingerprint computation
+crates/rts-daemon/src/reconciliation.rs     // NEW: mtime/size reconciliation worker
+crates/rts-daemon/src/store/schema.rs       // extend META with 5 new keys
+crates/rts-daemon/src/store/mod.rs          // wipe_data_tables(); preserve META
+crates/rts-daemon/src/methods/workspace.rs  // gate InitialWalkHandle::spawn on fingerprint
+crates/rts-daemon/src/methods/daemon.rs     // extend Daemon.Stats with mount_source + counters
+crates/rts-daemon/src/state.rs              // CacheCounters; MountSource on DaemonState
+crates/rts-daemon/src/gitignore_hash.rs     // NEW: effective-gitignore content hasher
+docs/protocol-v0.md                         // §5.4 (state dir alignment), §15.1 (rehydrate path), capability v2 entry
+```
+
+### Grammar version exposure (build.rs)
+
+Tree-sitter grammars are pinned in `crates/rts-core/Cargo.toml:18-31`. None expose a runtime version constant today. The plan adds `crates/rts-daemon/build.rs`:
+
+```rust
+fn main() {
+    let core_cargo_toml = std::fs::read_to_string("../rts-core/Cargo.toml").unwrap();
+    let parsed: toml::Value = toml::from_str(&core_cargo_toml).unwrap();
+    // Extract every tree-sitter-* dependency version
+    let mut versions: Vec<(String, String)> = vec![];
+    for (name, dep) in parsed["dependencies"].as_table().unwrap() {
+        if name.starts_with("tree-sitter-") {
+            let v = dep.as_str().or_else(|| dep.get("version")?.as_str()).unwrap();
+            versions.push((name.clone(), v.to_string()));
+        }
+    }
+    versions.sort();
+    let map_lit = serde_json::to_string(&versions).unwrap();
+    println!("cargo:rustc-env=RTS_GRAMMAR_VERSIONS={}", map_lit);
+}
+```
+
+Accessed at runtime via `env!("RTS_GRAMMAR_VERSIONS")`. Tied to the build; changes whenever a grammar version bump is committed. The Cargo-toml-derived version was chosen over `tree_sitter::Language::version()` (the C ABI number, coarser-grained and rarely changes — would miss most relevant grammar updates).
+
+### gitignore content hasher
+
+A new `gitignore_hash.rs` module assembles the effective-gitignore byte stream in this fixed order (matching the walker's precedence per `watcher.rs:299-307`):
+
+```
+workspace/.gitignore (if present)
+workspace/.git/info/exclude (if present)
+workspace/.rtsignore (if present)
+each ancestor/.gitignore from workspace upward to /, in walked order
+~/.config/git/ignore OR ${XDG_CONFIG_HOME}/git/ignore (if present)
+hardcoded fallbacks compiled into the binary (target/, node_modules/, .git/, .hg/, .svn/, build/, dist/, .next/, .cache/)
+```
+
+Each segment is prefixed with a length-tagged header (`u32 len, ASCII name, content`) to avoid ambiguity. Hash: `blake3` (already a workspace dep), truncated to 16 hex.
+
+Semantic normalization (whitespace, comment stripping) is **out of scope for v1** — byte-equal content only. Documented limitation.
+
+### `wipe_data_tables` helper
+
+`crates/rts-daemon/src/store/mod.rs` already has `Store::open` that wipes the file via `std::fs::remove_file` on schema mismatch (`store/mod.rs:174-189`). The plan replaces this with a finer-grained `wipe_data_tables(&mut self) -> Result<()>` that:
+
+1. Opens a redb write txn
+2. Calls `txn.delete_table(...)` for each data table (FILES, PATH_TO_FID, FID_TO_PATH, NAME_TO_SID, SID_TO_NAME, DEFS, FID_DEFS, REFS, FID_REFS, SID_REFS_OUT, SID_DOCS, UNRESOLVED_REFS, FID_UNRESOLVED)
+3. Preserves META and re-creates the data tables empty
+4. Commits with `Durability::Immediate`
+
+This way the schema-mismatch / fingerprint-mismatch path keeps the META table (where the *new* fingerprint will be written after cold-walk completion).
+
+For backward compatibility, the old `remove_file` path is retained for the SCHEMA_VERSION_NEWER case (refuse to open).
+
+### `DaemonState` additions
+
+```rust
+// crates/rts-daemon/src/state.rs (existing struct extended)
+pub struct DaemonState {
+    // ... existing fields ...
+    mount_source: AtomicCell<MountSource>,           // updated once per Workspace.Mount
+    cache_counters: CacheCounters,                   // process-lifetime cumulative
+}
+
+pub struct CacheCounters {
+    rehydrate_attempts: AtomicU64,
+    rehydrate_successes: AtomicU64,
+    rehydrate_invalidations: Mutex<HashMap<String, u64>>,  // by reason
+}
+
+pub enum MountSource {
+    ColdWalk,
+    Rehydrate,
+    ColdWalkAfterInvalidation(InvalidationReason),
+    ColdWalkAfterCrash,
+}
+
+pub enum InvalidationReason {
+    SchemaVersion { old: u32, new: u32 },
+    DaemonBinaryVersion { old: String, new: String },
+    GrammarVersion { language: String, old: String, new: String },
+    Gitignore,
+    EmptyOrMissingFingerprint,
+}
+
+impl InvalidationReason {
+    pub fn as_label(&self) -> String {
+        // Renders as "cold_walk_after_invalidation:grammar:rust:0.23→0.24" etc.
+    }
+}
+```
+
+### Reconciliation in progress marker
+
+The `META_RECONCILIATION_IN_PROGRESS = true` sentinel is written *before* the first synthetic `WatchEvent::*` reaches the writer; cleared *after* the last event drains AND the new fingerprint is written. If a daemon crashes mid-reconciliation, the next mount sees the sentinel and downgrades to `ColdWalkAfterCrash` (wipes data tables, runs full cold walk, but reports the diagnostic value).
+
+### Coordination with PR 001 and PR 002
+
+All three plans modify `crates/rts-daemon/src/methods/daemon.rs:140-151` (Daemon.Stats response) and `:18-87` (capability list). The plan sequences as:
+
+- **PR 001 (doctor)** lands first: adds `pinned_workspace_path`, `workspace_id`, `index_generation`, `cold_walk_completed_at_ms`. Capability `daemon_stats_v2`.
+- **PR 002 (grep v2)** rebases on PR 001: adds three sub-counters (`index_grep_multiline`, `index_grep_structural`, `index_grep_within_symbol`) to `CallCounters`. No new top-level Stats fields. New capabilities `index_grep_{multiline,structural,within_symbol}` and bundle `index_grep_v2`.
+- **PR 003 (this plan)** rebases on PR 002: adds `mount_source`, `rehydrate_attempts_total`, `rehydrate_successes_total`, `rehydrate_invalidations_by_reason` to Daemon.Stats. Reuses `daemon_stats_v2` capability (no new capability string needed — `mount_source` joins the v2 surface).
+
+### System-Wide Impact
+
+- **Interaction graph.** `Workspace.Mount` opens redb (existing) → computes current fingerprint → reads META fingerprint → decides path (rehydrate vs cold-walk-after-X) → either spawns reconciliation worker or `InitialWalkHandle::spawn` → watcher starts → writer drains events. The decision happens *once* per mount.
+- **Error propagation.** Fingerprint computation failures (build.rs didn't run; gitignore unreadable) → fall back to cold-walk path with `ColdWalkAfterInvalidation(...)` and log at `warn`. Never fail Mount; always degrade.
+- **State lifecycle.** META gains 5 new keys (additive — old daemons see unknown keys harmlessly via redb's table-aware open). `META_RECONCILIATION_IN_PROGRESS` is the only sentinel; cleared on success, observed on crash recovery.
+- **API surface parity.** `Daemon.Stats` grows fields under existing `daemon_stats_v2`. Capability list unchanged.
+- **Integration test scenarios.**
+  - First-ever mount on a workspace: `mount_source = "cold_walk"`.
+  - Second mount, no changes: `mount_source = "rehydrate"`; total mount-to-first-query latency under 100 ms p95 on 100k LOC.
+  - `SCHEMA_VERSION` bumped between sessions: `mount_source = "cold_walk_after_invalidation:schema:3→4"`.
+  - Daemon binary version bumped: `mount_source = "cold_walk_after_invalidation:binary:0.6.0→0.6.1"`.
+  - Grammar version bumped (single language): `mount_source = "cold_walk_after_invalidation:grammar:rust:0.23→0.24"`.
+  - Workspace `.gitignore` edited: `mount_source = "cold_walk_after_invalidation:gitignore"`.
+  - Daemon killed mid-cold-walk: next mount sees non-empty FILES with no fingerprint → `cold_walk_after_invalidation:empty_or_missing_fingerprint`. Wipes and re-walks.
+  - Daemon killed mid-reconciliation: next mount sees `META_RECONCILIATION_IN_PROGRESS` → `cold_walk_after_crash`. Wipes and re-walks.
+  - File edited between sessions (mtime changes): reconciliation re-parses that file only.
+  - File created between sessions: reconciliation indexes it.
+  - File deleted between sessions: reconciliation drops it.
+  - File edited via `git checkout` (mtime restored): rehydrate misses it (documented limitation); `RTS_REHYDRATE_PARANOID=1` catches it via content-hash.
+  - Workspace moved (`mv ~/src/foo ~/src/bar`): inode/path change → new `workspace_id` → new state_dir → first-ever mount path on the new dir.
+
+## Implementation Units
+
+Ordered by dependency. U1 depends on PR 001 + PR 002 being landed.
+
+### U1 — Grammar version exposure (build.rs)
+
+- **Goal.** `RTS_GRAMMAR_VERSIONS` env var available at runtime via `env!`, sorted-by-name JSON of `{"tree-sitter-LANG": "version"}` pairs.
+- **Files.** `crates/rts-daemon/build.rs` (new); `crates/rts-daemon/src/fingerprint.rs` (new — exposes `pub fn grammar_versions() -> &'static [(String, String)]`).
+- **Approach.** build.rs parses `../rts-core/Cargo.toml`, extracts all `tree-sitter-*` deps, emits sorted JSON via `cargo:rustc-env`. Runtime accessor returns parsed pairs.
+- **Patterns to follow.** Common Rust `build.rs` pattern; `cargo:rerun-if-changed=../rts-core/Cargo.toml` to invalidate the build cache on grammar bumps.
+- **Execution note.** Pragmatic. No tests beyond a smoke check that the env var has expected entries.
+- **Test scenarios.**
+  - Grammar version count matches `crates/rts-core/Cargo.toml` count (12).
+  - Build is rerun when `rts-core/Cargo.toml` changes.
+- **Verification.** `cargo build -p rts-daemon` succeeds; `cargo test -p rts-daemon fingerprint::grammar_versions` green.
+
+### U2 — gitignore content hasher
+
+- **Goal.** `pub fn effective_gitignore_hash(workspace_root: &Path) -> Result<String>` returns blake3-of-bytes(:16) for the effective gitignore content stack.
+- **Files.** `crates/rts-daemon/src/gitignore_hash.rs` (new); coordinates with `crates/rts-daemon/src/filter.rs:170-245`.
+- **Approach.** Read in fixed order: workspace `.gitignore`, `.git/info/exclude`, `.rtsignore`, ancestor `.gitignore`s upward, global `~/.config/git/ignore` (or `${XDG_CONFIG_HOME}/git/ignore`), then a stable byte representation of the hardcoded fallbacks. Length-prefix each segment with `(u32_len, ASCII_name)` for unambiguous concatenation. Hash with `blake3::hash`.
+- **Patterns to follow.** Existing `crates/rts-daemon/src/filter.rs:170-245` (`PrebuiltGitignore::build`) — same source paths, same precedence; this code just hashes them instead of compiling them into a matcher.
+- **Execution note.** Test-first: identical content in different file orderings → same hash; bytes-different content → different hash.
+- **Test scenarios.**
+  - No gitignore files exist: hash == blake3 of empty stack + fallbacks. Stable across runs.
+  - Workspace `.gitignore` edited by one byte: hash changes.
+  - Ancestor `.gitignore` added: hash changes.
+  - `XDG_CONFIG_HOME` set vs unset on Linux: doesn't change hash if file content is identical.
+- **Verification.** `cargo test -p rts-daemon gitignore_hash` green.
+
+### U3 — META schema extension + composite fingerprint
+
+- **Goal.** META table gains 5 new keys (4 fingerprint parts + 1 reconciliation sentinel). `Fingerprint::current()` and `Fingerprint::stored(&store)` produce comparable values.
+- **Files.** `crates/rts-daemon/src/store/schema.rs` (new META keys); `crates/rts-daemon/src/store/mod.rs` (read/write helpers); `crates/rts-daemon/src/fingerprint.rs` (`Fingerprint` struct + `compare` + `diff` for diagnostic invalidation reason).
+- **Approach.** META is a single-bucket key-value redb table; add string-keyed entries. `Fingerprint { schema_version, binary_version, grammar_versions, gitignore_hash, combined: String }`. `Fingerprint::diff(stored, current) -> InvalidationReason` returns the first-mismatching part for diagnostics.
+- **Patterns to follow.** `crates/rts-daemon/src/store/mod.rs:135-227` (existing `Store::open` + META reads for `SCHEMA_VERSION`); `store/schema.rs:13-130` (existing META layout).
+- **Execution note.** Test-first: every diff path yields the expected `InvalidationReason::*`.
+- **Test scenarios.**
+  - Identical fingerprints: `combined` matches; `diff` returns `None`.
+  - Schema bump: `diff` returns `SchemaVersion { old, new }`.
+  - Binary version bump: `diff` returns `DaemonBinaryVersion { old, new }`.
+  - Grammar bump for one language: `diff` returns `GrammarVersion { language, old, new }`.
+  - Gitignore hash changes: `diff` returns `Gitignore`.
+  - Missing fingerprint (older redb): `diff` returns `EmptyOrMissingFingerprint`.
+- **Verification.** `cargo test -p rts-daemon fingerprint::diff` green; META keys appear in a round-trip test.
+
+### U4 — `wipe_data_tables` (preserve META)
+
+- **Goal.** `Store::wipe_data_tables(&mut self) -> Result<()>` clears all data tables (FILES, PATH_TO_FID, FID_TO_PATH, NAME_TO_SID, SID_TO_NAME, DEFS, FID_DEFS, REFS, FID_REFS, SID_REFS_OUT, SID_DOCS, UNRESOLVED_REFS, FID_UNRESOLVED) while preserving META.
+- **Files.** `crates/rts-daemon/src/store/mod.rs` (new method; existing `remove_file` path on SCHEMA_VERSION_NEWER stays).
+- **Approach.** Single redb write txn that opens each data table and removes all entries (or `delete_table` then recreate empty). `Durability::Immediate` commit.
+- **Patterns to follow.** Existing `store/mod.rs:174-189` (file-level wipe) — the model; this version is table-level.
+- **Execution note.** Test-first: confirm META survives wipe; confirm data tables are empty.
+- **Test scenarios.**
+  - Populated store → `wipe_data_tables` → META intact, FILES count == 0.
+  - Schema-newer case still uses file-level wipe (refuses to open).
+- **Verification.** `cargo test -p rts-daemon store::wipe_data_tables` green.
+
+### U5 — Mount-time decision + reconciliation worker
+
+- **Goal.** At `Workspace.Mount`, decide `MountSource` based on fingerprint comparison and FILES count, then route to reconciliation or cold-walk.
+- **Files.** `crates/rts-daemon/src/methods/workspace.rs:145-213` (the decision branch); `crates/rts-daemon/src/reconciliation.rs` (new — the reconciliation worker).
+- **Approach.** Pre-mount: compute current fingerprint. Open store. Read stored fingerprint. Compare. If match + FILES non-empty + `!RECONCILIATION_IN_PROGRESS`: set `META_RECONCILIATION_IN_PROGRESS = true`, spawn reconciliation worker (parallel to watcher start), record `MountSource::Rehydrate`. Else: `wipe_data_tables()`, set `MountSource::ColdWalk*` with reason, call `InitialWalkHandle::spawn` as today.
+  
+  Reconciliation worker walks `ignore::WalkBuilder` (matches the cold-walk semantics at `watcher.rs:299-307`), stats each file, compares to FILES table entries, emits synthetic `WatchEvent::FileChanged/FileAdded/FileDeleted` events to the writer pipeline. On completion: writes the new fingerprint to META, clears `META_RECONCILIATION_IN_PROGRESS`.
+
+  `RTS_REHYDRATE_PARANOID=1` env var: on (mtime, size) match, also computes blake3 of file content; if differs from a stored content hash (added to FILES table — additive column), emit `FileChanged`. Off by default.
+- **Patterns to follow.** `crates/rts-daemon/src/methods/workspace.rs:115-213` (existing mount path); `crates/rts-daemon/src/watcher.rs:267-364` (existing walker); `crates/rts-daemon/src/writer.rs:151-172` (existing batch flush after walk).
+- **Execution note.** Test-first for each `MountSource` variant — see test scenarios below.
+- **Test scenarios.**
+  - First mount on empty state_dir: `ColdWalk`.
+  - Second mount, no changes: `Rehydrate`. Latency under 100 ms p95 on 100k LOC.
+  - Mount after `SCHEMA_VERSION` bump: `ColdWalkAfterInvalidation(SchemaVersion{...})`.
+  - Mount after grammar version bump: `ColdWalkAfterInvalidation(GrammarVersion{...})`.
+  - Mount after gitignore edit: `ColdWalkAfterInvalidation(Gitignore)`.
+  - Mount after binary version bump: `ColdWalkAfterInvalidation(DaemonBinaryVersion{...})`.
+  - Mount after kill-during-reconciliation (META has sentinel): `ColdWalkAfterCrash`.
+  - Mount after `rm -rf state_dir`: `ColdWalk` (treated as first-ever).
+  - Reconciliation re-parses only changed files (assertable via reconciliation worker emit log).
+  - `RTS_REHYDRATE_PARANOID=1` + file with same (mtime, size) but different content: re-parsed.
+- **Verification.** `cargo test -p rts-daemon methods::workspace::mount_source` green; manual bench on 100k LOC repo confirms latency target.
+
+### U6 — `mount_source` + cache counters in `Daemon.Stats v2`
+
+- **Goal.** `Daemon.Stats` response includes `mount_source` (current value), `rehydrate_attempts_total`, `rehydrate_successes_total`, `rehydrate_invalidations_by_reason`.
+- **Files.** `crates/rts-daemon/src/methods/daemon.rs:140-151` (extend response struct); `crates/rts-daemon/src/state.rs` (extend `DaemonState` with `mount_source: AtomicCell<MountSource>` and `cache_counters: CacheCounters`); `crates/rts-daemon/src/state.rs` (extend `CallCounters::snapshot()` to merge cache_counters).
+- **Approach.** Additive fields under existing `daemon_stats_v2` capability (no new capability string). Counters increment per Mount call.
+- **Patterns to follow.** PR 001's pattern of additive `daemon_stats_v2` fields; existing `CallCounters` AtomicU64 pattern.
+- **Execution note.** Test-first: round-trip test exercises every `mount_source` value.
+- **Test scenarios.**
+  - First call to `Daemon.Stats` after daemon spawn but before any mount: `mount_source` is absent or `null` (no mount yet).
+  - After first mount: `mount_source = "cold_walk"`.
+  - After rehydrate: `mount_source = "rehydrate"`; counters incremented.
+  - After invalidation: `mount_source = "cold_walk_after_invalidation:<reason>"`.
+- **Verification.** `cargo test -p rts-daemon methods::daemon::stats_v2_mount_source` green.
+
+### U7 — Documentation + bench fixture
+
+- **Goal.** `docs/protocol-v0.md` §5.4 (state dir) reaffirms the path convention; new appendix entry documents the rehydrate path; capability v2 entry lists the new fields. README's *Status* section gains the latency claim. A new bench fixture under `crates/rts-bench/benches/cold_mount.rs` measures rehydrate p95.
+- **Files.** `docs/protocol-v0.md`; `README.md`; `crates/rts-bench/benches/cold_mount.rs` (new); `changelog.d/<NNNN>-persisted-cold-mount.md`.
+- **Approach.** Pure docs + a small bench. README gets one new sentence under *Status*: *"Daemon startup: ~6 s cold-walk on first session, <100 ms thereafter (persisted snapshot via redb META fingerprint, v0.6+)."*
+- **Patterns to follow.** Appendix F per-alpha additive log entries; existing `bench-results/` JSON outputs.
+- **Verification.** Bench produces a JSON output that demonstrates the p95 target; docs lint clean.
+
+## Requirements Trace
+
+| ID  | Requirement (from origin) | Satisfied by | Notes |
+|-----|---------------------------|--------------|-------|
+| R1  | Persist post-cold-walk redb to XDG cache | U5 | **Path reframed:** reuse existing `state_dir_for` (XDG_STATE_HOME, not _CACHE_), per protocol-v0 §5.4. Redb is already there. |
+| R2  | On startup: open snapshot, verify fingerprint, decide path | U5 | Decision logic at mount-time, before `InitialWalkHandle::spawn` |
+| R3  | Composite fingerprint over (schema, binary, grammars, gitignore) | U1, U2, U3 | **Per-part columns** in META (not single hash) — enables diagnostic invalidation reasons |
+| R4  | Rehydrate path: re-parse only changed files | U5 | mtime/size reconciliation worker |
+| R5  | Snapshot writes at cold-walk-done + graceful shutdown | U5 | **Reframed:** the *data* is written continuously by redb; only the *fingerprint* is the snapshot atom |
+| R6  | Atomic writes; per-table checksum | U5 | **Reframed:** redb already provides ACID + page checksums. No separate atomic-write needed; the brainstorm's claim is redundant. |
+| R7  | Snapshot header + checksum-verify on load | U3 | **Reframed:** the META fingerprint *is* the header; redb already validates page checksums |
+| R8  | File permissions 0600 + dir 0700 | (already enforced) | Existing daemon `umask(0077)`; no new code |
+| R9  | First-query latency <100 ms p95 on healthy rehydrate | U5, U7 | Bench fixture in U7 |
+| R10 | `mount_source` field in `Daemon.Stats` | U6 | Joins PR 001's `daemon_stats_v2` capability |
+| R11 | `--reset-snapshot` flag clears the cache | U5 | Clears state_dir before mount; existing daemon flag scaffold |
+
+## Acceptance Criteria
+
+### Functional
+
+- [ ] **AC1.** First mount on a fresh workspace produces `mount_source = "cold_walk"` and a populated META fingerprint.
+- [ ] **AC2.** Restart the daemon without changes: second mount produces `mount_source = "rehydrate"` and skips `InitialWalkHandle::spawn`.
+- [ ] **AC3.** Bump `SCHEMA_VERSION` constant between daemon binaries: next mount produces `cold_walk_after_invalidation:schema:N→M`.
+- [ ] **AC4.** Bump a single tree-sitter grammar version: next mount produces `cold_walk_after_invalidation:grammar:<lang>:<old>→<new>`.
+- [ ] **AC5.** Edit workspace `.gitignore`: next mount produces `cold_walk_after_invalidation:gitignore`.
+- [ ] **AC6.** Bump daemon binary version (via build): next mount produces `cold_walk_after_invalidation:binary:<old>→<new>`.
+- [ ] **AC7.** Kill daemon during reconciliation (signal between sentinel-set and fingerprint-write): next mount produces `cold_walk_after_crash` and re-walks.
+- [ ] **AC8.** Kill daemon during cold-walk (no fingerprint ever written): next mount produces `cold_walk_after_invalidation:empty_or_missing_fingerprint`.
+- [ ] **AC9.** Edit one file (changes mtime) between mounts: reconciliation re-parses only that file; `index_generation` increments by 1.
+- [ ] **AC10.** Create a new file between mounts: reconciliation indexes it.
+- [ ] **AC11.** Delete a file between mounts: reconciliation drops it from FILES.
+- [ ] **AC12.** `RTS_REHYDRATE_PARANOID=1` with `git checkout` (mtime restored but content changed): re-parses the affected file. Without the flag: misses it (documented limitation).
+- [ ] **AC13.** `rm -rf state_dir/<workspace_id>/` between mounts: next mount produces `cold_walk` (treated as first-ever).
+- [ ] **AC14.** Move the workspace (`mv ~/src/foo ~/src/bar`): the new path produces a new `workspace_id` and a fresh `cold_walk` mount. Old state_dir orphaned (GC out of scope).
+- [ ] **AC15.** `Daemon.Stats` includes `mount_source`, `rehydrate_attempts_total`, `rehydrate_successes_total`, `rehydrate_invalidations_by_reason`. All under `daemon_stats_v2` capability.
+- [ ] **AC16.** All redb tables (including UNRESOLVED_REFS / FID_UNRESOLVED introduced in #103) survive rehydrate. Live-edit ref correctness from #103 is preserved.
+
+### Non-Functional
+
+- [ ] **AC17.** Healthy rehydrate p95 latency `<100 ms` on a 100k LOC workspace where no files changed (bench fixture in U7).
+- [ ] **AC18.** Cold-walk latency unchanged ±5% vs pre-PR baseline (no regression on the cold-walk path).
+- [ ] **AC19.** No new crate deps beyond `toml` (build.rs only, build-dep).
+- [ ] **AC20.** Reconciliation worker memory footprint scales linearly with FILES count, not workspace size; bounded buffer for per-file events.
+
+### Quality Gates
+
+- [ ] **AC21.** `cargo test --workspace` green; all `MountSource` variants covered.
+- [ ] **AC22.** `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- [ ] **AC23.** `docs/protocol-v0.md` §5.4 updated; rehydrate path documented in §15 appendix; capability v2 entry lists `mount_source` + counters.
+- [ ] **AC24.** `changelog.d/<NNNN>-persisted-cold-mount.md` fragment lands.
+- [ ] **AC25.** README *Status* line gains the latency claim.
+
+## Success Metrics
+
+- **First-week:** README's Status line lands; one closed issue references the new latency in a "feels instant now" note.
+- **Cache hit rate:** `rehydrate_successes / rehydrate_attempts >= 0.95` on the author's dev workspace across 100 daemon spawns over 14 days.
+- **Latency:** rehydrate p95 <100 ms on 100k LOC; cold-walk latency unchanged.
+- **agent-bench:** wall-clock per-task latency for tasks 2-N in a shared-workspace sequence drops measurably vs Phase 2 PR-A baseline; visible in `bench-results/` JSON.
+
+## Dependencies & Risks
+
+- **PR 001 (doctor) must land first.** This plan extends `daemon_stats_v2` capability with `mount_source` + cache counters. Without PR 001, the capability doesn't exist. Hard dependency.
+- **PR 002 (grep v2) lands second.** Both PR 002 and PR 003 touch `CallCounters`/Daemon.Stats but in non-overlapping ways. Sequence: 001 → 002 → 003. Rebase strictly.
+- **build.rs dependency.** `crates/rts-daemon/build.rs` adds a build-time `toml` parse. If `crates/rts-core/Cargo.toml` is malformed, the daemon won't build. Low risk; one-line catch-up if it ever breaks.
+- **mtime+size is not content-equivalent.** Documented limitation. `RTS_REHYDRATE_PARANOID=1` is the escape valve. If support requests demand it, promote to default in a follow-up PR.
+- **gitignore content hash is byte-equal only.** A whitespace-only edit of `.gitignore` invalidates the snapshot. Pragmatic compromise for v1; semantic normalization is a possible v2.
+- **State_dir GC is out of scope.** Workspaces that move or are deleted leak their state_dir. Disk growth is bounded by the count of distinct workspaces the user has indexed; a future `rts-bench doctor --gc-orphaned-state` or similar can address.
+- **Atomic-write inside redb.** redb's ACID semantics cover all the META writes. No separate tmpfile+rename for the fingerprint metadata. The brainstorm's R6 is redundant; the plan documents this rather than implementing redundant safety.
+- **macOS path alignment.** Existing daemon uses `~/Library/Caches/rts/<id>/db.redb` (per `workspace.rs:249-266`). Plan does NOT move this; alignment with brainstorm's `~/.cache/rts/<hash>/` was wrong. Protocol-v0 §5.4 is authoritative.
+
+## Scope Boundaries
+
+The following are explicit non-goals for this PR:
+
+- **No relocation of the redb file.** Reuse existing `state_dir_for`. Brainstorm R1 wording corrected.
+- **No real-time mirroring** of redb edits beyond what redb already does (ACID transactions). Already rejected in brainstorm as challenger.
+- **No in-tree cache** (`<workspace>/.rts-cache/`). Already rejected.
+- **No multi-machine snapshot sharing.** Workspace-id is per-machine (dev/inode).
+- **No state_dir garbage collection.** Disk growth is documented as a known issue.
+- **No semantic gitignore normalization.** Byte-equal content only.
+- **No content-hash by default.** Opt-in via `RTS_REHYDRATE_PARANOID=1`.
+- **No grammar hot-reload.** Tree-sitter grammars are statically linked.
+- **No `Daemon.Reset` RPC.** `--reset-snapshot` CLI flag is the only knob (per R11).
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-18-persisted-cold-mount-requirements.md](../brainstorms/2026-05-18-persisted-cold-mount-requirements.md). Carried-forward decisions (with research-driven corrections):
+  1. Full redb snapshot, mtime-rehydrate — Key Decisions §1 (redb already persisted; plan adds fingerprint gate)
+  2. XDG cache dir keyed by workspace hash — Key Decisions §2 (**corrected:** reuse `state_dir_for`; XDG_STATE_HOME not _CACHE_)
+  3. Single composite fingerprint — Key Decisions §3 (**corrected:** per-part columns + combined hash for diagnostics)
+  4. Write at cold-walk-done + graceful shutdown; checksum-verify on load — Key Decisions §4 (**corrected:** only the fingerprint is the snapshot atom; redb data writes are continuous and ACID)
+- **Research consolidations:**
+  - `crates/rts-daemon/src/store/mod.rs:42` — `SCHEMA_VERSION = 3` (the prior META key)
+  - `crates/rts-daemon/src/store/mod.rs:135-227` — `Store::open` schema check + rebuild path
+  - `crates/rts-daemon/src/store/schema.rs:13-130` — all redb tables (META has the single SCHEMA_VERSION key today)
+  - `crates/rts-daemon/src/methods/workspace.rs:117-137` — state_dir mount path
+  - `crates/rts-daemon/src/methods/workspace.rs:145-213` — **the decision site** (where `InitialWalkHandle::spawn` fires unconditionally today)
+  - `crates/rts-daemon/src/workspace.rs:22-148` — `WorkspaceFingerprint` (blake3 over dev/inode/path)
+  - `crates/rts-daemon/src/workspace.rs:239-266` — `state_dir_for` / `state_home_root`
+  - `crates/rts-daemon/src/watcher.rs:88-99` — `WatchEvent::ColdWalkComplete`
+  - `crates/rts-daemon/src/watcher.rs:267-364` — initial walk
+  - `crates/rts-daemon/src/writer.rs:102-114` — writer cancellation flush
+  - `crates/rts-daemon/src/writer.rs:151-172` — cold-walk-complete consumer
+  - `crates/rts-daemon/src/filter.rs:170-245` — `PrebuiltGitignore::build` (gitignore source paths and precedence)
+  - `crates/rts-core/Cargo.toml:18-31` — 12 tree-sitter grammar pins (the source for build.rs)
+  - `crates/rts-daemon/Cargo.toml:40-80` — existing deps (`blake3`, `dirs = "5"`, `redb = "2"`, `tempfile = "3"`)
+  - `docs/protocol-v0.md` §5.4 — canonical state path (XDG_STATE_HOME / Library/Caches)
+  - `docs/protocol-v0.md` §5.2 — workspace_id_hex definition
+  - `docs/protocol-v0.md` §15.1 — schema bump rebuild semantics (extended here for fingerprint)
+- **Related PRs / plans:**
+  - **PR 001** (`docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md`) — `daemon_stats_v2` capability (hard dependency).
+  - **PR 002** (`docs/plans/2026-05-18-002-feat-index-grep-v2-plan.md`) — `CallCounters` extensions (rebased before PR 003).
+  - #103 (UNRESOLVED_REFS / FID_UNRESOLVED tables — survive rehydrate per AC16)
+
+## Deferred to Implementation
+
+All 10 brainstorm-deferred questions resolved here:
+
+- **[Affects R1]** Cache path on macOS: aligned to existing `state_dir_for` (`~/Library/Caches/rts/<id>/`), NOT a new XDG_CACHE_HOME path. Protocol-v0 §5.4 is authoritative.
+- **[Affects R3]** Grammar version source: tree-sitter-LANG **crate** versions via build.rs injection. NOT runtime `Language::version()` (C ABI number, too coarse).
+- **[Affects R3]** gitignore content hashing: byte-equal content only; segments concatenated in walker-precedence order with length-prefix headers. Semantic normalization is v2.
+- **[Affects R7]** Snapshot header: META fingerprint columns + redb's own page checksums. No separate header file or sidecar manifest.
+- **[Affects R4]** Reconciliation walk strategy: top-down via existing `ignore::WalkBuilder` (matches cold-walk semantics). FILES table is iterated post-walk to find deleted entries.
+- **[Affects R5]** Atomic write on non-atomic FS: redb manages this internally. The plan does NOT add a separate tmpfile+rename for fingerprint; the META writes are inside redb txns.
+- **[Affects R9]** Rehydrate latency budget breakdown: redb open ~5ms, fingerprint read ~1ms, file-stat scan of 10k files ~50ms, incremental re-parse of changed files (variable). 100 ms p95 is the worst-case test budget.
+- **[Affects R5]** Snapshot-on-shutdown timing: bounded to 2s. If META write doesn't complete in 2s, daemon exit proceeds anyway; next mount sees inconsistent state and falls back to `cold_walk_after_invalidation:incomplete_fingerprint`.
+- **[Affects R3]** Daemon binary version: full semver string (`env!("CARGO_PKG_VERSION")`). Patch bumps invalidate; this is conservative but safe.
+- **[Affects R10]** doctor's `workspace_index` section consumes `mount_source` from `Daemon.Stats v2`. Per PR 001's plan U6, this is already on the doctor surface.
+
+## Post-Deploy Monitoring & Validation
+
+- **What to monitor/search**
+  - Logs: daemon `tracing` output at `info` for every Mount with the resolved `MountSource`. At `warn` for any fingerprint mismatch or reconciliation-in-progress on next startup.
+  - Metrics/Dashboards: `Daemon.Stats.mount_source` value, `rehydrate_successes / rehydrate_attempts` ratio over time, `rehydrate_invalidations_by_reason` distribution.
+- **Validation checks (queries/commands)**
+  - Manual: `rts-bench doctor` shows `mount_source` in the workspace_index section.
+  - Bench: `cargo bench -p rts-bench cold_mount` shows p95 <100ms on a healthy rehydrate.
+  - Round-trip: integration test exercises every `MountSource` variant.
+- **Expected healthy behavior**
+  - `rehydrate_successes / rehydrate_attempts >= 0.95` after the first week.
+  - p95 rehydrate latency <100ms on 100k LOC workspaces.
+  - No regression in cold-walk latency.
+- **Failure signal(s) / rollback trigger**
+  - Spike in `cold_walk_after_invalidation:*` rates → check whether a recent grammar bump or schema bump is responsible (expected) vs unexpected drift (regression).
+  - Spike in `cold_walk_after_crash` → daemon is being killed mid-reconciliation; investigate user-side `kill -9` patterns.
+  - Any panic in `reconciliation.rs` → revert. The redb file is untouched by the rehydrate-decide branch on the cold-walk path, so revert is safe.
+- **Validation window & owner**
+  - 14-day window post-merge; author monitors.
+
+---
+
+## Plan Status
+
+- **Detail level:** MORE (standard plan)
+- **SpecFlow:** complete; 12 edge cases and 4 ambiguities resolved
+- **Brainstorm corrections:** 5 (path, hash structure, snapshot atom, table preservation, atomic-write redundancy)
+- **Deepen:** not requested
+- **Coordination:** PR 001 → PR 002 → PR 003 sequencing required
+- **Next:** `/ce:work` on the three plans in order, starting with PR 001 (doctor).


### PR DESCRIPTION
## Summary

- Adds `rts-bench doctor`: a read-only first-run health check that inspects rts install state across all five supported agent hosts (Claude Code, Cursor, Continue, Aider, Cline) plus per-workspace index state. Prints OK/WARN/FAIL rows with copy-pasteable one-line fix snippets for every failing row. Documented exit-code contract (0/1/2 + reserved).
- Extends `Daemon.Stats` with v2 fields (`pinned_workspace_path`, `workspace_id`, `index_generation`, `cold_walk_completed_at_ms`) behind a new `daemon_stats_v2` capability. Pre-mount calls keep the v1 shape byte-for-byte; old clients are unaffected.
- Adds `docs/doctor-schema.md` (locked `doctor-v0` JSON schema, additive `capabilities[]` evolution), a "Verifying your install" section in `docs/install.md`, and a PR-level changelog fragment.

End-to-end smoke on this repo (binaries not on PATH, daemon not running):

```
$ rts-bench doctor --no-color
== binary ==
  [OK]   binary:doctor_version — rts-bench doctor v0.5.5
  [FAIL] binary:rts_daemon — rts-daemon not found on $PATH
    → curl -fsSL .../releases/latest/download/install.sh | sh
== daemon ==
  [WARN] daemon:not_running — daemon not running for this workspace
    → rts-daemon --workspace $PWD &
== mcp_registration ==
  [WARN] claude_code:multi_scope_drift — registers rts at multiple distinct binaries across scopes
  [OK]   claude_code:user_scope — rts registered (.../target/release/rts-mcp) via ~/.claude.json
  [FAIL] claude_code:project_scope — rts registered in .mcp.json but binary rts-mcp not found
    → claude mcp remove rts && claude mcp add rts -- $(which rts-mcp) --workspace "$PWD"
  [?]    cursor / continue / aider / cline — not detected (soft-detect or absent)
== hook ==
  [OK]   hook:current — hook installed and current (v0.5.5)
== workspace_index ==
  [WARN] workspace_index:no_daemon_stats — daemon unreachable
exit class: fail   (exit 1)
```

Plan + brainstorm + ideation are all in-tree:
- Plan: [`docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md`](https://github.com/njfio/rs-agent-code-utility/blob/feat/rts-bench-doctor/docs/plans/2026-05-18-001-feat-rts-bench-doctor-plan.md)
- Brainstorm: [`docs/brainstorms/2026-05-18-rts-doctor-requirements.md`](https://github.com/njfio/rs-agent-code-utility/blob/feat/rts-bench-doctor/docs/brainstorms/2026-05-18-rts-doctor-requirements.md)
- Ideation: [`docs/ideation/2026-05-17-what-else-after-phase-2-and-readme-ideation.md`](https://github.com/njfio/rs-agent-code-utility/blob/feat/rts-bench-doctor/docs/ideation/2026-05-17-what-else-after-phase-2-and-readme-ideation.md)
- Schema: [`docs/doctor-schema.md`](https://github.com/njfio/rs-agent-code-utility/blob/feat/rts-bench-doctor/docs/doctor-schema.md)

## What's in scope

**`Daemon.Stats v2`** (U1) — additive fields, new capability `daemon_stats_v2`, v1 shape preserved pre-mount.

**Doctor module** at `crates/rts-bench/src/doctor/` (~2.7k LOC), with one section per file plus a 5-host detector trait:

| Unit | Module | Tests | Notes |
|---|---|---|---|
| U2/U3 | `mod.rs`, `report.rs`, `ctx.rs`, `render.rs` | 8 | Scaffolding + types + panic-safe orchestrator + ANSI-gated renderer |
| U4 | `binary_section.rs` | 11 | `$PATH` walk, symlink resolution, cross-binary version drift |
| U5 | `daemon_section.rs` | 4 | Per-workspace socket probe + `Daemon.Stats v2` round-trip + pre-v2 fallback |
| U6 | `workspace_section.rs` | 7 | Pinned-path / cold-walk / index-gen reading from daemon stats |
| U7 | `mcp_section.rs` + `hosts/*.rs` | 23 | All 5 host detectors + Claude Code multi-scope drift |
| U8 | `nudge_hook.rs` + `.claude/hooks/rts-nudge.sh` (+1 line) | 10 | Hook presence/exec/version-marker check |
| U9 | clippy cleanup | — | Closes all 7 net-new clippy warnings |
| U10 | `docs/doctor-schema.md`, `docs/install.md`, `changelog.d/` | — | Schema + verifying-install section + changelog fragment |

**Total: 63 new doctor unit tests + 1 new `daemon_stats_v2_round_trip.rs` integration test.** Full workspace `cargo test --workspace` is green.

## What's NOT in scope (filed for follow-up)

- `--fix` mode (auto-apply recommended actions) — read-only in v1
- Behavioral telemetry (per-method call counts, nudge-fire log) — lives in `daemon-stats` (#104)
- Cross-version drift beyond the binary section — separate brainstorm
- Windows support — Unix sockets only
- `--section <name>` flag — all-or-nothing in v1
- README pitch update — deferred until #108 (README rewrite) merges to avoid conflict

## Known commit-history quirk

Two commits on this branch share a subject line due to a race between parallel sub-agents committing on the same worktree:

- `7d62180` says `feat(rts-bench): doctor binary section ...` but actually contains **U8's hook files** (`.claude/hooks/rts-nudge.sh` +1 line, `nudge_hook.rs` +419 lines)
- `81cbb8e` says the same subject and actually contains **U4's binary section** (the matching `binary_section.rs` +398 lines)

The diff content is correct in both commits; only the subject lines collided. PRs in this repo squash-merge by convention, so this doesn't survive into main. No fix-up rebase performed (skill rules discourage non-amend history rewrites).

## Testing

- [x] `cargo build --workspace` green
- [x] `cargo test --workspace` green — all suites pass
- [x] `cargo test -p rts-bench --bin rts-bench doctor` — 63 tests pass
- [x] `cargo test -p rts-daemon --test daemon_stats_v2_round_trip` — green, asserts v2 capability + fields populated post-mount
- [x] `cargo clippy -p rts-bench --bin rts-bench` — matches pre-existing main count (no new lints introduced)
- [x] `cargo fmt --all` — clean
- [x] End-to-end smoke: `./target/debug/rts-bench doctor` on this repo correctly identifies missing binaries (FAIL), missing daemon (WARN), Claude Code multi-scope drift (WARN), missing project-scope MCP binary (FAIL), current hook (OK), and exits 1
- [x] `--output json` validates against the `doctor-v0` schema
- [x] `--no-color` strips ANSI; `NO_COLOR=1` honored
- [x] Hook's `exit 0 ALWAYS` contract preserved after version-marker addition

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: doctor produces nothing persistent — stdout/stderr only
  - Metrics: GitHub issues filtered by `doctor` keyword in the next 30 days; agent-bench preflight pass rate (once the harness wires it up)
- **Validation checks (queries/commands)**
  - `rts-bench doctor` on a clean dev machine — exit class should be `fail` or `warn`, with each failure carrying a runnable fix snippet
  - `rts-bench doctor --output json | jq -e '.schema_version == "doctor-v0"'`
- **Expected healthy behavior**
  - Exit 0 on a freshly-installed working setup
  - <500 ms p95 latency on the rts repo
- **Failure signal(s) / rollback trigger**
  - Reports of doctor itself panicking (exit 2 spike). Rollback: revert the PR; no schema migrations to undo.
  - Reports of false-positive FAIL rows (e.g. Cursor detector hitting a layout we didn't handle). Triage as a row-text fix, not a revert.
- **Validation window & owner**
  - 14-day window post-merge; author monitors

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)