### PR TITLE
feat(rts-daemon): reconciliation worker for persisted cold-mount

### DIFF
--- a/changelog.d/xxx-feat-reconciliation-worker.md
+++ b/changelog.d/xxx-feat-reconciliation-worker.md
@@ -1,0 +1,103 @@
+### Reconciliation worker — catch on-disk drift after persisted cold-mount
+
+The persisted cold-mount path (#111) deferred reconciliation: when the
+daemon rehydrates from redb on restart, it trusts the on-disk index
+verbatim. That's correct when the workspace hasn't moved between
+sessions, but stale the moment anything edited a file while the daemon
+was dead — branch switch, external editor save, package upgrade.
+
+This PR ships the reconciliation worker that closes the loop.
+
+#### What
+
+**New `crates/rts-daemon/src/reconciler.rs` module.** Runs once,
+spawned from `Workspace.Mount` on the `MountSource::Rehydrate`
+branch. Fresh / cold-walk / wipe-after-invalidation mounts skip the
+worker — their cold walk already covers every file.
+
+The worker walks the mount root with the same ignore-respecting
+`ignore::WalkBuilder` used by the cold-walk path, then for each
+visited file:
+
+- Reads the persisted `FileMeta` via `Store::get_file_meta`.
+- Compares on-disk `mtime_ns` against the stored value.
+- On mismatch, confirms with a blake3 hash of the file bytes
+  (a touch-only modification that didn't change content shouldn't
+  trigger a reparse).
+- On drift, emits `WatchEvent::Touched` into the existing watcher
+  channel; the writer drain reparses and commits through the same
+  path as a live edit.
+
+After the walk, anything indexed but not visited (gone from disk, or
+now `.gitignore`'d, or secret-blocked) gets a `WatchEvent::Removed`
+so the writer drops the row.
+
+**Rate limiting.** A simple token bucket caps emission at 64
+events/sec by default (`DEFAULT_RATE_LIMIT_PER_SEC`). A mass-drift
+scenario — e.g. branch switch with thousands of touched files —
+won't stall the foreground writer.
+
+**`Daemon.Stats.reconciliation` field.** New nested object under the
+existing v2 response (only emitted when a workspace is mounted):
+
+```jsonc
+"reconciliation": {
+  "last_run_ns":   1748462100123456789,
+  "files_scanned": 1247,
+  "files_changed": 3,
+  "files_removed": 1,
+  "throttled":     0
+}
+```
+
+Backed by a shared `Arc<RwLock<ReconcileStats>>` on `DaemonState`
+following the same pattern as `rehydrate_invalidations`.
+
+**AC16 preserved.** The worker never touches `UNRESOLVED_REFS`
+directly. Cross-file edges into a drift-detected file flow through
+the writer's normal `Touched`/`Removed` arms, which recompute only
+the affected file's outgoing refs. Edges *from* other files into
+this file survive intact.
+
+#### Why this matters
+
+Without reconciliation, this sequence silently broke search:
+
+1. Daemon mounts `~/repo`, indexes 1.2k files, goes idle.
+2. User does `git checkout other-branch` — 80 files differ.
+3. Daemon respawns on next query, rehydrates from redb.
+4. `find_symbol` returns rows for the *old* branch's code until the
+   user re-touches each file.
+
+With reconciliation:
+
+1-2. Same as above.
+3. Daemon respawns, takes the Rehydrate path, then spawns the
+   worker. Within seconds, drift is detected and the writer
+   reparses each changed file.
+4. `find_symbol` returns the current branch's code.
+
+#### Verification
+
+- Plan: [`docs/plans/2026-05-18-004-feat-reconciliation-worker-plan.md`](../docs/plans/2026-05-18-004-feat-reconciliation-worker-plan.md)
+- New integration test
+  `crates/rts-daemon/tests/reconciliation_round_trip.rs`:
+  - Session 1: mount → index three files (`drifted.rs`, `orphan.rs`,
+    `stable.rs`) → assert cross-file caller edge from `stable.rs`
+    into `drifted.rs::stable_callee_hub` is resolved → kill daemon.
+  - Between sessions: edit `drifted.rs` body (new symbol
+    `drift_target_v2`), delete `orphan.rs`, leave `stable.rs`
+    untouched.
+  - Session 2: respawn daemon → assert `mount_source: "rehydrate"`,
+    poll `Daemon.Stats.reconciliation` for `files_changed >= 1
+    && files_removed >= 1`, assert `Index.FindSymbol` surfaces the
+    new symbol, assert `Index.FindCallers` still resolves
+    `stable_callee_hub` callers (AC16).
+- 768 workspace tests pass, including the existing
+  `persisted_cold_mount_round_trip` suite.
+
+#### Capability
+
+New capability advertised in `Daemon.Ping`: `reconciliation_worker`.
+Clients that need to gate on the new `Daemon.Stats.reconciliation`
+field check this capability.

--- a/crates/rts-daemon/src/main.rs
+++ b/crates/rts-daemon/src/main.rs
@@ -21,6 +21,7 @@ mod methods;
 mod outline;
 mod path;
 mod protocol;
+mod reconciler;
 mod refs;
 mod socket;
 mod state;

--- a/crates/rts-daemon/src/methods/daemon.rs
+++ b/crates/rts-daemon/src/methods/daemon.rs
@@ -107,6 +107,13 @@ const DAEMON_CAPABILITIES: &[&str] = &[
     "index_grep_structural",
     "index_grep_within_symbol",
     "index_grep_v2",
+    // v0.6 — reconciliation worker runs once on persisted cold-mount
+    // (`mount_source: "rehydrate"`) to detect files that drifted on
+    // disk while the daemon was dead. Surfaces via `Daemon.Stats`'s
+    // `reconciliation: { last_run_ns, files_scanned, files_changed,
+    // files_removed, throttled }` object. Old clients can ignore the
+    // field; this capability lets them gate on its presence.
+    "reconciliation_worker",
 ];
 
 /// `Daemon.Ping` — heartbeat + capability advertisement (protocol-v0 §4.1, §7.1).
@@ -264,6 +271,17 @@ pub async fn stats(
                 "rehydrate_invalidations_by_reason".into(),
                 serde_json::Value::Object(invalidations_obj),
             );
+        }
+
+        // v0.6 reconciliation worker stats. Only emitted alongside the
+        // other workspace-scoped fields (pre-mount Stats omits the
+        // entire reconciliation object). Default zeros until the
+        // worker completes its first pass; after that the snapshot
+        // tracks the most recent run.
+        if let Ok(snapshot) = state.reconcile_stats.read() {
+            if let Ok(value) = serde_json::to_value(&*snapshot) {
+                obj.insert("reconciliation".into(), value);
+            }
         }
     }
 

--- a/crates/rts-daemon/src/methods/workspace.rs
+++ b/crates/rts-daemon/src/methods/workspace.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use crate::error::{ErrorCode, ProtocolError};
 use crate::state::DaemonState;
 use crate::store::Store;
-use crate::watcher::Watcher;
+use crate::watcher::{WatchEvent, Watcher};
 use crate::workspace::{self, MountedWorkspace, state_dir_for};
 use crate::writer;
 
@@ -229,8 +229,8 @@ pub(super) async fn mount_inner(
     // start consuming from the channel first. See watcher.rs comment on
     // `InitialWalkHandle` for the 256-file plateau bug this restructure
     // fixes.
-    let (watcher, rx, initial) =
-        Watcher::start(&mounted.canonical.path, state.clone()).map_err(|e| {
+    let (watcher, rx, initial, watch_sink) = Watcher::start(&mounted.canonical.path, state.clone())
+        .map_err(|e| {
             ProtocolError::new(
                 ErrorCode::InternalError,
                 format!("could not start file watcher: {e}"),
@@ -379,6 +379,7 @@ pub(super) async fn mount_inner(
     }
 
     let payload = status_payload(&mounted, state, Some(&store));
+    let reconcile_root = mounted.canonical.path.clone();
     {
         let mut current = state.workspace.lock().map_err(|e| {
             ProtocolError::new(ErrorCode::InternalError, format!("state poisoned: {e}"))
@@ -401,7 +402,7 @@ pub(super) async fn mount_inner(
                 format!("store state poisoned: {e}"),
             )
         })?;
-        *store_slot = Some(store);
+        *store_slot = Some(store.clone());
     }
     {
         let mut cancel_slot = state.writer_cancel.lock().map_err(|e| {
@@ -412,6 +413,55 @@ pub(super) async fn mount_inner(
         })?;
         *cancel_slot = Some(writer_cancel);
     }
+
+    // v0.6 reconciliation worker (U5 follow-up): on the persisted
+    // cold-mount path (`MountSource::Rehydrate`), the cold walk is
+    // skipped — but files may have changed on disk between sessions.
+    // Spawn the reconciler so it scans the mount root and emits
+    // `WatchEvent::Touched`/`Removed` for any drift. The writer drain
+    // consumes those events through the same path as live edits.
+    //
+    // Fresh / cold-walk / wipe-after-invalidation mounts do NOT need
+    // this — their cold walk already covers every file. Reconciliation
+    // is additive on top of an already-trusted snapshot.
+    if matches!(mount_source, crate::state::MountSource::Rehydrate) {
+        // The writer task spawned above starts in `cold_walk_in_progress = true`
+        // and suppresses its periodic flush until a `ColdWalkComplete`
+        // barrier fires. On the rehydrate branch no walker is spawned
+        // (so the barrier never naturally arrives), and the writer
+        // would therefore hold reconciler-emitted touches in memory
+        // forever — well past the per-event 150 ms timer budget. Push
+        // an explicit `ColdWalkComplete` so the writer releases the
+        // hold-off and begins draining as events stream in. This is
+        // load-bearing for the reconciler's `Touched`/`Removed` events
+        // to be observable via `Index.FindSymbol` etc.
+        let barrier_sink = watch_sink.clone();
+        tokio::spawn(async move {
+            if barrier_sink
+                .send(WatchEvent::ColdWalkComplete)
+                .await
+                .is_err()
+            {
+                tracing::warn!("rehydrate: writer channel closed before ColdWalkComplete barrier");
+            }
+        });
+
+        let reconciler = crate::reconciler::Reconciler::new(
+            store.clone(),
+            watch_sink.clone(),
+            state.reconcile_stats.clone(),
+        );
+        tokio::spawn(async move {
+            if let Err(e) = reconciler.run(reconcile_root).await {
+                tracing::warn!(error = ?e, "reconciliation failed");
+            }
+        });
+    }
+    // Keep `watch_sink` alive only for the reconciler spawn; the
+    // watcher and writer hold their own references, so dropping the
+    // local clone here is a no-op for steady-state operation.
+    drop(watch_sink);
+
     state.mount_refcount.fetch_add(1, Ordering::Relaxed);
     state.touch();
     Ok(payload)

--- a/crates/rts-daemon/src/reconciler.rs
+++ b/crates/rts-daemon/src/reconciler.rs
@@ -1,0 +1,343 @@
+//! Post-cold-mount reconciliation worker.
+//!
+//! Runs once shortly after a persisted cold-mount (`MountSource::Rehydrate`)
+//! completes. Walks the mount root using the same ignore-respecting walker
+//! as the cold-walk path, compares each indexed file's on-disk metadata
+//! against the persisted `FileMeta`, and emits `WatchEvent::Touched` /
+//! `WatchEvent::Removed` for any drift. The writer drain consumes the
+//! events through the same path as live edits and rescans.
+//!
+//! Without this pass the daemon would serve stale rows for every file
+//! that changed while the previous daemon was dead (branch switches,
+//! external editor saves, package upgrades). The hot rehydrate path is
+//! preserved — reconciliation runs *after* `Mount` returns so the first
+//! query is not gated on a full walk.
+//!
+//! **AC16 preservation.** This worker never touches `UNRESOLVED_REFS`
+//! directly. Cross-file edges into a drift-detected file flow through
+//! the writer's normal `Touched`/`Removed` arms, which recompute only
+//! the affected file's outgoing refs. Edges *from* other files into
+//! this file survive intact.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use tokio::sync::mpsc;
+
+use crate::filter::{FilterDecision, PrebuiltGitignore, classify};
+use crate::store::Store;
+use crate::watcher::WatchEvent;
+
+/// Default per-second event emission cap. Bounds the impact of a
+/// mass-drift scenario (e.g. branch switch with thousands of touched
+/// files) on the foreground writer; the writer's batch budget would
+/// otherwise pile up.
+pub const DEFAULT_RATE_LIMIT_PER_SEC: u32 = 64;
+
+/// Per-worker stats surfaced via `Daemon.Stats.reconciliation`.
+///
+/// `last_run_ns` is the Unix-epoch nanoseconds when the most recent
+/// reconciliation pass finished; `0` until the first run completes.
+/// Counters are cumulative across the daemon process lifetime (one
+/// pass per persisted cold-mount in practice).
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct ReconcileStats {
+    pub last_run_ns: u64,
+    pub files_scanned: u64,
+    pub files_changed: u64,
+    pub files_removed: u64,
+    pub throttled: u64,
+}
+
+/// One reconciliation pass. Owns nothing past `run`.
+pub struct Reconciler {
+    store: Arc<Store>,
+    sink: mpsc::Sender<WatchEvent>,
+    stats: Arc<RwLock<ReconcileStats>>,
+    rate_limit_per_sec: u32,
+}
+
+impl Reconciler {
+    /// Construct a reconciler at the default rate limit.
+    pub fn new(
+        store: Arc<Store>,
+        sink: mpsc::Sender<WatchEvent>,
+        stats: Arc<RwLock<ReconcileStats>>,
+    ) -> Self {
+        Self {
+            store,
+            sink,
+            stats,
+            rate_limit_per_sec: DEFAULT_RATE_LIMIT_PER_SEC,
+        }
+    }
+
+    /// Walk `root`, compare against the persisted store, emit drift
+    /// events. Returns a snapshot of the resulting stats.
+    pub async fn run(self, root: PathBuf) -> anyhow::Result<ReconcileStats> {
+        let started = Instant::now();
+        let gitignore = PrebuiltGitignore::build(&root)
+            .map_err(|e| anyhow::anyhow!("rebuild gitignore for reconcile: {e}"))?;
+
+        // Snapshot the persisted file set up front. We can't keep a
+        // redb txn open across the walk + async sends, but a single
+        // pass over `list_files_with_defs` gives us everything we need
+        // (path + fid) to detect orphans below.
+        let indexed = self
+            .store
+            .list_files_with_defs()
+            .map_err(|e| anyhow::anyhow!("reconcile: list_files_with_defs: {e:#}"))?;
+        let indexed_paths: std::collections::HashSet<String> =
+            indexed.iter().map(|f| f.path.clone()).collect();
+
+        let mut visited: std::collections::HashSet<String> =
+            std::collections::HashSet::with_capacity(indexed_paths.len());
+        let mut files_scanned: u64 = 0;
+        let mut files_changed: u64 = 0;
+        let mut files_removed: u64 = 0;
+        let mut throttled: u64 = 0;
+
+        // Token-bucket pacing: refill `rate_limit_per_sec` tokens once
+        // per second, starting full. A drift event that exhausts the
+        // bucket sleeps until the next refill. Bench/test runs that
+        // never exceed the cap pay zero latency cost.
+        let mut bucket_tokens: u32 = self.rate_limit_per_sec.max(1);
+        let mut bucket_window_started: Instant = Instant::now();
+
+        let walker = ignore::WalkBuilder::new(&root)
+            .standard_filters(true)
+            .git_ignore(true)
+            .git_global(true)
+            .git_exclude(true)
+            .ignore(true)
+            .add_custom_ignore_filename(".rtsignore")
+            .follow_links(false)
+            .build();
+
+        for entry in walker {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(err) => {
+                    tracing::warn!(error = %err, "reconcile walk error; continuing");
+                    continue;
+                }
+            };
+            if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                continue;
+            }
+            let abs_path = entry.into_path();
+            let decision = classify(&abs_path, &gitignore);
+            match decision {
+                FilterDecision::IndexFull | FilterDecision::IndexSignatureOnly => {}
+                FilterDecision::Skip(_) => continue,
+            }
+            files_scanned = files_scanned.saturating_add(1);
+
+            let rel_path = match abs_path.strip_prefix(&root) {
+                Ok(p) => p.to_path_buf(),
+                Err(_) => continue,
+            };
+            let rel_key = rel_path.to_string_lossy().into_owned();
+            visited.insert(rel_key.clone());
+
+            // File on disk but never indexed yet — emit `Touched` so
+            // the writer picks it up. This covers the new-file-while-
+            // daemon-was-dead case, which the cold-walk path would
+            // have handled naturally.
+            let Some((_, meta)) = self.store.get_file_meta(&rel_key).ok().flatten() else {
+                if Self::should_throttle(
+                    &mut bucket_tokens,
+                    &mut bucket_window_started,
+                    self.rate_limit_per_sec,
+                )
+                .await
+                {
+                    throttled = throttled.saturating_add(1);
+                }
+                if self
+                    .sink
+                    .send(WatchEvent::Touched {
+                        path: abs_path.clone(),
+                        decision,
+                    })
+                    .await
+                    .is_err()
+                {
+                    tracing::warn!("reconcile sink closed; aborting walk");
+                    break;
+                }
+                files_changed = files_changed.saturating_add(1);
+                continue;
+            };
+
+            if !file_drifted(&abs_path, &meta) {
+                continue;
+            }
+
+            if Self::should_throttle(
+                &mut bucket_tokens,
+                &mut bucket_window_started,
+                self.rate_limit_per_sec,
+            )
+            .await
+            {
+                throttled = throttled.saturating_add(1);
+            }
+
+            if self
+                .sink
+                .send(WatchEvent::Touched {
+                    path: abs_path.clone(),
+                    decision,
+                })
+                .await
+                .is_err()
+            {
+                tracing::warn!("reconcile sink closed; aborting walk");
+                break;
+            }
+            files_changed = files_changed.saturating_add(1);
+        }
+
+        // Orphan detection: anything indexed but not seen during the
+        // walk is gone (or now gitignored/secret-blocked); emit
+        // `Removed` so the writer drops its rows.
+        for rel_key in indexed_paths.iter() {
+            if visited.contains(rel_key) {
+                continue;
+            }
+            let abs = root.join(rel_key);
+            if Self::should_throttle(
+                &mut bucket_tokens,
+                &mut bucket_window_started,
+                self.rate_limit_per_sec,
+            )
+            .await
+            {
+                throttled = throttled.saturating_add(1);
+            }
+            if self
+                .sink
+                .send(WatchEvent::Removed { path: abs })
+                .await
+                .is_err()
+            {
+                tracing::warn!("reconcile sink closed; aborting orphan sweep");
+                break;
+            }
+            files_removed = files_removed.saturating_add(1);
+        }
+
+        let last_run_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+
+        let snapshot = ReconcileStats {
+            last_run_ns,
+            files_scanned,
+            files_changed,
+            files_removed,
+            throttled,
+        };
+        if let Ok(mut guard) = self.stats.write() {
+            *guard = snapshot.clone();
+        }
+        tracing::info!(
+            target: "rts_daemon::reconciler",
+            files_scanned,
+            files_changed,
+            files_removed,
+            throttled,
+            elapsed_ms = started.elapsed().as_millis() as u64,
+            "reconciliation pass complete"
+        );
+        Ok(snapshot)
+    }
+
+    /// Token-bucket gate. Returns `true` when the caller had to wait
+    /// for a refill (i.e. the emission was throttled).
+    async fn should_throttle(
+        bucket_tokens: &mut u32,
+        bucket_window_started: &mut Instant,
+        rate_limit_per_sec: u32,
+    ) -> bool {
+        let cap = rate_limit_per_sec.max(1);
+        if *bucket_tokens > 0 {
+            *bucket_tokens -= 1;
+            return false;
+        }
+        let elapsed = bucket_window_started.elapsed();
+        let throttled = if elapsed < Duration::from_secs(1) {
+            let remaining = Duration::from_secs(1) - elapsed;
+            tokio::time::sleep(remaining).await;
+            true
+        } else {
+            false
+        };
+        *bucket_window_started = Instant::now();
+        *bucket_tokens = cap - 1;
+        throttled
+    }
+}
+
+fn file_drifted(abs_path: &Path, meta: &crate::store::schema::FileMeta) -> bool {
+    let Ok(meta_io) = std::fs::metadata(abs_path) else {
+        // Can't stat — treat as drift; the writer will resolve the
+        // race (real removal will surface during its own read attempt).
+        return true;
+    };
+    let mtime_ns = meta_io
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0);
+    if mtime_ns != meta.mtime_ns {
+        // Mtime mismatch is the cheap signal; confirm with a hash so
+        // touch-only modifications (mtime bumped, bytes unchanged)
+        // don't trigger a needless reparse.
+        let Ok(content) = std::fs::read(abs_path) else {
+            return true;
+        };
+        let hash: [u8; 32] = blake3::hash(&content).into();
+        return hash != meta.content_hash;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn throttle_passes_through_under_cap() {
+        let mut tokens: u32 = 4;
+        let mut window = Instant::now();
+        // First three calls drain the bucket; none should report throttle.
+        for _ in 0..3 {
+            let was = Reconciler::should_throttle(&mut tokens, &mut window, 4).await;
+            assert!(!was);
+        }
+        assert_eq!(tokens, 1);
+    }
+
+    #[tokio::test]
+    async fn throttle_sleeps_when_bucket_drained() {
+        let mut tokens: u32 = 1;
+        let mut window = Instant::now();
+        // First call consumes the last token (no throttle).
+        let was = Reconciler::should_throttle(&mut tokens, &mut window, 1).await;
+        assert!(!was);
+        // Next call has no tokens and must wait for a refill.
+        let started = Instant::now();
+        let was = Reconciler::should_throttle(&mut tokens, &mut window, 1).await;
+        assert!(was, "second call should report throttled");
+        assert!(
+            started.elapsed() >= Duration::from_millis(500),
+            "throttled call should sleep close to 1s; got {:?}",
+            started.elapsed()
+        );
+    }
+}

--- a/crates/rts-daemon/src/state.rs
+++ b/crates/rts-daemon/src/state.rs
@@ -4,8 +4,8 @@
 //! and an "active connections" gauge driving the idle-shutdown timer (per
 //! `docs/protocol-v0.md` §15.2).
 
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 
 use crate::outline::OutlineCache;
@@ -220,6 +220,12 @@ pub struct DaemonState {
     /// `InvalidationReason::as_label()` string so the JSON shape is
     /// stable.
     pub rehydrate_invalidations: Mutex<std::collections::BTreeMap<String, u64>>,
+    /// v0.6 persisted-cold-mount reconciliation stats. Shared with the
+    /// reconciler worker (spawned from `Workspace.Mount` on the
+    /// `Rehydrate` branch) and read by `Daemon.Stats`. `RwLock` rather
+    /// than `Mutex` because reads via `Daemon.Stats` outnumber writes
+    /// (one write per pass) by a large margin.
+    pub reconcile_stats: Arc<RwLock<crate::reconciler::ReconcileStats>>,
 }
 
 /// Per-method call counts for the daemon's RPC surface. All fields
@@ -517,6 +523,7 @@ impl DaemonState {
             rehydrate_attempts: AtomicU64::new(0),
             rehydrate_successes: AtomicU64::new(0),
             rehydrate_invalidations: Mutex::new(std::collections::BTreeMap::new()),
+            reconcile_stats: Arc::new(RwLock::new(crate::reconciler::ReconcileStats::default())),
         }
     }
 

--- a/crates/rts-daemon/src/watcher.rs
+++ b/crates/rts-daemon/src/watcher.rs
@@ -143,7 +143,12 @@ impl Watcher {
     pub fn start(
         root: &Path,
         state: Arc<DaemonState>,
-    ) -> std::io::Result<(Watcher, mpsc::Receiver<WatchEvent>, InitialWalkHandle)> {
+    ) -> std::io::Result<(
+        Watcher,
+        mpsc::Receiver<WatchEvent>,
+        InitialWalkHandle,
+        mpsc::Sender<WatchEvent>,
+    )> {
         let gitignore = PrebuiltGitignore::build(root)?;
         let gitignore = Arc::new(gitignore);
         let (tx, rx) = mpsc::channel::<WatchEvent>(CHANNEL_CAPACITY);
@@ -249,6 +254,7 @@ impl Watcher {
             },
             rx,
             initial,
+            tx,
         ))
     }
 }
@@ -474,7 +480,7 @@ mod tests {
         std::fs::write(tmp.path().join("a.rs.swp"), "swap").unwrap();
 
         let state = fresh_state();
-        let (_watcher, mut rx, initial) = Watcher::start(tmp.path(), state).unwrap();
+        let (_watcher, mut rx, initial, _tx) = Watcher::start(tmp.path(), state).unwrap();
         let _ = initial.spawn();
 
         let mut seen = std::collections::HashSet::new();
@@ -500,7 +506,7 @@ mod tests {
     async fn live_create_surfaces_through_debouncer() {
         let tmp = tempfile::tempdir().unwrap();
         let state = fresh_state();
-        let (_watcher, mut rx, initial) = Watcher::start(tmp.path(), state.clone()).unwrap();
+        let (_watcher, mut rx, initial, _tx) = Watcher::start(tmp.path(), state.clone()).unwrap();
         // Run initial walk now that the receiver is owned by the test.
         let _ = initial.spawn();
 
@@ -529,7 +535,7 @@ mod tests {
     async fn live_create_of_secrets_file_is_filtered() {
         let tmp = tempfile::tempdir().unwrap();
         let state = fresh_state();
-        let (_watcher, mut rx, initial) = Watcher::start(tmp.path(), state).unwrap();
+        let (_watcher, mut rx, initial, _tx) = Watcher::start(tmp.path(), state).unwrap();
         let _ = initial.spawn();
 
         // Drain initial walk.

--- a/crates/rts-daemon/tests/reconciliation_round_trip.rs
+++ b/crates/rts-daemon/tests/reconciliation_round_trip.rs
@@ -1,0 +1,413 @@
+//! End-to-end test for the reconciliation worker that runs after a
+//! persisted cold-mount (`MountSource::Rehydrate`).
+//!
+//! Asserts the AC chain from `docs/plans/2026-05-18-004-feat-reconciliation-worker-plan.md`:
+//!
+//! 1. Mount a workspace, let it index, kill the daemon.
+//! 2. Between sessions, modify one file's bytes + mtime and delete
+//!    another. The workspace fingerprint stays stable (file content
+//!    isn't part of it) so the next mount takes the Rehydrate path.
+//! 3. Restart the daemon. `Daemon.Stats` should report
+//!    `reconciliation.files_changed >= 1` and `files_removed >= 1`
+//!    once the worker drains.
+//! 4. `Index.FindSymbol` returns the post-edit symbol (proving
+//!    `WatchEvent::Touched` reached the writer + got reparsed).
+//! 5. AC16: a third file that was NOT modified still has its
+//!    cross-file caller edges visible after reconciliation —
+//!    `Index.FindCallers` works without a fresh cold walk.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(5), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn socket_path(home_dir: &std::path::Path, runtime_dir: &std::path::Path) -> std::path::PathBuf {
+    if cfg!(target_os = "macos") {
+        home_dir
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.join("rts").join("default.sock")
+    }
+}
+
+fn spawn_daemon(
+    runtime_dir: &std::path::Path,
+    state_dir: &std::path::Path,
+    home_dir: &std::path::Path,
+) -> anyhow::Result<std::process::Child> {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir, std::fs::Permissions::from_mode(0o700));
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir)
+        .env("XDG_STATE_HOME", state_dir)
+        .env("HOME", home_dir)
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    Ok(cmd.spawn()?)
+}
+
+/// Poll until `Index.FindSymbol(name)` returns at least one match. The
+/// match indicates the reconciler emitted Touched and the writer
+/// reparsed + committed. We don't pin a specific `start_line` because
+/// the test only cares that the renamed symbol becomes visible, not
+/// which line it landed on.
+async fn poll_find_symbol_exists(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+    id_seed: u32,
+) -> anyhow::Result<Value> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u32 = id_seed;
+    let mut last: Option<Value> = None;
+    loop {
+        id += 1;
+        let r = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if let Some(arr) = r["result"]["matches"].as_array() {
+            if !arr.is_empty() {
+                return Ok(r);
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "FindSymbol({name}) never returned matches within {timeout:?}; last={last:?}"
+            );
+        }
+        last = Some(r);
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn reconciler_reindexes_drift_and_removes_orphans_on_rehydrate() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    // Seed three files:
+    //   - drifted.rs: gets edited between sessions (new symbol body)
+    //   - orphan.rs:  gets deleted between sessions
+    //   - stable.rs:  unchanged across sessions; carries a cross-file
+    //                 call into a stable callee defined in drifted.rs
+    //                 so we can prove UNRESOLVED_REFS survives (AC16).
+    std::fs::write(
+        workspace.path().join("drifted.rs"),
+        "pub fn drift_target_v1() {}\npub fn stable_callee_hub() {}\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("orphan.rs"),
+        "pub fn orphan_fn() {}\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("stable.rs"),
+        "pub fn stable_caller() {\n    stable_callee_hub();\n}\n",
+    )?;
+
+    let sock = socket_path(home_dir.path(), runtime_dir.path());
+
+    // ---- Session 1: cold-walk path; populate the index. ----
+    {
+        let mut child = spawn_daemon(runtime_dir.path(), state_dir.path(), home_dir.path())?;
+        let _kill = KillOnDrop(&mut child);
+        wait_for_socket(&sock, Duration::from_secs(5)).await?;
+        let mut stream = UnixStream::connect(&sock).await?;
+
+        let mount = round_trip(
+            &mut stream,
+            "1",
+            "Workspace.Mount",
+            json!({ "root": workspace.path() }),
+        )
+        .await?;
+        assert!(
+            mount["error"].is_null(),
+            "session-1 mount failed: {mount:?}"
+        );
+
+        // Poll until all three files have at least their hub symbol indexed.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut id: u32 = 10;
+        loop {
+            id += 1;
+            let r = round_trip(
+                &mut stream,
+                &id.to_string(),
+                "Index.FindSymbol",
+                json!({ "name": "drift_target_v1" }),
+            )
+            .await?;
+            if let Some(arr) = r["result"]["matches"].as_array() {
+                if !arr.is_empty() {
+                    break;
+                }
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!("session-1: drift_target_v1 never indexed within 5s");
+            }
+            tokio::time::sleep(Duration::from_millis(75)).await;
+        }
+
+        // Confirm cross-file caller edge landed pre-restart. The
+        // writer's batch barrier (`ColdWalkComplete`) flushes
+        // everything together so the call from `stable.rs` into
+        // `stable_callee_hub` is resolved in REFS, not stranded in
+        // UNRESOLVED_REFS.
+        let pre = round_trip(
+            &mut stream,
+            "100",
+            "Index.FindCallers",
+            json!({ "name": "stable_callee_hub" }),
+        )
+        .await?;
+        let pre_callers = pre["result"]["callers"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            !pre_callers.is_empty(),
+            "session-1 should resolve stable.rs -> stable_callee_hub: {pre:?}"
+        );
+
+        drop(stream);
+    }
+
+    // Wait briefly for the daemon to fully tear down so the next
+    // bind doesn't race for the socket file.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let _ = std::fs::remove_file(&sock);
+
+    // Mutate the workspace while the daemon is dead:
+    //   - drifted.rs gains a NEW symbol (drift_target_v2). Sleep a
+    //     beat first so the OS-supplied mtime is guaranteed to be
+    //     newer than the original write (the daemon stores
+    //     nanosecond-precision mtime, so on Linux even a same-millis
+    //     write usually drifts; on coarser-grained APFS, a short
+    //     sleep is the cross-platform belt + suspenders).
+    //   - orphan.rs is removed entirely
+    //   - stable.rs is untouched
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    std::fs::write(
+        workspace.path().join("drifted.rs"),
+        // Add leading blank lines so `drift_target_v2` sits at line 3
+        // (deterministic for the assertion below).
+        "\n\npub fn drift_target_v2() {}\npub fn stable_callee_hub() {}\n",
+    )?;
+    std::fs::remove_file(workspace.path().join("orphan.rs"))?;
+
+    // ---- Session 2: rehydrate path; reconciler should fire. ----
+    {
+        let mut child = spawn_daemon(runtime_dir.path(), state_dir.path(), home_dir.path())?;
+        let _kill = KillOnDrop(&mut child);
+        wait_for_socket(&sock, Duration::from_secs(5)).await?;
+        let mut stream = UnixStream::connect(&sock).await?;
+
+        let mount = round_trip(
+            &mut stream,
+            "1",
+            "Workspace.Mount",
+            json!({ "root": workspace.path() }),
+        )
+        .await?;
+        assert!(
+            mount["error"].is_null(),
+            "session-2 mount failed: {mount:?}"
+        );
+
+        // Confirm we actually took the rehydrate path (otherwise the
+        // reconciler is moot — a cold walk would handle the drift on
+        // its own and this test would still pass for the wrong reason).
+        let stats0 = round_trip(&mut stream, "2", "Daemon.Stats", json!({})).await?;
+        assert_eq!(
+            stats0["result"]["mount_source"].as_str(),
+            Some("rehydrate"),
+            "session-2 must take rehydrate path; got {stats0:?}"
+        );
+
+        // Poll Daemon.Stats.reconciliation until it reflects at least
+        // one changed file (drifted.rs) and one removed (orphan.rs).
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut id: u32 = 20;
+        loop {
+            id += 1;
+            let r = round_trip(&mut stream, &id.to_string(), "Daemon.Stats", json!({})).await?;
+            let recon = &r["result"]["reconciliation"];
+            let changed = recon["files_changed"].as_u64().unwrap_or(0);
+            let removed = recon["files_removed"].as_u64().unwrap_or(0);
+            let scanned = recon["files_scanned"].as_u64().unwrap_or(0);
+            if changed >= 1 && removed >= 1 {
+                assert!(
+                    scanned >= changed,
+                    "files_scanned ({scanned}) should cover files_changed ({changed}); got {recon:?}"
+                );
+                assert!(
+                    recon["last_run_ns"].as_u64().unwrap_or(0) > 0,
+                    "last_run_ns should be non-zero once the pass completes: {recon:?}"
+                );
+                break;
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!(
+                    "reconciliation never reported drift within 10s; last reading: {r:?}"
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        // The writer drain runs async. Wait for the reparse to land
+        // before asserting the post-drift symbol view.
+        let r =
+            poll_find_symbol_exists(&mut stream, "drift_target_v2", Duration::from_secs(10), 200)
+                .await?;
+        // Symbol exists in drifted.rs after the reparse — that's what
+        // we care about. The exact `start_line` depends on
+        // language-specific signature parsing; one match is enough.
+        assert!(
+            r["result"]["matches"]
+                .as_array()
+                .map(|a| !a.is_empty())
+                .unwrap_or(false),
+            "drift_target_v2 should be indexed after reconciliation reparse"
+        );
+
+        // Old symbol should be gone (file was overwritten, not
+        // appended). Use a short-deadline poll so we don't flake on
+        // the still-draining writer.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut id: u32 = 300;
+        loop {
+            id += 1;
+            let r = round_trip(
+                &mut stream,
+                &id.to_string(),
+                "Index.FindSymbol",
+                json!({ "name": "drift_target_v1" }),
+            )
+            .await?;
+            let arr = r["result"]["matches"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+            if arr.is_empty() {
+                break;
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!("drift_target_v1 still present after reconcile + reparse; got {r:?}");
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        // AC16: `stable.rs` was not modified between sessions, and the
+        // callee `stable_callee_hub` lives in `drifted.rs` (which WAS
+        // touched). Reconciliation must NOT invalidate the cross-file
+        // caller edge from `stable.rs` into `stable_callee_hub`.
+        // Once the writer commits its post-touch batch, REFS should
+        // still contain the edge.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut id: u32 = 400;
+        let callers = loop {
+            id += 1;
+            let r = round_trip(
+                &mut stream,
+                &id.to_string(),
+                "Index.FindCallers",
+                json!({ "name": "stable_callee_hub" }),
+            )
+            .await?;
+            let arr = r["result"]["callers"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default();
+            if !arr.is_empty() {
+                break arr;
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!(
+                    "AC16 violation: stable.rs caller edge into stable_callee_hub vanished after reconcile; got {r:?}"
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        };
+
+        // Confirm it's actually `stable.rs` (not a re-parse of
+        // drifted.rs that ate its own caller edge).
+        let has_stable = callers.iter().any(|c| {
+            c.get("file")
+                .and_then(|v| v.as_str())
+                .map(|s| s.ends_with("stable.rs"))
+                .unwrap_or(false)
+        });
+        assert!(
+            has_stable,
+            "AC16: caller edge from stable.rs should survive reconciliation; got {callers:?}"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- New `crates/rts-daemon/src/reconciler.rs` post-cold-mount worker. Spawned from `Workspace.Mount` on the `MountSource::Rehydrate` branch; walks the mount root with the same ignore-respecting walker as the cold-walk path, compares each indexed file's on-disk `mtime_ns` against the persisted `FileMeta` (with blake3 confirmation on mtime mismatch), and emits `WatchEvent::Touched` for any drift plus `WatchEvent::Removed` for indexed paths that vanished. Token-bucket rate-limited at 64 events/sec.
- `Daemon.Stats` gains a `reconciliation: { last_run_ns, files_scanned, files_changed, files_removed, throttled }` object, backed by a shared `Arc<RwLock<ReconcileStats>>` on `DaemonState`. New capability `reconciliation_worker` advertised in `Daemon.Ping`.
- Closes the AC16 corner: cross-file `UNRESOLVED_REFS` edges into a drift-detected file survive reconciliation. The worker never touches the table directly — only the affected file's outgoing refs are recomputed via the writer's normal `Touched`/`Removed` path.
- Fresh / cold-walk / wipe-after-invalidation mounts skip the worker — their cold walk already covers every file.

## Implementation note

The Rehydrate branch additionally pushes a synthetic `WatchEvent::ColdWalkComplete` into the writer's channel before spawning the worker. Without it the writer would sit in its `cold_walk_in_progress = true` hold-off forever (the barrier that normally releases the timer-driven flush is sent at the end of the initial walk, which Rehydrate skips). Reconciler-emitted touches would otherwise accumulate in memory until `BATCH_SIZE_BUDGET` — fine for mass drift, but invisible to `Index.FindSymbol` for the common single-file-change case.

## Testing notes

- New integration test `crates/rts-daemon/tests/reconciliation_round_trip.rs` covers the full AC chain: mount three files, kill daemon, edit one + delete another, restart, poll `Daemon.Stats.reconciliation` for drift, assert `Index.FindSymbol` reflects the post-edit symbol, assert `Index.FindCallers` on an unchanged file still returns its pre-restart edge (AC16).
- Reconciler module ships two unit tests around the token-bucket rate limiter.
- `cargo fmt --all -- --check` clean.
- `cargo clippy --workspace --all-targets` shows no new warnings on the introduced code (pre-existing baseline warnings in `rts-core` are untouched).
- `cargo test --workspace` → 768 passed, 0 failed.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: feature is additive on persisted cold-mount, surfaces via Daemon.Stats counters, no external integrations

🤖 Generated with Claude Sonnet 4.5 (1M context) via Claude Code + Compound Engineering v2.49.0

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>