### PR TITLE
feat(rts-daemon): AST-precise call edges for Java, PHP, Swift, C#

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ no longer maintained.
 The redb store carries both halves of the code graph: `defs` + `fid_defs`
 for "where is X defined?" and (v0.3+) `refs` + `fid_refs` + `sid_refs_out`
 for "who calls X?", "what does X reference?", and transitive impact
-queries. AST-precise via tags.scm on Rust/Python/Go/Ruby/JS/TS; regex
-fallback on the remaining five languages.
+queries. AST-precise via tags.scm on Rust/Python/Go/Ruby/JS/TS/Java/PHP/Swift/C#
+(10 of the 12 indexed languages); regex fallback for C and C++.
 
 Both halves are local-only and offline. The daemon is single-uid via
 SO_PEERCRED / LOCAL_PEERCRED, refuses to run as root, sets

--- a/changelog.d/xxx-feat-ast-precise-call-edges-java-php-swift-csharp.md
+++ b/changelog.d/xxx-feat-ast-precise-call-edges-java-php-swift-csharp.md
@@ -1,0 +1,74 @@
+### AST-precise call edges for Java, PHP, Swift, and C#
+
+`Index.FindCallers` and the closure walker now use tree-sitter queries
+(not regex) on Java, PHP, Swift, and C# files. Coverage of AST-precise
+call edges goes from 6 of 12 indexed languages (Rust/Python/Go/Ruby/JS/TS)
+to 10 of 12. C and C++ remain on the regex fallback for now — function
+pointers parse identical to identifier references, so the precision win
+there is smaller.
+
+#### What
+
+Four new query strings in `crates/rts-daemon/src/language.rs`, registered
+against the central `LanguageInfo` table and the `cached_refs_query`
+cache:
+
+- **`JAVA_REFS`** — `method_invocation.name` and
+  `object_creation_expression.type`. Chained `a.b().c()` parses as nested
+  `method_invocation` nodes, so the query captures `b` and `c` as
+  separate call sites; the receiver `a` is a plain identifier under
+  `object:` and never matches.
+- **`PHP_REFS`** — `function_call_expression` (including the
+  `qualified_name` variant for `\Foo\bar()`), `member_call_expression`,
+  `scoped_call_expression`, and `object_creation_expression` (both bare
+  `(name)` and namespaced `(qualified_name (name))` children).
+  Variable-function `$fn()` is intentionally not captured — no static
+  target to resolve.
+- **`SWIFT_REFS`** — `call_expression` with `simple_identifier` (bare)
+  and `navigation_expression` (method calls). Trailing closures still
+  parse as `call_expression`, so they're covered without a separate
+  pattern. Authored against the installed Swift 0.7 grammar's
+  `node-types.json`; upstream `tags.scm` ships only `@definition.*`.
+- **`CSHARP_REFS`** — `invocation_expression` in four shapes (bare
+  identifier, member-access, generic-name, member-access-of-generic-name)
+  plus `object_creation_expression` (identifier and generic-name).
+  Covers `Foo()`, `obj.Foo()`, `Foo<T>()`, `obj.Foo<T>()`, `new Foo()`,
+  and `new Foo<T>()`.
+
+#### Why this matters
+
+Pre-AST-precise edges, calling `Index.FindCallers` on a Java method
+returned every textual occurrence of the name — including imports,
+comments, and string literals — plus an edge per local variable that
+happened to share the name. The same noise hit PHP/Swift/C#. For
+polyglot backends (Java services + WordPress/Laravel PHP) and mobile +
+.NET codebases, the value pitch of "AST-precise call graph" only held
+on half the supported language matrix.
+
+#### Verification
+
+- Unit tests in `crates/rts-daemon/src/refs.rs` exercise the four new
+  queries against representative fixtures (chained calls, member/static
+  calls, namespaced calls, trailing closures, generic invocations) and
+  assert local variables are NOT captured.
+- `java_php_swift_csharp_cached_queries_construct_without_panic` in
+  `crates/rts-daemon/src/language.rs` forces query compilation at unit-
+  test time so a grammar bump that breaks the queries surfaces here
+  rather than at first `Index.Outline` call.
+- Per-language integration tests `crates/rts-daemon/tests/call_edges_*.rs`
+  spawn the daemon, mount a per-language fixture, and assert
+  `Index.FindCallers` returns the expected method-level edges.
+- All existing Rust/Python/Go/Ruby/JS/TS call-edge tests continue to
+  pass — the new queries plug into the existing cache and dispatcher
+  without touching the hot path.
+
+#### Out of scope
+
+- C and C++ AST queries. Their fallback regex behavior already
+  approximates what a tags.scm query would produce because function
+  pointer calls look identical to identifier references; deferred.
+- PHP `method_declaration` symbol extraction. The AST query captures
+  member-call and scoped-call sites correctly, but the existing
+  `extract_php_symbols` only indexes `function_definition` + class
+  defs — so member/static call edges in PHP don't resolve to a target
+  yet. Tracked separately.

--- a/crates/rts-daemon/src/language.rs
+++ b/crates/rts-daemon/src/language.rs
@@ -194,6 +194,125 @@ const TYPESCRIPT_REFS: &str = r#"
         property: (property_identifier) @name)) @reference.class
 "#;
 
+/// Java reference patterns. Upstream `tree-sitter-java/queries/tags.scm`
+/// ships `(method_invocation name: (identifier) @name arguments: ...
+/// @reference.call)` — we lift the `@name` capture and re-anchor
+/// `@reference.call` on the outer node to match the rest of this
+/// module's shape.
+///
+/// Chained `a.b().c()` parses as nested `method_invocation` nodes
+/// (the outer is `c`, with `object: (method_invocation ... b ...)`),
+/// so the query captures both `b` and `c` as separate call sites —
+/// the receiver `a` is just an identifier under `object:` and never
+/// matches as `name:`.
+///
+/// `object_creation_expression` covers `new Foo(...)`; the grammar's
+/// `type:` field admits the `_simple_type` supertype whose subtypes
+/// include `type_identifier`, so the pattern matches by subtype.
+const JAVA_REFS: &str = r#"
+(method_invocation
+    name: (identifier) @name) @reference.call
+
+(object_creation_expression
+    type: (type_identifier) @name) @reference.call
+"#;
+
+/// PHP reference patterns. Upstream tags.scm covers
+/// `function_call_expression`, `member_call_expression`, and
+/// `scoped_call_expression` already; we also pick up
+/// `object_creation_expression` for `new Foo(...)` / `new \Foo\Bar(...)`.
+///
+/// Edge cases:
+/// - `\Foo\bar()` parses as `function_call_expression` with
+///   `function: (qualified_name (name) @name)` — covered.
+/// - Variable-function calls `$fn()` resolve to a `variable_name`
+///   under `function:` with no static target — intentionally skipped.
+/// - `Static::method()` parses as `scoped_call_expression`; the
+///   receiver is `scope:` and the called method is `name:`.
+const PHP_REFS: &str = r#"
+(function_call_expression
+    function: (name) @name) @reference.call
+
+(function_call_expression
+    function: (qualified_name (name) @name)) @reference.call
+
+(member_call_expression
+    name: (name) @name) @reference.call
+
+(scoped_call_expression
+    name: (name) @name) @reference.call
+
+(object_creation_expression
+    (name) @name) @reference.call
+
+(object_creation_expression
+    (qualified_name (name) @name)) @reference.call
+"#;
+
+/// Swift reference patterns. Upstream `tree-sitter-swift` 0.7's
+/// `queries/tags.scm` ships only `@definition.*` captures — no
+/// `@reference.call`. Locally authored against the grammar's
+/// `node-types.json`:
+///
+/// - Bare calls (`foo(...)`) parse as `call_expression` with a
+///   `simple_identifier` child.
+/// - Method calls (`obj.foo(...)`) parse as `call_expression` whose
+///   first child is a `navigation_expression`. The called method
+///   name is the `suffix:` field of the inner `navigation_suffix`.
+/// - Trailing closures (`foo { ... }`) still parse as
+///   `call_expression`; the method name is captured by the same
+///   patterns above — no special handling needed.
+const SWIFT_REFS: &str = r#"
+(call_expression
+    (simple_identifier) @name) @reference.call
+
+(call_expression
+    (navigation_expression
+        (navigation_suffix
+            suffix: (simple_identifier) @name))) @reference.call
+"#;
+
+/// C# reference patterns. Upstream tags.scm only ships
+/// `@reference.send` for member-access invocations — locally
+/// authored here for full coverage.
+///
+/// Three call shapes:
+/// - `Foo(...)` — `invocation_expression` with `function: (identifier)`.
+/// - `obj.Foo(...)` — `invocation_expression` with
+///   `function: (member_access_expression name: (identifier))`.
+/// - `Foo<T>(...)` — `invocation_expression` with
+///   `function: (generic_name (identifier))` (bare) or
+///   `function: (member_access_expression name: (generic_name (identifier)))`
+///   (member). Both covered.
+///
+/// `object_creation_expression` (`new Foo(...)`) has a `type:` field
+/// whose declared type is the `type` supertype; `identifier` and
+/// `generic_name` are subtypes, so the patterns match by subtype.
+const CSHARP_REFS: &str = r#"
+(invocation_expression
+    function: (identifier) @name) @reference.call
+
+(invocation_expression
+    function: (member_access_expression
+        name: (identifier) @name)) @reference.call
+
+(invocation_expression
+    function: (generic_name
+        (identifier) @name)) @reference.call
+
+(invocation_expression
+    function: (member_access_expression
+        name: (generic_name
+            (identifier) @name))) @reference.call
+
+(object_creation_expression
+    type: (identifier) @name) @reference.call
+
+(object_creation_expression
+    type: (generic_name
+        (identifier) @name)) @reference.call
+"#;
+
 /// Path → [`LanguageInfo`]. The canonical extension table.
 ///
 /// `.tsx` is intentionally routed to the same TypeScript renderer as
@@ -237,7 +356,7 @@ pub fn info_for_path(rel_path: &str) -> Option<LanguageInfo> {
         "java" => Some(LanguageInfo {
             language: Language::Java,
             signature_renderer: Some(rust_tree_sitter::signature::render_java),
-            refs_query: None,
+            refs_query: Some(JAVA_REFS),
         }),
         "c" | "h" => Some(LanguageInfo {
             language: Language::C,
@@ -252,7 +371,7 @@ pub fn info_for_path(rel_path: &str) -> Option<LanguageInfo> {
         "php" | "phtml" => Some(LanguageInfo {
             language: Language::Php,
             signature_renderer: Some(rust_tree_sitter::signature::render_php),
-            refs_query: None,
+            refs_query: Some(PHP_REFS),
         }),
         "rb" | "rake" => Some(LanguageInfo {
             language: Language::Ruby,
@@ -262,12 +381,12 @@ pub fn info_for_path(rel_path: &str) -> Option<LanguageInfo> {
         "swift" => Some(LanguageInfo {
             language: Language::Swift,
             signature_renderer: Some(rust_tree_sitter::signature::render_swift),
-            refs_query: None,
+            refs_query: Some(SWIFT_REFS),
         }),
         "cs" | "csx" => Some(LanguageInfo {
             language: Language::CSharp,
             signature_renderer: Some(rust_tree_sitter::signature::render_csharp),
-            refs_query: None,
+            refs_query: Some(CSHARP_REFS),
         }),
         _ => None,
     }
@@ -294,6 +413,10 @@ static GO_QUERY: OnceLock<Option<Query>> = OnceLock::new();
 static RUBY_QUERY: OnceLock<Option<Query>> = OnceLock::new();
 static JAVASCRIPT_QUERY: OnceLock<Option<Query>> = OnceLock::new();
 static TYPESCRIPT_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static JAVA_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static PHP_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static SWIFT_QUERY: OnceLock<Option<Query>> = OnceLock::new();
+static CSHARP_QUERY: OnceLock<Option<Query>> = OnceLock::new();
 
 /// Cached `Query` for `language`. Returns `Some` if the language has a
 /// tags.scm-derived `@reference.*` query *and* construction succeeded;
@@ -309,6 +432,10 @@ pub fn cached_refs_query(info: &LanguageInfo) -> Option<&'static Query> {
         Language::Ruby => &RUBY_QUERY,
         Language::JavaScript => &JAVASCRIPT_QUERY,
         Language::TypeScript => &TYPESCRIPT_QUERY,
+        Language::Java => &JAVA_QUERY,
+        Language::Php => &PHP_QUERY,
+        Language::Swift => &SWIFT_QUERY,
+        Language::CSharp => &CSHARP_QUERY,
         _ => return None,
     };
     let query_src = info.refs_query?;
@@ -423,6 +550,49 @@ mod tests {
         // `.to_ascii_lowercase()` in `info_for_path`.
         assert!(info_for_path("Demo.RS").is_some());
         assert!(info_for_path("DEMO.PY").is_some());
+    }
+
+    #[test]
+    fn java_php_swift_csharp_have_refs_query() {
+        // Coverage matrix: 10/12 languages with AST-precise call edges
+        // (Rust, Python, Go, Ruby, JS, TS already; this slice adds
+        // Java, PHP, Swift, C#). C and C++ stay on the regex fallback.
+        for (ext, lang) in [
+            ("Main.java", Language::Java),
+            ("Index.php", Language::Php),
+            ("App.swift", Language::Swift),
+            ("Program.cs", Language::CSharp),
+        ] {
+            let info = info_for_path(ext).unwrap_or_else(|| panic!("{ext} should be supported"));
+            assert_eq!(info.language, lang, "{ext} routed to wrong language");
+            assert!(
+                info.refs_query.is_some(),
+                "{ext} should carry a refs query after this slice"
+            );
+        }
+        // C and C++ stay regex-fallback this round — guard so a future
+        // change can't silently slip them in without updating tests.
+        for ext in ["a.c", "a.h", "a.cpp", "a.hpp"] {
+            assert!(
+                info_for_path(ext).unwrap().refs_query.is_none(),
+                "{ext} should stay regex-fallback (C/C++ deferred)"
+            );
+        }
+    }
+
+    #[test]
+    fn java_php_swift_csharp_cached_queries_construct_without_panic() {
+        // Forces `Query::new` for each grammar so a query-vs-grammar
+        // mismatch surfaces at unit-test time, not at first
+        // `Index.Outline` call in production.
+        for ext in ["Main.java", "Index.php", "App.swift", "Program.cs"] {
+            let info = info_for_path(ext).unwrap();
+            let q = cached_refs_query(&info);
+            assert!(
+                q.is_some(),
+                "{ext}: refs query failed to construct — check against the current grammar"
+            );
+        }
     }
 
     #[test]

--- a/crates/rts-daemon/src/refs.rs
+++ b/crates/rts-daemon/src/refs.rs
@@ -26,17 +26,11 @@
 //!
 //! ### Scope (v0)
 //!
-//! Tags.scm precision is wired for **Rust, Python, Go, Ruby** — the
-//! four languages whose upstream `tree-sitter-*/queries/tags.scm`
-//! ships clean `@reference.call` (and `@reference.implementation`
-//! for Rust) captures with `@name` sub-captures.
-//!
-//! For the other seven languages (C, C++, Java, JavaScript, TypeScript,
-//! PHP, Swift), the upstream tags.scm either omits `@reference.*`
-//! captures or uses different conventions. Those fall through to the
-//! existing regex tokenizer — **no regression** vs alpha.26. A v1.1
-//! slice adds locally-authored query overrides for the remaining
-//! languages once they have a concrete user asking.
+//! Tags.scm precision is wired for **Rust, Python, Go, Ruby,
+//! JavaScript, TypeScript, Java, PHP, Swift, C#** — 10 of the 12
+//! indexed languages. C and C++ stay on the regex tokenizer for now
+//! (function-pointer calls look identical to identifier references,
+//! so the precision win is smaller).
 
 use rust_tree_sitter::{Language, Parser, query::Query};
 
@@ -143,14 +137,13 @@ pub(crate) fn references_for_path(rel_path: &str, content: &str) -> Vec<String> 
 /// writer (v0.3 U1) to populate the persistent ref graph.
 ///
 /// For languages with a tags.scm reference query (Rust, Python, Go,
-/// Ruby, JavaScript, TypeScript), each hit carries a precise byte
-/// range from the `@name` capture. For fallback-regex languages
-/// (C, C++, Java, PHP, Swift) we synthesize the byte range as
-/// `start = end = 0` and 1-based `start_line = end_line = 1` —
-/// enough to populate the index for "who calls X?" queries but not
-/// precise enough for "show me the call site." This trade-off
-/// matches v0.2 behavior: those languages already use the regex
-/// path for closure-walker identifier extraction.
+/// Ruby, JavaScript, TypeScript, Java, PHP, Swift, C#), each hit
+/// carries a precise byte range from the `@name` capture. For the
+/// remaining regex-fallback languages (C, C++) we synthesize the
+/// byte range as `start = end = 0` and 1-based
+/// `start_line = end_line = 1` — enough to populate the index for
+/// "who calls X?" queries but not precise enough for "show me the
+/// call site."
 pub(crate) fn references_with_ranges(rel_path: &str, content: &str) -> Vec<RefHit> {
     if let Some(info) = crate::language::info_for_path(rel_path) {
         if let Some(query) = crate::language::cached_refs_query(&info) {
@@ -350,16 +343,148 @@ function caller(): JSX.Element {
     }
 
     #[test]
-    fn unsupported_language_returns_none_from_extract() {
-        // Java isn't wired in this slice; should return None and let
-        // the dispatcher fall through.
-        // (We can't pass an unsupported Language variant — the enum is
-        // exhaustive — but we can confirm the path-driven dispatcher
-        // routes via the regex.)
-        let src = "public class C { void f() { other(); } }";
-        let refs = references_for_path("X.java", src);
-        // Regex fallback picks up everything, including class/void/etc.
-        // The point is: it returns something non-empty.
-        assert!(!refs.is_empty());
+    fn java_references_capture_calls_and_object_creation() {
+        // `other()` is a call site; `new Widget()` is object creation.
+        // `local` is a local variable — regex tokenizer would include
+        // it; tags.scm-style query does not.
+        let src = "\
+public class C {
+    void caller() {
+        int local = 0;
+        other(local);
+        Widget w = new Widget(local);
+    }
+}";
+        let refs = references_for_path("C.java", src);
+        assert!(
+            refs.iter().any(|n| n == "other"),
+            "method call should be captured; got {refs:?}"
+        );
+        assert!(
+            refs.iter().any(|n| n == "Widget"),
+            "object creation should be captured; got {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|n| n == "local"),
+            "local var should not be a ref; got {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|n| n == "caller"),
+            "caller is a def, not a ref; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn php_references_capture_calls_member_and_static() {
+        // Mixes function call, member call, scoped (static) call,
+        // namespace-qualified call, and `new`. All should resolve;
+        // `$x` local variable should not.
+        let src = "<?php
+function caller() {
+    $x = 0;
+    bare_call($x);
+    $obj->member_call();
+    Klass::static_call();
+    \\Foo\\namespaced_call();
+    $w = new Widget();
+}
+";
+        let refs = references_for_path("a.php", src);
+        for expected in [
+            "bare_call",
+            "member_call",
+            "static_call",
+            "namespaced_call",
+            "Widget",
+        ] {
+            assert!(
+                refs.iter().any(|n| n == expected),
+                "expected {expected:?} in php refs; got {refs:?}"
+            );
+        }
+        assert!(
+            !refs.iter().any(|n| n == "x"),
+            "variable name should not be a ref; got {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|n| n == "caller"),
+            "caller is a def, not a ref; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn swift_references_capture_bare_and_method_calls() {
+        // Bare call, method call via navigation, and a trailing-closure
+        // call should all resolve.
+        let src = "\
+func caller() {
+    let local = 0
+    bareCall(local)
+    obj.methodName()
+    runWithClosure { _ in }
+}
+";
+        let refs = references_for_path("App.swift", src);
+        assert!(
+            refs.iter().any(|n| n == "bareCall"),
+            "bare call should be captured; got {refs:?}"
+        );
+        assert!(
+            refs.iter().any(|n| n == "methodName"),
+            "method call should be captured; got {refs:?}"
+        );
+        assert!(
+            refs.iter().any(|n| n == "runWithClosure"),
+            "trailing-closure call should be captured; got {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|n| n == "local"),
+            "local var should not be a ref; got {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|n| n == "caller"),
+            "caller is a def, not a ref; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn csharp_references_capture_calls_generics_and_new() {
+        // Bare, member, generic, generic-member, and `new` — all
+        // shapes should resolve. `local` should not.
+        let src = "\
+class C {
+    void Caller() {
+        int local = 0;
+        Bare(local);
+        obj.MemberCall(local);
+        Generic<int>(local);
+        obj.GenericMember<int>(local);
+        var w = new Widget(local);
+        var lst = new List<int>();
+    }
+}
+";
+        let refs = references_for_path("Program.cs", src);
+        for expected in [
+            "Bare",
+            "MemberCall",
+            "Generic",
+            "GenericMember",
+            "Widget",
+            "List",
+        ] {
+            assert!(
+                refs.iter().any(|n| n == expected),
+                "expected {expected:?} in c# refs; got {refs:?}"
+            );
+        }
+        assert!(
+            !refs.iter().any(|n| n == "local"),
+            "local var should not be a ref; got {refs:?}"
+        );
+        assert!(
+            !refs.iter().any(|n| n == "Caller"),
+            "Caller is a def, not a ref; got {refs:?}"
+        );
     }
 }

--- a/crates/rts-daemon/tests/call_edges_csharp.rs
+++ b/crates/rts-daemon/tests/call_edges_csharp.rs
@@ -1,0 +1,204 @@
+//! End-to-end test: C# call edges resolve via `Index.FindCallers`.
+//!
+//! Exercises:
+//!   - bare invocation: `Bare()`
+//!   - member-access invocation: `obj.MemberCall()`
+//!   - generic invocation: `Generic<int>()`
+//!   - object creation: `new Widget()`
+//!   - generic object creation: `new List<int>()`
+//!
+//! The generic variants are the C#-specific edge case the AST query
+//! has to cover (`function: (generic_name (identifier))` vs the
+//! simpler bare `function: (identifier)`).
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn csharp_generic_and_member_calls_resolve() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // Targets — bare, member, generic, and a `new`-able class.
+    std::fs::write(
+        workspace.path().join("Targets.cs"),
+        "class Targets {\n\
+             public static void Bare() {}\n\
+             public void MemberCall() {}\n\
+             public static T Generic<T>(T x) { return x; }\n\
+         }\n\
+         class Widget {\n\
+             public Widget() {}\n\
+         }\n",
+    )?;
+
+    std::fs::write(
+        workspace.path().join("Caller.cs"),
+        "class Caller {\n\
+             public void CallerEntry() {\n\
+                 Targets.Bare();\n\
+                 var t = new Targets();\n\
+                 t.MemberCall();\n\
+                 Targets.Generic<int>(42);\n\
+                 var w = new Widget();\n\
+             }\n\
+         }\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+
+    for sym in ["Bare", "MemberCall", "Generic", "Widget", "CallerEntry"] {
+        wait_for_symbol(&mut stream, sym, Duration::from_secs(5)).await?;
+    }
+
+    for target in ["Bare", "MemberCall", "Generic", "Widget"] {
+        let resp = round_trip(
+            &mut stream,
+            "10",
+            "Index.FindCallers",
+            json!({ "name": target }),
+        )
+        .await?;
+        assert!(
+            resp["error"].is_null(),
+            "find_callers({target}) failed: {resp:?}"
+        );
+        let names: Vec<String> = resp["result"]["callers"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|c| c["enclosing_qualified_name"].as_str().map(String::from))
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "CallerEntry"),
+            "expected CallerEntry to call {target}; got {names:?}"
+        );
+    }
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}

--- a/crates/rts-daemon/tests/call_edges_java.rs
+++ b/crates/rts-daemon/tests/call_edges_java.rs
@@ -1,0 +1,226 @@
+//! End-to-end test: Java call edges resolve via `Index.FindCallers`.
+//!
+//! Fixture exercises the chained-call edge case (`a.b().c()`): both
+//! `b` and `c` should appear as call sites, but the receiver `a` —
+//! which is just a local variable reference, not a method call —
+//! must not. Object creation (`new Widget()`) should also resolve.
+//!
+//! Why this matters: pre-AST-precise edges, the Java regex fallback
+//! emitted an edge for every identifier-shaped token in the file,
+//! including variable names and class-name occurrences in comments
+//! or strings. This test pins the behavior: only method calls and
+//! `new` are call edges.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn java_chained_calls_resolve_method_level_edges() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // Targets we want callers for.
+    std::fs::write(
+        workspace.path().join("Targets.java"),
+        "public class Targets {\n\
+             public Targets bMethod() { return this; }\n\
+             public void cMethod() {}\n\
+             public Targets nested() { return this; }\n\
+         }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("Widget.java"),
+        "public class Widget {\n\
+             public Widget() {}\n\
+         }\n",
+    )?;
+
+    // Caller exercising chained `a.bMethod().cMethod()` plus `new Widget()`.
+    // `a` is a local — must NOT show up as a caller of any symbol.
+    std::fs::write(
+        workspace.path().join("Caller.java"),
+        "public class Caller {\n\
+             public void callerEntry() {\n\
+                 Targets a = new Targets();\n\
+                 a.bMethod().cMethod();\n\
+                 Widget w = new Widget();\n\
+             }\n\
+         }\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+
+    wait_for_symbol(&mut stream, "bMethod", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "cMethod", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "callerEntry", Duration::from_secs(5)).await?;
+
+    // Both `b` and `c` in `a.bMethod().cMethod()` should show
+    // `callerEntry` as a caller — separate `method_invocation` nodes.
+    for target in ["bMethod", "cMethod", "Widget"] {
+        let resp = round_trip(
+            &mut stream,
+            "10",
+            "Index.FindCallers",
+            json!({ "name": target }),
+        )
+        .await?;
+        assert!(
+            resp["error"].is_null(),
+            "find_callers({target}) failed: {resp:?}"
+        );
+        let callers = resp["result"]["callers"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        let names: Vec<&str> = callers
+            .iter()
+            .filter_map(|c| c["enclosing_qualified_name"].as_str())
+            .collect();
+        assert!(
+            names.contains(&"callerEntry"),
+            "expected callerEntry as caller of {target}; got {names:?}"
+        );
+    }
+
+    // The receiver `a` is a local Targets-typed variable, not a
+    // method — there is no such method-name def, so FindCallers
+    // returns SYMBOL_NOT_FOUND. This is the precise behavior we
+    // want: regex fallback would have emitted an `a` edge.
+    let missing = round_trip(
+        &mut stream,
+        "20",
+        "Index.FindCallers",
+        json!({ "name": "a" }),
+    )
+    .await?;
+    assert_eq!(
+        missing["error"]["code"], "SYMBOL_NOT_FOUND",
+        "local variable `a` should not have a def to call; got {missing:?}"
+    );
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}

--- a/crates/rts-daemon/tests/call_edges_php.rs
+++ b/crates/rts-daemon/tests/call_edges_php.rs
@@ -1,0 +1,211 @@
+//! End-to-end test: PHP call edges resolve via `Index.FindCallers`.
+//!
+//! Exercises three call shapes the AST query covers and the symbol
+//! extractor today indexes targets for:
+//!   1. bare function call: `bare_target()`
+//!   2. namespace-qualified call: `\namespaced_target()`
+//!   3. object creation: `new Klass()`
+//!
+//! Member-call (`$obj->method_target()`) and scoped-call
+//! (`Klass::static_target()`) capture correctly in the AST query
+//! (see the `php_references_capture_calls_member_and_static` unit
+//! test in `refs.rs`), but `extract_php_symbols` does not currently
+//! index `method_declaration` defs — so end-to-end `FindCallers`
+//! on those targets is blocked by a pre-existing PHP-symbol-extractor
+//! gap, not by the call-edge AST query. Out of scope for this slice.
+//!
+//! Variable-function `$fn()` is intentionally NOT a call edge in the
+//! AST query (no static target); regex fallback would have included
+//! it as junk.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn php_bare_namespaced_and_new_calls_resolve() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    std::fs::write(
+        workspace.path().join("targets.php"),
+        "<?php\n\
+         function bare_target() {}\n\
+         function namespaced_target() {}\n\
+         class Klass {\n\
+             public function member_target() {}\n\
+             public static function static_target() {}\n\
+         }\n",
+    )?;
+
+    // Includes member and scoped calls so the AST query is exercised
+    // even though their target defs aren't indexed yet (see file-level
+    // comment).
+    std::fs::write(
+        workspace.path().join("caller.php"),
+        "<?php\n\
+         function caller_entry() {\n\
+             bare_target();\n\
+             $obj = new Klass();\n\
+             $obj->member_target();\n\
+             Klass::static_target();\n\
+             \\namespaced_target();\n\
+         }\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+
+    for sym in ["bare_target", "namespaced_target", "Klass", "caller_entry"] {
+        wait_for_symbol(&mut stream, sym, Duration::from_secs(5)).await?;
+    }
+
+    for target in ["bare_target", "namespaced_target", "Klass"] {
+        let resp = round_trip(
+            &mut stream,
+            "10",
+            "Index.FindCallers",
+            json!({ "name": target }),
+        )
+        .await?;
+        assert!(
+            resp["error"].is_null(),
+            "find_callers({target}) failed: {resp:?}"
+        );
+        let names: Vec<String> = resp["result"]["callers"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|c| c["enclosing_qualified_name"].as_str().map(String::from))
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "caller_entry"),
+            "expected caller_entry to call {target}; got {names:?}"
+        );
+    }
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}

--- a/crates/rts-daemon/tests/call_edges_swift.rs
+++ b/crates/rts-daemon/tests/call_edges_swift.rs
@@ -1,0 +1,192 @@
+//! End-to-end test: Swift call edges resolve via `Index.FindCallers`.
+//!
+//! Exercises:
+//!   - bare function call
+//!   - trailing-closure call (which still parses as `call_expression`
+//!     and should yield a normal call edge)
+//!
+//! Trailing closures are the Swift-specific edge case the AST query
+//! has to cover; regex fallback would have lumped the closure body's
+//! identifiers in as "calls" too.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn swift_trailing_closure_call_resolves() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    std::fs::write(
+        workspace.path().join("Targets.swift"),
+        "func bareTarget() {}\n\
+         func closureTarget(_ block: () -> Void) {}\n",
+    )?;
+
+    std::fs::write(
+        workspace.path().join("Caller.swift"),
+        "func callerEntry() {\n\
+             bareTarget()\n\
+             closureTarget {\n\
+                 // body intentionally references no symbols\n\
+             }\n\
+         }\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+
+    for sym in ["bareTarget", "closureTarget", "callerEntry"] {
+        wait_for_symbol(&mut stream, sym, Duration::from_secs(5)).await?;
+    }
+
+    for target in ["bareTarget", "closureTarget"] {
+        let resp = round_trip(
+            &mut stream,
+            "10",
+            "Index.FindCallers",
+            json!({ "name": target }),
+        )
+        .await?;
+        assert!(
+            resp["error"].is_null(),
+            "find_callers({target}) failed: {resp:?}"
+        );
+        let names: Vec<String> = resp["result"]["callers"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|c| c["enclosing_qualified_name"].as_str().map(String::from))
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "callerEntry"),
+            "expected callerEntry to call {target}; got {names:?}"
+        );
+    }
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}


### PR DESCRIPTION
## Summary

Adds `@reference.call` tree-sitter queries for **Java**, **PHP**, **Swift**, and **C#**, raising AST-precise call-edge coverage from **6 of 12 indexed languages** (Rust/Python/Go/Ruby/JS/TS) to **10 of 12**. C and C++ remain on the regex fallback — function pointers and identifier references are syntactically indistinguishable there, so the precision win is materially smaller; tracked as an optional follow-on per the plan.

Implementation is purely additive in `crates/rts-daemon/src/language.rs`:

- 4 new `&'static str` query constants (`JAVA_REFS`, `PHP_REFS`, `SWIFT_REFS`, `CSHARP_REFS`) authored against each grammar's installed `node-types.json` and `queries/tags.scm`.
- 4 new `OnceLock<Option<Query>>` cells wired into `cached_refs_query`.
- 4 entries in `info_for_path` flipped from `refs_query: None` to `Some(..._REFS)`.

No new dependencies. No `unsafe`. The hot path (`refs::extract_references`) is unchanged — the only delta is more `@name` strings flowing through it for these 4 languages.

## Edge cases handled

- **Java** — chained `a.b().c()` parses as nested `method_invocation` nodes (the outer wraps the inner via `object:`). Both `b` and `c` capture as separate call sites; the receiver `a` never appears as a `name:` field. `object_creation_expression.type:` covers `new Widget()`.
- **PHP** — covers `function_call_expression` (including `(qualified_name (name))` for `\Foo\bar()`), `member_call_expression` (for `$obj->method()`), `scoped_call_expression` (for `Klass::method()`), and `object_creation_expression` (both bare `(name)` and namespaced `(qualified_name (name))` children). Variable-function `$fn()` is intentionally not captured — there's no static target to resolve.
- **Swift** — authored against the installed Swift 0.7 grammar's `node-types.json`; upstream `queries/tags.scm` only ships `@definition.*`. `call_expression (simple_identifier)` for bare calls; `call_expression (navigation_expression (navigation_suffix suffix: (simple_identifier)))` for method calls. Trailing closures `foo { ... }` still parse as `call_expression`, so they're covered without a separate pattern.
- **C#** — four invocation shapes: bare `identifier`, `member_access_expression`, generic `(generic_name (identifier))`, and member-access-of-generic-name. Plus `object_creation_expression` for `new Foo()` and `new Foo<T>()`. Generic-method invocations like `Foo<int>()` parse the function as a `generic_name`, not as a bare `identifier`, so they require the third invocation pattern; without it every generic call site is invisible.

## Swift 0.7 grammar status

The plan flagged a risk that Swift 0.7 might lack the node names assumed in modern `tags.scm` examples. Verification against the installed grammar's `node-types.json` confirmed `call_expression`, `navigation_expression`, `navigation_suffix`, and `simple_identifier` all exist with the expected field shape. No grammar upgrade needed in this PR.

## Tests

- **Unit tests** in `crates/rts-daemon/src/refs.rs`:
  - `java_references_capture_calls_and_object_creation` — asserts method calls + `new` are captured and local variables are NOT.
  - `php_references_capture_calls_member_and_static` — asserts all four call shapes resolve and `$x` does not.
  - `swift_references_capture_bare_and_method_calls` — includes a trailing-closure call.
  - `csharp_references_capture_calls_generics_and_new` — includes generic and generic-member shapes.
- **Query-compile smoke tests** in `crates/rts-daemon/src/language.rs`:
  - `java_php_swift_csharp_have_refs_query` — guards the table entries.
  - `java_php_swift_csharp_cached_queries_construct_without_panic` — forces `Query::new` for each grammar at unit-test time so grammar drift surfaces here, not at first `Index.Outline` call in production.
- **Integration tests** under `crates/rts-daemon/tests/`:
  - `call_edges_java.rs` — Java fixture with chained `a.bMethod().cMethod()` + `new Widget()`; asserts `Index.FindCallers` returns `callerEntry` as a caller of `bMethod`, `cMethod`, and `Widget`, but `a` (a local) returns `SYMBOL_NOT_FOUND`.
  - `call_edges_php.rs` — covers bare, namespaced, and object-creation call shapes via `Index.FindCallers`. Member-call (`$obj->method()`) and scoped-call (`Klass::static()`) capture correctly in the AST query (verified in the `php_references_capture_calls_member_and_static` unit test) but the existing `extract_php_symbols` does not currently index `method_declaration` defs — out of scope for this slice; documented inline.
  - `call_edges_swift.rs` — bareCall + trailing-closure call, both resolve via `Index.FindCallers`.
  - `call_edges_csharp.rs` — bare, member, generic, and `new` shapes, all resolve via `Index.FindCallers`.

## Regression coverage

Existing call-edge tests verified passing locally after this change:

- `refs::tests::rust_references_capture_call_sites_only`
- `refs::tests::rust_references_pick_up_macros_and_method_calls`
- `refs::tests::python_references_capture_calls_only`
- `refs::tests::javascript_references_capture_calls_and_new`
- `refs::tests::typescript_references_capture_calls_and_new`
- `refs::tests::typescript_tsx_alias_uses_same_query`
- `refs::tests::references_for_path_uses_tags_for_rust`
- `refs::tests::references_for_path_falls_back_to_regex_on_unknown_lang`
- All existing language-dispatch tests in `language::tests`
- `find_callers_round_trip` integration test (Rust hub-spoke)
- Full `cargo test -p rts-daemon` suite (236 unit tests + all integration tests pass)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p rts-daemon -p rts-mcp -p rts-bench --all-targets` clean (no new warnings introduced)
- [x] `cargo test -p rts-daemon` passes (existing + 4 new integration tests + new unit tests)
- [x] No `unsafe` blocks (workspace-wide `unsafe_code = "deny"` upheld)
- [x] No new external dependencies
- [x] README "language coverage" sentence updated: 6→10 languages
- [x] Changelog fragment added under `changelog.d/`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: queries are static; failures surface at query-compilation time which is integration-tested. Indexing metrics in `Daemon.Stats` are unchanged.

---

🤖 Generated with Claude Sonnet 4.5 (1M context) via Claude Code + Compound Engineering v2.49.0

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>