### PR TITLE
feat(rts-mcp): connection-manager resilience — heartbeat, reconnect, structured disconnection

### DIFF
--- a/changelog.d/xxx-feat-mcp-connection-resilience.md
+++ b/changelog.d/xxx-feat-mcp-connection-resilience.md
@@ -1,0 +1,49 @@
+### MCP shim resilience — heartbeat, reconnect-with-backoff, structured disconnection
+
+`rts-mcp` and `rts` no longer drop off the tool list when the daemon hiccups. A background heartbeat detects daemon death proactively, a bounded reconnect loop auto-respawns the daemon, and tool calls during the disconnect window return new structured `DAEMON_UNAVAILABLE` / `DAEMON_DOWN` JSON-RPC error codes so agents can branch on transient vs. sustained outage without parsing English text.
+
+#### What
+
+**New `crates/rts-mcp/src/connection.rs` module.** A `ConnectionManager` wraps the per-workspace `DaemonClient` plus two background tokio tasks:
+
+- **Heartbeat loop.** Issues `Daemon.Ping` every `RTS_MCP_HEARTBEAT_INTERVAL_SECS` (default 10s) with a per-call timeout of `RTS_MCP_HEARTBEAT_TIMEOUT_SECS` (default 3s). A failed ping demotes state to `Reconnecting`.
+- **Reconnect-with-backoff.** Schedule `1s, 2s, 4s, 8s, 16s, 30s, 30s, 30s` (configurable via `RTS_MCP_RECONNECT_MAX_ATTEMPTS` default 8 and `RTS_MCP_RECONNECT_CEILING_SECS` default 30). After the bounded attempts state transitions to `Down`, but retries continue at the ceiling forever — transient outages of arbitrary length still recover.
+
+**Three-state machine** (`Connected | Reconnecting | Down`) wrapped in `Arc<RwLock<…>>`. Tool calls take a read lock briefly to check state — calls during a known disconnect window short-circuit at the state check and return the structured error without touching the daemon mutex, so a burst of N concurrent calls during reconnect costs O(1) on the daemon mutex, not O(N).
+
+**Two new MCP-shim error codes** (shim-emitted; not daemon protocol-v0 codes):
+
+- `DAEMON_UNAVAILABLE` (numeric `-32098`) — transient. `error.data.retry_after_ms` carries the wall-clock hint until the next reconnect attempt. `error.data.transient: true`.
+- `DAEMON_DOWN` (numeric `-32097`) — sustained outage after bounded-attempt exhaustion. `error.data.first_failure_ms_ago` describes how long the daemon has been unreachable. `error.data.transient: false`.
+
+**Cross-binary parity.** Both `rts-mcp` (the MCP shim) AND the `rts` human-facing CLI binary (PR #113) use the same `ConnectionManager`. The CLI disables the background heartbeat (single-shot — no point spawning a task we'll abort 50 ms later) but still benefits from the foreground reconnect-on-transport-error path. Source: `crates/rts-mcp/src/cli.rs::connect`.
+
+**Heartbeat ↔ idle-shutdown interaction.** `Daemon.Ping` resets the daemon's `last_activity`. The daemon's idle-shutdown is already gated on `active_connections > 0` (`crates/rts-daemon/src/state.rs::is_idle`), but the heartbeat additionally refreshes activity so a future loosening of the connection-count gate still sees fresh traffic. **An MCP shim that's still attached keeps its daemon alive — this is intentional.** Documented in code comments + protocol-v0 §14.1.
+
+#### Why this matters
+
+Round-11 dogfood surfaced the failure mode: the rts MCP server silently disconnected mid-session, the agent received only a "their MCP server disconnected" system reminder, and `mcp__rts__*` tools dropped off the tool list with no error and no recovery path. Three diagnosable failure modes:
+
+1. **No heartbeat.** A single transport error was terminal; the shim sat on a dead socket until the next tool call hit `Broken pipe`.
+2. **No reconnect.** Disconnections compounded — the agent worked around once; the second disconnection taught the agent to default to `Bash(grep)` permanently.
+3. **No structured transient-error code.** `INTERNAL_ERROR broken pipe` was indistinguishable from "this method doesn't exist" to the MCP host.
+
+For a project whose entire pitch is "AST-precise code retrieval for AI agents," **a tool that abandons agents on first flake is a tool agents won't come back to.** This change closes the gap with shapes proven in gRPC keepalive, HTTP/2 GOAWAY, and Tower's retry stack.
+
+#### Verification
+
+- Full plan: [`docs/plans/2026-05-19-004-feat-mcp-server-resilience-plan.md`](../docs/plans/2026-05-19-004-feat-mcp-server-resilience-plan.md)
+- New integration test `crates/rts-mcp/tests/connection_resilience.rs` covers the four plan scenarios end-to-end against real binaries:
+  1. **Daemon idle-shutdown survival** — `RTS_IDLE_SHUTDOWN_SECS=2`, idle 5s, next tool call succeeds.
+  2. **Daemon SIGKILL recovery** — kill daemon, observe `DAEMON_UNAVAILABLE`, subsequent calls succeed via auto-respawn.
+  3. **MCP shim crash leaves daemon alive** — kill shim 1, shim 2 connects to the SAME daemon PID.
+  4. **Concurrent tool calls during reconnect** — 10 concurrent calls return consistent `DAEMON_UNAVAILABLE` shapes with bounded `retry_after_ms` hints; no thundering-herd.
+- Unit tests for the backoff schedule (`1s, 2s, 4s, 8s, 16s, 30s, 30s, 30s`), error-code round-trip, and `ResilienceConfig` defaults.
+- Protocol-v0 §14.1 documents the new error codes and env vars.
+- v1.x daemons unaffected — shim is the sole owner of resilience state; daemon wire protocol is byte-identical.
+
+#### Out of scope (filed for follow-up)
+
+- **`Daemon.Stats` disconnection counters** (`disconnections.total`, `disconnections.last_at_ms`, `disconnections.last_duration_ms`). Better folded into the opt-in telemetry plan than dragged into this PR — sibling-field pattern reserved for that landing.
+- **MCP protocol-level reconnect** (shim → MCP host). That's the host's responsibility; out of scope per the plan.
+- **Multi-daemon failover.** Single-process daemon is the only supported topology in v0.6.

--- a/crates/rts-mcp/src/bin/rts.rs
+++ b/crates/rts-mcp/src/bin/rts.rs
@@ -249,13 +249,14 @@ async fn run_command(
     workspace: &std::path::Path,
     style: &Style,
 ) -> Result<i32, CmdError> {
-    let mut client = cli::connect(workspace).await?;
+    let client = cli::connect(workspace).await?;
 
     match &cli.cmd {
         Cmd::Mount { path } => {
-            // The connect() step has already issued Mount, but a CLI
-            // user typing `rts mount` deserves explicit confirmation
-            // (and lets us print the workspace id).
+            // The connect() + first-call lazy-Mount handle the mount
+            // implicitly. A CLI user typing `rts mount` deserves
+            // explicit confirmation, so we still issue an explicit
+            // `Workspace.Mount` here (daemon makes it idempotent).
             let target = path
                 .as_deref()
                 .map(|p| {
@@ -285,7 +286,7 @@ async fn run_command(
                     }
                     Ok(exit::OK)
                 }
-                Err(e) => Ok(cli::render_daemon_error(&e, style)),
+                Err(e) => Ok(cli::render_connection_error(&e, style)),
             }
         }
         Cmd::Find {
@@ -311,7 +312,7 @@ async fn run_command(
                 params.insert("limit".into(), Value::Number((*n).into()));
             }
             let body = match cli::call_method(
-                &mut client,
+                &client,
                 workspace,
                 "Index.FindSymbol",
                 Value::Object(params),
@@ -319,7 +320,7 @@ async fn run_command(
             .await
             {
                 Ok(v) => v,
-                Err(e) => return Ok(cli::render_daemon_error(&e, style)),
+                Err(e) => return Ok(cli::render_connection_error(&e, style)),
             };
             if cli.json {
                 println!(
@@ -360,11 +361,11 @@ async fn run_command(
                 params.insert("limit".into(), Value::Number((*n).into()));
             }
             let body =
-                match cli::call_method(&mut client, workspace, "Index.Grep", Value::Object(params))
+                match cli::call_method(&client, workspace, "Index.Grep", Value::Object(params))
                     .await
                 {
                     Ok(v) => v,
-                    Err(e) => return Ok(cli::render_daemon_error(&e, style)),
+                    Err(e) => return Ok(cli::render_connection_error(&e, style)),
                 };
             if cli.json {
                 println!(
@@ -394,7 +395,7 @@ async fn run_command(
                 params.insert("file".into(), Value::String(f.clone()));
             }
             let body = match cli::call_method(
-                &mut client,
+                &client,
                 workspace,
                 "Index.FindCallers",
                 Value::Object(params),
@@ -402,7 +403,7 @@ async fn run_command(
             .await
             {
                 Ok(v) => v,
-                Err(e) => return Ok(cli::render_daemon_error(&e, style)),
+                Err(e) => return Ok(cli::render_connection_error(&e, style)),
             };
             if cli.json {
                 println!(
@@ -429,17 +430,13 @@ async fn run_command(
             if let Some(b) = token_budget {
                 params.insert("token_budget".into(), Value::Number((*b).into()));
             }
-            let body = match cli::call_method(
-                &mut client,
-                workspace,
-                "Index.Outline",
-                Value::Object(params),
-            )
-            .await
-            {
-                Ok(v) => v,
-                Err(e) => return Ok(cli::render_daemon_error(&e, style)),
-            };
+            let body =
+                match cli::call_method(&client, workspace, "Index.Outline", Value::Object(params))
+                    .await
+                {
+                    Ok(v) => v,
+                    Err(e) => return Ok(cli::render_connection_error(&e, style)),
+                };
             if cli.json {
                 println!(
                     "{}",
@@ -470,7 +467,7 @@ async fn run_command(
                 params.insert("kind".into(), Value::String(k.clone()));
             }
             let body = match cli::call_method(
-                &mut client,
+                &client,
                 workspace,
                 "Index.ReadSymbol",
                 Value::Object(params),
@@ -478,7 +475,7 @@ async fn run_command(
             .await
             {
                 Ok(v) => v,
-                Err(e) => return Ok(cli::render_daemon_error(&e, style)),
+                Err(e) => return Ok(cli::render_connection_error(&e, style)),
             };
             if cli.json {
                 println!(
@@ -493,11 +490,10 @@ async fn run_command(
             Ok(if n == 0 { exit::NO_RESULTS } else { exit::OK })
         }
         Cmd::Stats => {
-            let body =
-                match cli::call_method(&mut client, workspace, "Daemon.Stats", json!({})).await {
-                    Ok(v) => v,
-                    Err(e) => return Ok(cli::render_daemon_error(&e, style)),
-                };
+            let body = match cli::call_method(&client, workspace, "Daemon.Stats", json!({})).await {
+                Ok(v) => v,
+                Err(e) => return Ok(cli::render_connection_error(&e, style)),
+            };
             if cli.json {
                 println!(
                     "{}",

--- a/crates/rts-mcp/src/cli.rs
+++ b/crates/rts-mcp/src/cli.rs
@@ -10,7 +10,8 @@ use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
-use crate::daemon_client::{DaemonClient, DaemonError};
+use crate::connection::{ConnectionError, ConnectionManager, ResilienceConfig};
+use crate::daemon_client::DaemonClient;
 use crate::socket;
 
 /// Documented exit-code contract for the `rts` binary.
@@ -155,7 +156,20 @@ impl Style {
 /// `RTS_NO_AUTOSPAWN=1` disables the spawn — if the socket isn't there,
 /// we error out instead of starting a daemon (useful in CI / sandboxed
 /// environments where the user wants to manage the daemon lifecycle).
-pub async fn connect(workspace: &Path) -> anyhow::Result<DaemonClient> {
+///
+/// v0.6+: returns a [`ConnectionManager`] (Plan 004) rather than a bare
+/// [`DaemonClient`]. The manager owns the socket and exposes the same
+/// `call()` API the MCP shim uses; background heartbeat is *disabled*
+/// for the CLI (single-shot — no point spawning a task we'll abort
+/// 50 ms later) but the foreground reconnect-on-transport-error path
+/// still fires, so a CLI invocation that races a daemon restart
+/// transparently auto-spawns a fresh daemon instead of bailing.
+///
+/// Cross-binary parity: same code path the MCP shim's `main.rs` uses,
+/// minus the background heartbeat. The structured `DAEMON_UNAVAILABLE`
+/// / `DAEMON_DOWN` errors surface via the manager and get mapped to
+/// the documented CLI exit codes by [`render_connection_error`].
+pub async fn connect(workspace: &Path) -> anyhow::Result<ConnectionManager> {
     let daemon_bin = socket::resolve_daemon_bin()?;
 
     let no_autospawn = std::env::var_os("RTS_NO_AUTOSPAWN")
@@ -195,46 +209,51 @@ pub async fn connect(workspace: &Path) -> anyhow::Result<DaemonClient> {
             })?
     };
 
-    Ok(DaemonClient::new(
-        stream,
+    let client = DaemonClient::new(stream, daemon_bin.clone(), workspace.to_path_buf());
+    Ok(ConnectionManager::new(
+        client,
         daemon_bin,
         workspace.to_path_buf(),
+        ResilienceConfig::from_env(),
+        /* start_background_tasks */ false,
     ))
 }
 
-/// Mount + one RPC. Every CLI invocation is a single-shot — we Mount on
-/// the connection (idempotent on the daemon side) and then call the
-/// requested method. The daemon's per-workspace socket means concurrent
-/// `rts` calls share state through the daemon, not the connection.
+/// Mount + one RPC. Every CLI invocation is a single-shot — the
+/// connection manager handles Mount lazily on the first call, so this
+/// function is now a thin alias over `ConnectionManager::call`. The
+/// `workspace` parameter is unused by the manager (it tracks the path
+/// internally) and kept in the signature for source-compatibility
+/// with the pre-resilience CLI; future cleanups may drop it.
 pub async fn call_method(
-    client: &mut DaemonClient,
-    workspace: &Path,
+    client: &ConnectionManager,
+    _workspace: &Path,
     method: &str,
     params: Value,
-) -> Result<Value, DaemonError> {
-    // Mount first. The daemon makes Mount idempotent (§5.4) so repeated
-    // calls from the CLI don't reset anything.
-    let _ = client
-        .call("Workspace.Mount", serde_json::json!({ "root": workspace }))
-        .await?;
+) -> Result<Value, ConnectionError> {
     client.call(method, params).await
 }
 
-/// Map a `DaemonError` to a user-friendly stderr message and an exit
-/// code. `INDEX_NOT_READY` typically resolves in tens of milliseconds
-/// on a warm daemon; on the cold path the CLI will block on the Mount
-/// itself, so we don't add a polling loop here.
-pub fn render_daemon_error(e: &DaemonError, style: &Style) -> i32 {
+/// Map a `ConnectionError` to a user-friendly stderr message and an
+/// exit code. Pre-resilience this took a bare `DaemonError`; the
+/// signature now accepts a `ConnectionError` so it can render the
+/// new `DAEMON_UNAVAILABLE` / `DAEMON_DOWN` shapes with their
+/// `retry_after_ms` hints.
+///
+/// Both transient (`DAEMON_UNAVAILABLE`) and sustained (`DAEMON_DOWN`)
+/// disconnections map to exit code `3` (`DAEMON_ERROR`); a future
+/// release could split these but the CLI contract today is "any
+/// daemon-side problem returns 3."
+pub fn render_connection_error(e: &ConnectionError, style: &Style) -> i32 {
     eprintln!(
         "{}: {} ({})",
         style.red("rts error"),
-        e.message,
-        style.dim(&e.code)
+        e.message(),
+        style.dim(e.code())
     );
-    if e.code == "DEADLINE_EXCEEDED" {
-        exit::TIMEOUT
-    } else {
-        exit::DAEMON_ERROR
+    match e {
+        ConnectionError::Daemon(de) if de.code == "DEADLINE_EXCEEDED" => exit::TIMEOUT,
+        _ => exit::DAEMON_ERROR,
     }
 }
 

--- a/crates/rts-mcp/src/connection.rs
+++ b/crates/rts-mcp/src/connection.rs
@@ -1,0 +1,959 @@
+//! Connection manager — heartbeat, reconnect-with-backoff, structured
+//! disconnection state. (Plan
+//! `docs/plans/2026-05-19-004-feat-mcp-server-resilience-plan.md`.)
+//!
+//! ## Motivation
+//!
+//! Pre-resilience, the rts-mcp shim opened the per-workspace UDS connection
+//! once at startup and treated any transport error as fatal. When the
+//! daemon's idle-shutdown timer fired or the daemon crashed, the shim would
+//! sit on a dead socket; the next tool call returned `Broken pipe` and the
+//! MCP host marked the server as disconnected. The reconnect-on-call path
+//! added in v0.5.5 (`DaemonClient::reconnect`) covered the *next* tool call
+//! after a death, but not:
+//!
+//! - **Concurrent tool calls during the reconnect window** — they queued on
+//!   the mutex and all paid the auto-spawn deadline serially.
+//! - **No proactive detection** — a disconnect went undiscovered until the
+//!   next tool call; on idle sessions that could be minutes.
+//! - **No structured disconnection error** — agents saw `INTERNAL_ERROR
+//!   broken pipe`, which is indistinguishable from a daemon bug.
+//!
+//! The `ConnectionManager` here adds:
+//!
+//! 1. **Heartbeat loop.** A background task issues `Daemon.Ping` every
+//!    `RTS_MCP_HEARTBEAT_INTERVAL_SECS` (default 10s). A failed ping demotes
+//!    state to `Reconnecting`.
+//! 2. **Reconnect-with-backoff.** When demoted, a background reconnect task
+//!    schedules attempts at 1s, 2s, 4s, 8s, 16s, 30s, 30s, 30s
+//!    (`RTS_MCP_RECONNECT_MAX_ATTEMPTS`, default 8). After the cap, state
+//!    transitions to `Down` but retries continue at the 30s ceiling forever
+//!    — transient outages of arbitrary length still recover.
+//! 3. **Structured disconnection.** Tool calls hitting non-`Connected`
+//!    state return `ConnectionError::DaemonUnavailable { retry_after_ms }`
+//!    or `ConnectionError::DaemonDown`. The shim's tool-handler layer
+//!    maps these to JSON-RPC error codes `-32098` / `-32097` so agents
+//!    can branch on transient vs. sustained outage.
+//!
+//! ## Heartbeat ↔ idle-shutdown interaction
+//!
+//! `Daemon.Ping` resets the daemon's `last_activity` timestamp. The daemon
+//! only idle-shuts down when `active_connections == 0` AND the activity
+//! window has elapsed (`crates/rts-daemon/src/state.rs::is_idle`); the
+//! shim's heartbeat keeps `active_connections >= 1` for the lifetime of
+//! the shim process, so idle-shutdown is already gated. The heartbeat
+//! additionally bumps `last_activity` so a future change that loosens the
+//! connection-count gate (e.g. counting only *recent* connections) still
+//! sees fresh traffic. **An MCP shim that's still attached keeps its
+//! daemon alive — this is intentional.**
+//!
+//! ## State machine
+//!
+//! ```text
+//!  ┌──────────────┐  heartbeat ok / call ok    ┌──────────────┐
+//!  │              │ ──────────────────────────►│              │
+//!  │  Connected   │                            │  Reconnecting│
+//!  │              │ ◄──────────────────────────│              │
+//!  └──────┬───────┘  ping/call transport err   └──────┬───────┘
+//!         │                                           │
+//!         │                                           │ max_attempts
+//!         │                                           │ exhausted
+//!         │                                           ▼
+//!         │                                    ┌──────────────┐
+//!         │  ceiling reconnect succeeds        │              │
+//!         └─────────────────────────────◄──────│     Down     │
+//!                                              │              │
+//!                                              └──────────────┘
+//! ```
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::net::UnixStream;
+use tokio::sync::{Mutex, RwLock};
+use tokio::time::Instant;
+use tracing::{debug, info, warn};
+
+use crate::daemon_client::{DaemonClient, DaemonError};
+use crate::socket;
+
+/// JSON-RPC error code for transient daemon unavailability — the daemon
+/// is in the middle of reconnect. Carries a `retry_after_ms` hint.
+///
+/// Numeric: matches the plan's `-32098`. Per JSON-RPC 2.0, codes in
+/// the range `-32099..=-32000` are reserved for implementation-defined
+/// errors; we use the high end of that range for our transport-layer
+/// concerns to avoid clashing with the daemon's `-32099` `CANCELLED`
+/// (which is application-level, surfaced through a different field).
+pub const DAEMON_UNAVAILABLE_CODE: i32 = -32098;
+
+/// JSON-RPC error code for sustained daemon outage — the reconnect
+/// loop has exhausted its bounded attempts but continues to retry at
+/// the ceiling interval. Agents seeing this code should surface to the
+/// user.
+pub const DAEMON_DOWN_CODE: i32 = -32097;
+
+/// Stable string code mirroring [`DAEMON_UNAVAILABLE_CODE`]. The shim
+/// returns this in the `error.code` field so agents that match on
+/// strings (existing pattern across protocol-v0 §14) can branch on it.
+pub const DAEMON_UNAVAILABLE_STRING: &str = "DAEMON_UNAVAILABLE";
+
+/// Stable string code mirroring [`DAEMON_DOWN_CODE`].
+pub const DAEMON_DOWN_STRING: &str = "DAEMON_DOWN";
+
+/// Default heartbeat interval (override via `RTS_MCP_HEARTBEAT_INTERVAL_SECS`).
+const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+/// Default per-ping timeout (override via `RTS_MCP_HEARTBEAT_TIMEOUT_SECS`).
+const DEFAULT_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(3);
+/// Default max reconnect attempts before transitioning to `Down`
+/// (override via `RTS_MCP_RECONNECT_MAX_ATTEMPTS`).
+const DEFAULT_MAX_RECONNECT_ATTEMPTS: u32 = 8;
+/// Backoff ceiling (override via `RTS_MCP_RECONNECT_CEILING_SECS`).
+const DEFAULT_RECONNECT_CEILING: Duration = Duration::from_secs(30);
+
+/// Resilience knobs. All have defaults; nothing requires user setup.
+#[derive(Debug, Clone)]
+pub struct ResilienceConfig {
+    pub heartbeat_interval: Duration,
+    pub heartbeat_timeout: Duration,
+    pub max_reconnect_attempts: u32,
+    pub reconnect_ceiling: Duration,
+}
+
+impl Default for ResilienceConfig {
+    fn default() -> Self {
+        Self {
+            heartbeat_interval: DEFAULT_HEARTBEAT_INTERVAL,
+            heartbeat_timeout: DEFAULT_HEARTBEAT_TIMEOUT,
+            max_reconnect_attempts: DEFAULT_MAX_RECONNECT_ATTEMPTS,
+            reconnect_ceiling: DEFAULT_RECONNECT_CEILING,
+        }
+    }
+}
+
+impl ResilienceConfig {
+    /// Load knobs from `RTS_MCP_HEARTBEAT_*` / `RTS_MCP_RECONNECT_*` env
+    /// vars, falling back to the documented defaults on parse failure.
+    /// Parse failures emit a `warn` so misconfiguration is loud.
+    pub fn from_env() -> Self {
+        let mut cfg = Self::default();
+        if let Some(v) = env_secs("RTS_MCP_HEARTBEAT_INTERVAL_SECS") {
+            cfg.heartbeat_interval = v;
+        }
+        if let Some(v) = env_secs("RTS_MCP_HEARTBEAT_TIMEOUT_SECS") {
+            cfg.heartbeat_timeout = v;
+        }
+        if let Some(v) = env_u32("RTS_MCP_RECONNECT_MAX_ATTEMPTS") {
+            cfg.max_reconnect_attempts = v;
+        }
+        if let Some(v) = env_secs("RTS_MCP_RECONNECT_CEILING_SECS") {
+            cfg.reconnect_ceiling = v;
+        }
+        cfg
+    }
+}
+
+fn env_secs(key: &str) -> Option<Duration> {
+    match std::env::var(key) {
+        Ok(s) => match s.parse::<u64>() {
+            Ok(n) if n > 0 => Some(Duration::from_secs(n)),
+            Ok(_) => {
+                warn!(target: "rts_mcp::connection", "{key}=0 ignored; using default");
+                None
+            }
+            Err(e) => {
+                warn!(target: "rts_mcp::connection", "{key} parse failed ({e}); using default");
+                None
+            }
+        },
+        Err(_) => None,
+    }
+}
+
+fn env_u32(key: &str) -> Option<u32> {
+    match std::env::var(key) {
+        Ok(s) => match s.parse::<u32>() {
+            Ok(n) => Some(n),
+            Err(e) => {
+                warn!(target: "rts_mcp::connection", "{key} parse failed ({e}); using default");
+                None
+            }
+        },
+        Err(_) => None,
+    }
+}
+
+/// Connection-manager state. Stored behind `Arc<RwLock<…>>`; heartbeat
+/// takes the write lock briefly to transition, tool-call sites take the
+/// read lock to inspect.
+///
+/// The `DaemonClient` socket itself lives in a separate `Arc<Mutex<…>>`
+/// — see the module-level docs for why the plan's "socket lives inside
+/// the enum" sketch was relaxed.
+#[derive(Debug, Clone)]
+pub enum ConnectionState {
+    /// Connection live; last ping succeeded within the heartbeat
+    /// window. Tool calls forward through.
+    Connected {
+        /// Wall-clock instant of the most recent successful ping or
+        /// tool call. Exposed mostly for diagnostics.
+        last_pong_at: Instant,
+    },
+    /// Reconnect in flight. Tool calls return `DAEMON_UNAVAILABLE`
+    /// with a `retry_after_ms` derived from `next_retry_at`.
+    Reconnecting {
+        attempt: u32,
+        next_retry_at: Instant,
+        last_error: String,
+    },
+    /// Reconnect attempts exhausted. Tool calls return `DAEMON_DOWN`.
+    /// The reconnect loop continues at the ceiling interval; recovery
+    /// promotes back to `Connected` automatically.
+    Down {
+        first_failure_at: Instant,
+        last_error: String,
+    },
+}
+
+impl ConnectionState {
+    fn new_connected() -> Self {
+        Self::Connected {
+            last_pong_at: Instant::now(),
+        }
+    }
+
+    fn is_connected(&self) -> bool {
+        matches!(self, ConnectionState::Connected { .. })
+    }
+}
+
+/// Error surface for `ConnectionManager::call`. Two new variants
+/// (`DaemonUnavailable`, `DaemonDown`) carry the structured
+/// disconnection state; `Daemon` wraps the underlying
+/// [`DaemonError`] for everything that landed on the socket and came
+/// back with a typed error.
+#[derive(Debug, Clone)]
+pub enum ConnectionError {
+    /// Daemon socket is down and reconnect is in progress. `retry_after_ms`
+    /// is the wall-clock time until the next reconnect attempt is
+    /// scheduled. Agents should retry the call after that delay.
+    DaemonUnavailable {
+        retry_after_ms: u64,
+        attempt: u32,
+        last_error: String,
+    },
+    /// Reconnect attempts have been exhausted; ceiling-interval retries
+    /// continue but the daemon has been unreachable long enough that the
+    /// agent should surface this to the user. The state can still recover
+    /// — a subsequent successful retry returns the manager to `Connected`.
+    DaemonDown {
+        first_failure_ms_ago: u64,
+        last_error: String,
+    },
+    /// Daemon returned a structured `error` envelope (e.g.
+    /// `INDEX_NOT_READY`, `OUT_OF_ROOT`).
+    Daemon(DaemonError),
+}
+
+impl ConnectionError {
+    /// Stable string code suitable for the `error.code` field of an MCP
+    /// `CallToolResult::error` body.
+    pub fn code(&self) -> &str {
+        match self {
+            ConnectionError::DaemonUnavailable { .. } => DAEMON_UNAVAILABLE_STRING,
+            ConnectionError::DaemonDown { .. } => DAEMON_DOWN_STRING,
+            ConnectionError::Daemon(e) => &e.code,
+        }
+    }
+
+    /// Human-readable message. For `DaemonUnavailable` / `DaemonDown`
+    /// this is built to be unambiguously transient/sustained so the
+    /// agent doesn't mistake either for "tool doesn't exist."
+    pub fn message(&self) -> String {
+        match self {
+            ConnectionError::DaemonUnavailable {
+                retry_after_ms,
+                attempt,
+                last_error,
+            } => format!(
+                "rts-daemon temporarily unavailable (reconnect attempt {attempt}); \
+                 retry in {retry_after_ms}ms. Last error: {last_error}"
+            ),
+            ConnectionError::DaemonDown {
+                first_failure_ms_ago,
+                last_error,
+            } => format!(
+                "rts-daemon has been unreachable for {first_failure_ms_ago}ms after \
+                 exhausting reconnect attempts; ceiling-interval retries continue. \
+                 Last error: {last_error}"
+            ),
+            ConnectionError::Daemon(e) => e.message.clone(),
+        }
+    }
+
+    /// Structured payload for the MCP `error.data` slot. For transient
+    /// disconnects this carries `retry_after_ms` so agents can back off
+    /// without parsing the message string.
+    pub fn data(&self) -> Value {
+        match self {
+            ConnectionError::DaemonUnavailable {
+                retry_after_ms,
+                attempt,
+                last_error,
+            } => json!({
+                "retry_after_ms": retry_after_ms,
+                "attempt": attempt,
+                "last_error": last_error,
+                "transient": true,
+            }),
+            ConnectionError::DaemonDown {
+                first_failure_ms_ago,
+                last_error,
+            } => json!({
+                "first_failure_ms_ago": first_failure_ms_ago,
+                "last_error": last_error,
+                "transient": false,
+            }),
+            ConnectionError::Daemon(e) => e.data.clone().unwrap_or(Value::Null),
+        }
+    }
+
+    /// True iff the error indicates the manager is in a non-Connected
+    /// state. Used by tests and diagnostics.
+    pub fn is_disconnection(&self) -> bool {
+        matches!(
+            self,
+            ConnectionError::DaemonUnavailable { .. } | ConnectionError::DaemonDown { .. }
+        )
+    }
+}
+
+impl std::fmt::Display for ConnectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] {}", self.code(), self.message())
+    }
+}
+
+impl std::error::Error for ConnectionError {}
+
+/// Compute the reconnect delay for a given attempt count. Schedule:
+/// `1s, 2s, 4s, 8s, 16s, 30s, 30s, …` (ceiling at
+/// `cfg.reconnect_ceiling`). `attempt` is 1-indexed.
+fn backoff_for_attempt(attempt: u32, ceiling: Duration) -> Duration {
+    // 2^(attempt-1) seconds, capped at ceiling. Saturating arithmetic
+    // so absurd attempt counts never panic.
+    let secs = 1u64
+        .checked_shl(attempt.saturating_sub(1))
+        .unwrap_or(u64::MAX);
+    let raw = Duration::from_secs(secs);
+    if raw > ceiling { ceiling } else { raw }
+}
+
+/// Long-lived connection manager. Owns the socket (via a `DaemonClient`
+/// inside an `Arc<Mutex<…>>`) and a background heartbeat / reconnect
+/// task. `clone()` is cheap (`Arc` clones); the same manager is shared
+/// by the MCP server's tool handlers.
+#[derive(Clone)]
+pub struct ConnectionManager {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    /// Owning handle to the live socket. Tool calls take this mutex
+    /// briefly per call. Heartbeat / reconnect tasks take it too.
+    daemon: Arc<Mutex<DaemonClient>>,
+    /// Connection-state metadata. Separate from `daemon` so heartbeat
+    /// status reads don't serialize behind a long-running tool call.
+    state: Arc<RwLock<ConnectionState>>,
+    /// Path to `rts-daemon` for re-auto-spawn on reconnect.
+    daemon_bin: PathBuf,
+    /// Canonical workspace path — required for per-workspace socket
+    /// resolution + Mount on the reconnected daemon.
+    workspace: PathBuf,
+    /// Heartbeat / reconnect knobs.
+    config: ResilienceConfig,
+    /// `true` when the background tasks have been spawned. Set in
+    /// `start_background_tasks`; checked by `Drop` to skip aborting
+    /// non-existent handles.
+    background_started: std::sync::atomic::AtomicBool,
+    /// Handles to the background tasks so `Drop` can abort them; the
+    /// daemon stays up but the shim's tasks shouldn't outlive the
+    /// manager.
+    heartbeat_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    reconnect_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// `Workspace.Mount` sentinel — cleared on reconnect, set on first
+    /// successful Mount. Mirrors `RtsServer.mounted` but lives here so
+    /// the CLI can reuse the manager without re-implementing the
+    /// lazy-mount handshake. v0.6 keeps Mount idempotent on the
+    /// daemon, so multiple sets across reconnects are safe.
+    mounted: std::sync::atomic::AtomicBool,
+    /// Wakes the reconnect task when a foreground tool call observes
+    /// a transport error and demotes the state. Without this, the
+    /// reconnect loop would sleep through the heartbeat interval
+    /// before noticing.
+    reconnect_signal: tokio::sync::Notify,
+}
+
+impl ConnectionManager {
+    /// Build a manager around an already-open `DaemonClient`. Spawns
+    /// the background heartbeat + reconnect tasks immediately when
+    /// `start_background_tasks: true`.
+    ///
+    /// CLI callers pass `start_background_tasks: false` to skip the
+    /// heartbeat — a single-shot CLI doesn't need it and shouldn't
+    /// leak a task. The reconnect path still fires synchronously on
+    /// the next `call()` if needed (matching pre-resilience behavior).
+    pub fn new(
+        client: DaemonClient,
+        daemon_bin: PathBuf,
+        workspace: PathBuf,
+        config: ResilienceConfig,
+        start_background_tasks: bool,
+    ) -> Self {
+        let inner = Arc::new(Inner {
+            daemon: Arc::new(Mutex::new(client)),
+            state: Arc::new(RwLock::new(ConnectionState::new_connected())),
+            daemon_bin,
+            workspace,
+            config,
+            background_started: std::sync::atomic::AtomicBool::new(false),
+            heartbeat_handle: Mutex::new(None),
+            reconnect_handle: Mutex::new(None),
+            mounted: std::sync::atomic::AtomicBool::new(false),
+            reconnect_signal: tokio::sync::Notify::new(),
+        });
+        let mgr = Self { inner };
+        if start_background_tasks {
+            mgr.start_background_tasks();
+        }
+        mgr
+    }
+
+    /// Spawn the heartbeat and reconnect tasks. Idempotent — the second
+    /// call is a no-op (the `background_started` flag gates it).
+    pub fn start_background_tasks(&self) {
+        if self
+            .inner
+            .background_started
+            .swap(true, std::sync::atomic::Ordering::AcqRel)
+        {
+            return;
+        }
+        let hb = tokio::spawn(heartbeat_loop(self.inner.clone()));
+        let rc = tokio::spawn(reconnect_loop(self.inner.clone()));
+        // Stash the handles for abort-on-drop. We use try_lock since
+        // we just allocated these and nothing else holds the mutex.
+        if let Ok(mut g) = self.inner.heartbeat_handle.try_lock() {
+            *g = Some(hb);
+        }
+        if let Ok(mut g) = self.inner.reconnect_handle.try_lock() {
+            *g = Some(rc);
+        }
+    }
+
+    /// Snapshot the current state. Cheap read-lock.
+    pub async fn state(&self) -> ConnectionState {
+        self.inner.state.read().await.clone()
+    }
+
+    /// Cheap synchronous check: are we Connected? Used by the MCP
+    /// tool layer to short-circuit on `DAEMON_UNAVAILABLE`/`DAEMON_DOWN`
+    /// without taking the daemon mutex.
+    pub async fn is_connected(&self) -> bool {
+        self.inner.state.read().await.is_connected()
+    }
+
+    /// Forward a daemon RPC, transparently handling the
+    /// `Workspace.Mount` lazy handshake. Returns the JSON result on
+    /// success, a structured `ConnectionError` on failure.
+    ///
+    /// **Behavior:**
+    /// 1. If state is `Reconnecting` or `Down`, returns the matching
+    ///    `ConnectionError` immediately without touching the socket
+    ///    (no thundering-herd on the daemon-mutex during a known
+    ///    disconnect window).
+    /// 2. If state is `Connected`, acquires the daemon mutex, ensures
+    ///    `Workspace.Mount` has been called (lazy), forwards the call.
+    /// 3. On a transport-shaped `DaemonError`, demotes state to
+    ///    `Reconnecting` and returns `DaemonUnavailable`. The
+    ///    background reconnect task picks it up. The caller does NOT
+    ///    retry here — pre-resilience the retry was bounded inline,
+    ///    but the new design uses the manager's state machine
+    ///    explicitly so concurrent callers all see consistent state.
+    pub async fn call(&self, method: &str, params: Value) -> Result<Value, ConnectionError> {
+        // 1. Fast-path state check. If we're not Connected, return the
+        //    structured error without acquiring the daemon mutex.
+        {
+            let st = self.inner.state.read().await;
+            match &*st {
+                ConnectionState::Reconnecting {
+                    attempt,
+                    next_retry_at,
+                    last_error,
+                } => {
+                    let now = Instant::now();
+                    let retry_after_ms = if *next_retry_at > now {
+                        (*next_retry_at - now).as_millis() as u64
+                    } else {
+                        0
+                    };
+                    return Err(ConnectionError::DaemonUnavailable {
+                        retry_after_ms,
+                        attempt: *attempt,
+                        last_error: last_error.clone(),
+                    });
+                }
+                ConnectionState::Down {
+                    first_failure_at,
+                    last_error,
+                } => {
+                    return Err(ConnectionError::DaemonDown {
+                        first_failure_ms_ago: first_failure_at.elapsed().as_millis() as u64,
+                        last_error: last_error.clone(),
+                    });
+                }
+                ConnectionState::Connected { .. } => { /* fall through */ }
+            }
+        }
+
+        // 2. Connected path. Acquire daemon, ensure Mount, forward call.
+        let mut guard = self.inner.daemon.lock().await;
+        if !self
+            .inner
+            .mounted
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            match guard
+                .call("Workspace.Mount", json!({ "root": self.inner.workspace }))
+                .await
+            {
+                Ok(_) => {
+                    self.inner
+                        .mounted
+                        .store(true, std::sync::atomic::Ordering::Release);
+                }
+                Err(e) if e.is_disconnect() => {
+                    drop(guard);
+                    self.demote_to_reconnecting(format!(
+                        "Workspace.Mount transport error: {}",
+                        e.message
+                    ))
+                    .await;
+                    return Err(self
+                        .unavailable_now(format!("Mount failed: {}", e.message))
+                        .await);
+                }
+                Err(e) => return Err(ConnectionError::Daemon(e)),
+            }
+        }
+
+        match guard.call(method, params).await {
+            Ok(v) => {
+                // Successful call counts as a fresh heartbeat — bump
+                // last_pong_at so we don't waste a ping on a known-live
+                // socket. Take write-lock briefly.
+                drop(guard);
+                self.bump_pong().await;
+                Ok(v)
+            }
+            Err(e) if e.is_disconnect() => {
+                drop(guard);
+                self.demote_to_reconnecting(format!("{} transport error: {}", method, e.message))
+                    .await;
+                Err(self
+                    .unavailable_now(format!("{} failed: {}", method, e.message))
+                    .await)
+            }
+            Err(e) => Err(ConnectionError::Daemon(e)),
+        }
+    }
+
+    /// Refresh `last_pong_at` without changing the discriminant. No-op
+    /// when state is non-Connected.
+    async fn bump_pong(&self) {
+        let mut st = self.inner.state.write().await;
+        if matches!(&*st, ConnectionState::Connected { .. }) {
+            *st = ConnectionState::Connected {
+                last_pong_at: Instant::now(),
+            };
+        }
+    }
+
+    /// Foreground demote: a tool call hit a transport error. Sets the
+    /// state to `Reconnecting{attempt:1, next_retry_at: now+1s}` and
+    /// signals the reconnect task. Idempotent — if we're already
+    /// reconnecting, leaves the attempt counter alone (the reconnect
+    /// task owns it).
+    async fn demote_to_reconnecting(&self, reason: String) {
+        let mut st = self.inner.state.write().await;
+        match &*st {
+            ConnectionState::Reconnecting { .. } | ConnectionState::Down { .. } => {
+                // Already non-Connected; nothing to do.
+                return;
+            }
+            ConnectionState::Connected { .. } => {
+                warn!(
+                    target: "rts_mcp::connection",
+                    "daemon disconnect detected; entering reconnect ({reason})"
+                );
+                // Clear the Mount sentinel — the next successful
+                // reconnect will need a fresh Mount on the new daemon.
+                self.inner
+                    .mounted
+                    .store(false, std::sync::atomic::Ordering::Release);
+                *st = ConnectionState::Reconnecting {
+                    attempt: 1,
+                    next_retry_at: Instant::now() + Duration::from_secs(1),
+                    last_error: reason,
+                };
+            }
+        }
+        drop(st);
+        // Kick the reconnect loop awake immediately.
+        self.inner.reconnect_signal.notify_one();
+    }
+
+    /// Read the current state and build a `DaemonUnavailable` error
+    /// reflecting where in the reconnect schedule we are. Caller has
+    /// just demoted us, so this is guaranteed to find `Reconnecting`
+    /// (or, in a rare race with the reconnect task, `Down`).
+    async fn unavailable_now(&self, fallback_msg: String) -> ConnectionError {
+        let st = self.inner.state.read().await;
+        match &*st {
+            ConnectionState::Reconnecting {
+                attempt,
+                next_retry_at,
+                last_error,
+            } => {
+                let now = Instant::now();
+                let retry_after_ms = if *next_retry_at > now {
+                    (*next_retry_at - now).as_millis() as u64
+                } else {
+                    0
+                };
+                ConnectionError::DaemonUnavailable {
+                    retry_after_ms,
+                    attempt: *attempt,
+                    last_error: last_error.clone(),
+                }
+            }
+            ConnectionState::Down {
+                first_failure_at,
+                last_error,
+            } => ConnectionError::DaemonDown {
+                first_failure_ms_ago: first_failure_at.elapsed().as_millis() as u64,
+                last_error: last_error.clone(),
+            },
+            ConnectionState::Connected { .. } => {
+                // Lost a race with the reconnect task. Surface the
+                // original fallback message.
+                ConnectionError::DaemonUnavailable {
+                    retry_after_ms: 0,
+                    attempt: 0,
+                    last_error: fallback_msg,
+                }
+            }
+        }
+    }
+
+    /// Test/diagnostics helper: snapshot the daemon binary path.
+    #[doc(hidden)]
+    pub fn daemon_bin_path(&self) -> &std::path::Path {
+        &self.inner.daemon_bin
+    }
+}
+
+impl std::fmt::Debug for ConnectionManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConnectionManager")
+            .field("workspace", &self.inner.workspace)
+            .field("daemon_bin", &self.inner.daemon_bin)
+            .field("config", &self.inner.config)
+            .finish()
+    }
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        // Abort the background tasks if they were spawned. `try_lock`
+        // because we're in `drop` and can't await. Aborting an already-
+        // finished JoinHandle is a no-op.
+        if let Ok(mut g) = self.heartbeat_handle.try_lock() {
+            if let Some(h) = g.take() {
+                h.abort();
+            }
+        }
+        if let Ok(mut g) = self.reconnect_handle.try_lock() {
+            if let Some(h) = g.take() {
+                h.abort();
+            }
+        }
+    }
+}
+
+/// Heartbeat task — runs in the background, demotes state on ping
+/// failure, promotes back on ping success.
+async fn heartbeat_loop(inner: Arc<Inner>) {
+    let interval = inner.config.heartbeat_interval;
+    let timeout = inner.config.heartbeat_timeout;
+    debug!(
+        target: "rts_mcp::connection",
+        "heartbeat task started (interval={interval:?}, timeout={timeout:?})"
+    );
+
+    loop {
+        tokio::time::sleep(interval).await;
+
+        // Only ping when we believe we're Connected. While reconnecting,
+        // the reconnect task is in charge.
+        let connected = inner.state.read().await.is_connected();
+        if !connected {
+            continue;
+        }
+
+        let ping_res = {
+            let mut guard = inner.daemon.lock().await;
+            tokio::time::timeout(timeout, guard.call("Daemon.Ping", json!({}))).await
+        };
+        match ping_res {
+            Ok(Ok(_)) => {
+                // Reset last_pong_at.
+                let mut st = inner.state.write().await;
+                if matches!(&*st, ConnectionState::Connected { .. }) {
+                    *st = ConnectionState::new_connected();
+                }
+            }
+            Ok(Err(e)) => {
+                warn!(
+                    target: "rts_mcp::connection",
+                    "heartbeat ping returned error ({}); demoting",
+                    e.message
+                );
+                demote_inner(&inner, format!("heartbeat ping error: {}", e.message)).await;
+                inner.reconnect_signal.notify_one();
+            }
+            Err(_) => {
+                warn!(
+                    target: "rts_mcp::connection",
+                    "heartbeat ping timed out after {timeout:?}; demoting"
+                );
+                demote_inner(&inner, format!("heartbeat ping timeout {timeout:?}")).await;
+                inner.reconnect_signal.notify_one();
+            }
+        }
+    }
+}
+
+/// Background reconnect task — sleeps until either the heartbeat /
+/// foreground call demotes state, then steps the backoff schedule
+/// until reconnect succeeds.
+async fn reconnect_loop(inner: Arc<Inner>) {
+    debug!(target: "rts_mcp::connection", "reconnect task started");
+    loop {
+        // Wait until someone signals a disconnect. The notify is
+        // edge-triggered with one permit, so spurious wakes are
+        // possible; we re-check state below.
+        inner.reconnect_signal.notified().await;
+
+        loop {
+            // Snapshot state. If we're already Connected (e.g. heartbeat
+            // raced ahead), exit the inner loop and wait for the next
+            // signal.
+            let (next_retry_at, attempt) = {
+                let st = inner.state.read().await;
+                match &*st {
+                    ConnectionState::Reconnecting {
+                        next_retry_at,
+                        attempt,
+                        ..
+                    } => (*next_retry_at, *attempt),
+                    ConnectionState::Down { .. } => {
+                        // Sleep at ceiling and try again.
+                        let ceiling = inner.config.reconnect_ceiling;
+                        (
+                            Instant::now() + ceiling,
+                            inner.config.max_reconnect_attempts + 1,
+                        )
+                    }
+                    ConnectionState::Connected { .. } => break,
+                }
+            };
+
+            let now = Instant::now();
+            if next_retry_at > now {
+                tokio::time::sleep(next_retry_at - now).await;
+            }
+
+            // Attempt the reconnect.
+            let attempt_res = try_reconnect(&inner).await;
+            match attempt_res {
+                Ok(()) => {
+                    let mut st = inner.state.write().await;
+                    if !matches!(&*st, ConnectionState::Connected { .. }) {
+                        info!(
+                            target: "rts_mcp::connection",
+                            "reconnect succeeded on attempt {attempt}"
+                        );
+                    }
+                    *st = ConnectionState::new_connected();
+                    // Mount sentinel was cleared on demote; the next
+                    // tool call will re-Mount the fresh daemon.
+                    break;
+                }
+                Err(e) => {
+                    let next_attempt = attempt.saturating_add(1);
+                    let mut st = inner.state.write().await;
+                    if next_attempt > inner.config.max_reconnect_attempts {
+                        match &*st {
+                            ConnectionState::Down { .. } => {
+                                // Already Down; update last_error and
+                                // continue retrying at ceiling.
+                                *st = ConnectionState::Down {
+                                    first_failure_at: match &*st {
+                                        ConnectionState::Down {
+                                            first_failure_at, ..
+                                        } => *first_failure_at,
+                                        _ => Instant::now(),
+                                    },
+                                    last_error: e.to_string(),
+                                };
+                            }
+                            ConnectionState::Reconnecting { .. } => {
+                                warn!(
+                                    target: "rts_mcp::connection",
+                                    "reconnect exhausted after {} attempts; transitioning to Down ({})",
+                                    inner.config.max_reconnect_attempts,
+                                    e
+                                );
+                                *st = ConnectionState::Down {
+                                    first_failure_at: Instant::now(),
+                                    last_error: e.to_string(),
+                                };
+                            }
+                            ConnectionState::Connected { .. } => {
+                                // Raced with another task that promoted
+                                // us. Trust the promotion.
+                                break;
+                            }
+                        }
+                    } else {
+                        let backoff =
+                            backoff_for_attempt(next_attempt, inner.config.reconnect_ceiling);
+                        debug!(
+                            target: "rts_mcp::connection",
+                            "reconnect attempt {attempt} failed ({e}); next in {backoff:?}"
+                        );
+                        *st = ConnectionState::Reconnecting {
+                            attempt: next_attempt,
+                            next_retry_at: Instant::now() + backoff,
+                            last_error: e.to_string(),
+                        };
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn demote_inner(inner: &Inner, reason: String) {
+    let mut st = inner.state.write().await;
+    if let ConnectionState::Connected { .. } = &*st {
+        inner
+            .mounted
+            .store(false, std::sync::atomic::Ordering::Release);
+        *st = ConnectionState::Reconnecting {
+            attempt: 1,
+            next_retry_at: Instant::now() + Duration::from_secs(1),
+            last_error: reason,
+        };
+    }
+}
+
+/// Open a fresh UDS connection (auto-spawning the daemon if needed),
+/// send one `Daemon.Ping`, and on success swap it into the manager's
+/// `DaemonClient`. Returns `Ok(())` on success.
+async fn try_reconnect(inner: &Inner) -> Result<(), String> {
+    let stream: UnixStream =
+        socket::connect_with_auto_spawn(&inner.daemon_bin, Some(&inner.workspace))
+            .await
+            .map_err(|e| format!("auto-spawn: {e:#}"))?;
+    // Swap the new stream into the existing DaemonClient by building
+    // a fresh client and replacing the contents of the mutex.
+    let new_client = DaemonClient::new(stream, inner.daemon_bin.clone(), inner.workspace.clone());
+    // Quick `Daemon.Ping` on the new client to confirm it speaks. We
+    // do this *after* the mutex swap so the ping uses the new socket
+    // and any failure surfaces here, not on the next tool call.
+    {
+        let mut guard = inner.daemon.lock().await;
+        *guard = new_client;
+        guard
+            .call("Daemon.Ping", json!({}))
+            .await
+            .map_err(|e| format!("ping after reconnect: {}", e.message))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_schedule_matches_spec() {
+        let c = Duration::from_secs(30);
+        assert_eq!(backoff_for_attempt(1, c), Duration::from_secs(1));
+        assert_eq!(backoff_for_attempt(2, c), Duration::from_secs(2));
+        assert_eq!(backoff_for_attempt(3, c), Duration::from_secs(4));
+        assert_eq!(backoff_for_attempt(4, c), Duration::from_secs(8));
+        assert_eq!(backoff_for_attempt(5, c), Duration::from_secs(16));
+        assert_eq!(backoff_for_attempt(6, c), Duration::from_secs(30));
+        assert_eq!(backoff_for_attempt(7, c), Duration::from_secs(30));
+        assert_eq!(backoff_for_attempt(8, c), Duration::from_secs(30));
+        // Defensive: absurd attempt counts cap at the ceiling, no panic.
+        assert_eq!(backoff_for_attempt(64, c), Duration::from_secs(30));
+        assert_eq!(backoff_for_attempt(u32::MAX, c), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn connection_error_codes_round_trip_strings() {
+        let e = ConnectionError::DaemonUnavailable {
+            retry_after_ms: 500,
+            attempt: 2,
+            last_error: "x".into(),
+        };
+        assert_eq!(e.code(), DAEMON_UNAVAILABLE_STRING);
+        assert!(e.is_disconnection());
+        let body = e.data();
+        assert_eq!(body["retry_after_ms"], 500);
+        assert_eq!(body["attempt"], 2);
+        assert_eq!(body["transient"], true);
+
+        let d = ConnectionError::DaemonDown {
+            first_failure_ms_ago: 100_000,
+            last_error: "y".into(),
+        };
+        assert_eq!(d.code(), DAEMON_DOWN_STRING);
+        assert!(d.is_disconnection());
+        let body = d.data();
+        assert_eq!(body["first_failure_ms_ago"], 100_000);
+        assert_eq!(body["transient"], false);
+    }
+
+    #[test]
+    fn resilience_config_defaults_are_documented() {
+        let cfg = ResilienceConfig::default();
+        assert_eq!(cfg.heartbeat_interval, Duration::from_secs(10));
+        assert_eq!(cfg.heartbeat_timeout, Duration::from_secs(3));
+        assert_eq!(cfg.max_reconnect_attempts, 8);
+        assert_eq!(cfg.reconnect_ceiling, Duration::from_secs(30));
+    }
+
+    // Note on env-driven config: `ResilienceConfig::from_env` reads
+    // process-global env vars and Rust 2024 made `set_var`/`remove_var`
+    // `unsafe`. Workspace lints deny `unsafe_code`, so we cannot mutate
+    // env in unit tests. Coverage for env parsing lives in the
+    // integration tests (`tests/connection_resilience.rs`), which set
+    // env vars on the subprocess they spawn.
+}

--- a/crates/rts-mcp/src/lib.rs
+++ b/crates/rts-mcp/src/lib.rs
@@ -10,5 +10,6 @@
 //! the public API.
 
 pub mod cli;
+pub mod connection;
 pub mod daemon_client;
 pub mod socket;

--- a/crates/rts-mcp/src/main.rs
+++ b/crates/rts-mcp/src/main.rs
@@ -15,6 +15,7 @@ use rmcp::service::ServiceExt;
 
 mod server;
 
+use rts_mcp::connection::{ConnectionManager, ResilienceConfig};
 use rts_mcp::daemon_client::DaemonClient;
 use rts_mcp::socket;
 use server::RtsServer;
@@ -109,18 +110,26 @@ async fn main() -> Result<()> {
     // re-resolve the binary path or route to the per-workspace socket.
     let daemon = DaemonClient::new(stream, daemon_bin.clone(), workspace.clone());
 
-    // v0.4: Workspace.Mount is now deferred — see `RtsServer::call_daemon`.
-    // The first agent tool call (find_symbol / outline_workspace / etc.)
-    // triggers the Mount. Daemon prewarm overlaps with the seconds the
-    // user spends typing their first question, so Mount is effectively
-    // free.
-    //
-    // Pre-v0.4 behavior was to Mount synchronously here at startup,
-    // which paid the 6 s cold-walk tax during rts-mcp boot — before
-    // the agent's first tool call could even be served. The deferred
-    // approach lets Claude Code / Cursor / etc. show tools as
-    // available immediately and amortizes the walk into the user's
-    // typing time.
+    // v0.6+: wrap the bare DaemonClient in a ConnectionManager so the
+    // shim gets heartbeat + reconnect-with-backoff + structured
+    // disconnection state (Plan 004). The heartbeat task is enabled
+    // for the long-lived MCP shim; the CLI variant disables it (see
+    // `cli::connect`). Env vars `RTS_MCP_HEARTBEAT_*` /
+    // `RTS_MCP_RECONNECT_*` override the defaults; see
+    // `connection.rs` for the full list.
+    let connection = ConnectionManager::new(
+        daemon,
+        daemon_bin.clone(),
+        workspace.clone(),
+        ResilienceConfig::from_env(),
+        /* start_background_tasks */ true,
+    );
+
+    // v0.4: Workspace.Mount is now deferred — see
+    // `ConnectionManager::call`. The first agent tool call
+    // (find_symbol / outline_workspace / etc.) triggers the Mount.
+    // Daemon prewarm overlaps with the seconds the user spends
+    // typing their first question, so Mount is effectively free.
 
     let instructions = format!(
         "rts-mcp serves four read-only retrieval tools for the workspace at {}. \
@@ -128,14 +137,13 @@ async fn main() -> Result<()> {
          first for orientation, then `find_symbol`/`read_symbol` for targeted reads.",
         workspace.display()
     );
-    let server = RtsServer::new(daemon, workspace.clone(), instructions);
-    // v0.5.8: hold a clone of the daemon Arc so we can issue one
+    let server = RtsServer::new(connection.clone(), instructions);
+    // v0.5.8: hold a clone of the connection so we can issue one
     // last `Daemon.Stats` after `service.waiting()` returns —
     // `serve()` consumes the server, so this is the only window we
-    // have to grab a handle. The Mutex is uncontested at shutdown
-    // (stdio is closed → no tool calls can race), so the lock + RPC
-    // round-trip is sub-millisecond.
-    let daemon_for_shutdown = server.daemon_handle();
+    // have to grab a handle. The manager is `Clone` (Arc-counted
+    // internals), no Mutex contention at shutdown.
+    let connection_for_shutdown = connection.clone();
     let service = server
         .serve(rmcp::transport::stdio())
         .await
@@ -149,7 +157,7 @@ async fn main() -> Result<()> {
     // point on its way out. Failures here are non-fatal: stderr
     // logging is observational, not load-bearing for the daemon
     // lifecycle.
-    dump_session_stats(&daemon_for_shutdown).await;
+    dump_session_stats(&connection_for_shutdown).await;
     tracing::info!(target: "rts_mcp", "rts-mcp shut down cleanly");
     Ok(())
 }
@@ -164,10 +172,8 @@ async fn main() -> Result<()> {
 /// crashed before we got here, or the socket may already be gone)
 /// is reported via a single `tracing::warn!` and the function
 /// returns. Shutdown should never block on observability.
-async fn dump_session_stats(daemon: &std::sync::Arc<tokio::sync::Mutex<DaemonClient>>) {
-    let mut guard = daemon.lock().await;
-    let result = guard.call("Daemon.Stats", serde_json::json!({})).await;
-    drop(guard);
+async fn dump_session_stats(connection: &ConnectionManager) {
+    let result = connection.call("Daemon.Stats", serde_json::json!({})).await;
 
     let body = match result {
         Ok(v) => v,
@@ -179,7 +185,7 @@ async fn dump_session_stats(daemon: &std::sync::Arc<tokio::sync::Mutex<DaemonCli
             tracing::debug!(
                 target: "rts_mcp",
                 error = %e,
-                "Daemon.Stats unavailable (likely pre-v0.5.7 daemon); skipping shutdown dump"
+                "Daemon.Stats unavailable (likely pre-v0.5.7 daemon or mid-reconnect); skipping shutdown dump"
             );
             return;
         }

--- a/crates/rts-mcp/src/server.rs
+++ b/crates/rts-mcp/src/server.rs
@@ -5,8 +5,6 @@
 //! Each tool call translates to one `Index.*` request on the persistent
 //! Unix-socket connection held by the server.
 
-use std::sync::Arc;
-
 use rmcp::{
     ErrorData as McpError, ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -16,9 +14,8 @@ use rmcp::{
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
-use tokio::sync::Mutex;
 
-use rts_mcp::daemon_client::{DaemonClient, DaemonError};
+use rts_mcp::connection::{ConnectionError, ConnectionManager};
 
 // Built-in tool descriptions are pinned inline (the `#[tool(description = ...)]`
 // macro expects a literal string and does not accept const-path expressions).
@@ -326,148 +323,52 @@ pub struct RtsServer {
     // rustc can't see through the macro for the dead-code analysis.
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
-    daemon: Arc<Mutex<DaemonClient>>,
-    /// v0.4: workspace path needed for lazy `Workspace.Mount`.
-    /// rts-mcp used to call Mount immediately at startup; with the
-    /// daemon's prewarm-on-spawn (PR #51), deferring Mount until
-    /// the first agent tool call lets the daemon's background walk
-    /// overlap with the seconds-to-minutes between session start and
-    /// the user's first code question. By the time Mount fires, the
-    /// daemon's prewarm has already populated the index — Mount hits
-    /// the idempotent path and returns immediately.
-    workspace: std::path::PathBuf,
-    /// Whether `Workspace.Mount` has been called for this session.
-    /// `AtomicBool` so the (cheap) fast-path in `call_daemon` is a
-    /// single relaxed load. Synchronization for the slow-path
-    /// (do-the-mount) happens through the daemon `Mutex` we already
-    /// hold there — no double-mount race possible.
-    ///
-    /// Wrapped in `Arc` because `RtsServer: Clone` (rmcp requirement)
-    /// and `AtomicBool` itself is not `Clone`.
-    mounted: Arc<std::sync::atomic::AtomicBool>,
+    /// v0.6+: connection manager owns the daemon socket plus the
+    /// background heartbeat / reconnect tasks (see
+    /// `connection.rs` and Plan 004). Replaces the bare
+    /// `Arc<Mutex<DaemonClient>>` and the inline retry loop the
+    /// pre-resilience server carried — tool calls now see structured
+    /// `DAEMON_UNAVAILABLE` / `DAEMON_DOWN` errors when the daemon
+    /// is mid-reconnect rather than blocking on the daemon mutex.
+    connection: ConnectionManager,
     instructions: String,
 }
 
 #[tool_router]
 impl RtsServer {
-    pub fn new(daemon: DaemonClient, workspace: std::path::PathBuf, instructions: String) -> Self {
+    /// Build a server around an established [`ConnectionManager`]. The
+    /// manager owns the socket and the background heartbeat /
+    /// reconnect tasks; this struct is the rmcp tool-router shim that
+    /// translates between MCP `tools/call` envelopes and daemon RPCs.
+    pub fn new(connection: ConnectionManager, instructions: String) -> Self {
         Self {
             tool_router: Self::tool_router(),
-            daemon: Arc::new(Mutex::new(daemon)),
-            workspace,
-            mounted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            connection,
             instructions,
         }
     }
 
-    /// Clone the inner daemon handle. Used by `main.rs` so it can
-    /// keep a reference to the daemon connection after `serve()`
-    /// consumes the server — specifically to issue a final
-    /// `Daemon.Stats` query on session shutdown (v0.5.8+).
-    ///
-    /// The lock is taken via the returned `Arc<Mutex<…>>` exactly
-    /// like every tool handler does it; concurrent access during
-    /// the session is fine and the shutdown call only runs after
-    /// `service.waiting().await` returns (i.e., the agent has
-    /// hung up stdio, no more tool calls can race).
-    pub fn daemon_handle(&self) -> Arc<Mutex<DaemonClient>> {
-        self.daemon.clone()
+    /// Clone the connection manager. Used by `main.rs` (when it needs
+    /// to keep a handle after `serve()` consumes the server) and by
+    /// test code that drives the server directly. The manager is
+    /// `Clone` (Arc-counted internals), so this is cheap.
+    #[allow(dead_code)]
+    pub fn connection(&self) -> ConnectionManager {
+        self.connection.clone()
     }
 
-    /// Forward a method to the daemon. On the FIRST call (or after
-    /// a prior `Workspace.Mount` failure), this also issues
-    /// `Workspace.Mount` so subsequent tool calls have a workspace
-    /// to read from.
+    /// Forward a method to the daemon via the connection manager.
+    /// Returns `ConnectionError`, which preserves the structured
+    /// disconnection states (`DaemonUnavailable` / `DaemonDown`) so
+    /// the tool layer can emit JSON-RPC `-32098` / `-32097` codes.
     ///
-    /// The `daemon` mutex serializes — concurrent tool calls don't
-    /// race on the mount; the first one in does the mount, the
-    /// others wait on the mutex and see `mounted == true` by the
-    /// time they get the lock.
-    async fn call_daemon(&self, method: &str, params: Value) -> Result<Value, DaemonError> {
-        // Retry-on-disconnect loop. Pre-v0.5.5 this method made a
-        // single attempt; if the daemon had died mid-session, the
-        // first transport error left the connection wedged and every
-        // subsequent tool call failed with `Broken pipe`. v0.5.5+ does
-        // one explicit reconnect (auto-spawning a fresh daemon on the
-        // per-workspace socket) and retries the call once.
-        //
-        // Why ONE retry, not infinite:
-        // - A working daemon should never need reconnects mid-session.
-        // - Repeated disconnects after one reconnect indicates the
-        //   daemon won't stay up (binary missing, crash loop, etc.);
-        //   surfacing the error to the agent beats hot-spinning the
-        //   spawn flow.
-        // - Wall-clock cost is bounded: at most two `CALL_TIMEOUT`s
-        //   (35s × 2 = 70s).
-        for attempt in 0..2 {
-            let mut guard = self.daemon.lock().await;
-            if !self.mounted.load(std::sync::atomic::Ordering::Acquire) {
-                let mount_resp = match guard
-                    .call(
-                        "Workspace.Mount",
-                        serde_json::json!({ "root": self.workspace }),
-                    )
-                    .await
-                {
-                    Ok(v) => v,
-                    Err(e) if attempt == 0 && e.is_disconnect() => {
-                        // Reconnect path on the FIRST call after spawn.
-                        // Rare in practice (the auto-spawn flow has
-                        // already verified the socket accepts a
-                        // connection), but harmless to handle.
-                        tracing::warn!(
-                            target: "rts_mcp",
-                            "daemon disconnected during Workspace.Mount; reconnecting + retrying ({})",
-                            e.message,
-                        );
-                        guard.reconnect().await?;
-                        // Mount sentinel stays false (which it already is);
-                        // the next iteration will re-Mount.
-                        drop(guard);
-                        continue;
-                    }
-                    Err(e) => return Err(e),
-                };
-                let workspace_id = mount_resp["workspace_id"].as_str().unwrap_or("<unknown>");
-                tracing::info!(
-                    target: "rts_mcp",
-                    "lazy-mounted workspace {} as id={} on first tool call (attempt={})",
-                    self.workspace.display(),
-                    workspace_id,
-                    attempt,
-                );
-                self.mounted
-                    .store(true, std::sync::atomic::Ordering::Release);
-            }
-            match guard.call(method, params.clone()).await {
-                Ok(v) => return Ok(v),
-                Err(e) if attempt == 0 && e.is_disconnect() => {
-                    tracing::warn!(
-                        target: "rts_mcp",
-                        "daemon disconnected during {} ({}); reconnecting + retrying",
-                        method,
-                        e.message,
-                    );
-                    guard.reconnect().await?;
-                    // The respawned daemon has no Workspace.Mount — clear
-                    // the sentinel so the retry iteration re-mounts before
-                    // re-issuing the original call.
-                    self.mounted
-                        .store(false, std::sync::atomic::Ordering::Release);
-                    drop(guard);
-                    continue;
-                }
-                Err(e) => return Err(e),
-            }
-        }
-        // Unreachable: the loop either returns or continues; the
-        // `continue` arm runs exactly once because `attempt == 0`
-        // gates it. Defensive return so the compiler is satisfied.
-        Err(DaemonError {
-            code: "INTERNAL_ERROR".to_string(),
-            message: "exhausted reconnect retries".to_string(),
-            data: None,
-        })
+    /// The pre-resilience inline retry-on-disconnect loop has moved
+    /// into the manager (`crates/rts-mcp/src/connection.rs`); calls
+    /// here are one-shot. Concurrent tool calls during a known
+    /// disconnect window all see the same structured error without
+    /// queueing on the daemon mutex (no thundering-herd).
+    async fn call_daemon(&self, method: &str, params: Value) -> Result<Value, ConnectionError> {
+        self.connection.call(method, params).await
     }
 
     #[tool(
@@ -489,7 +390,7 @@ impl RtsServer {
             .await
         {
             Ok(v) => Ok(success_json(&v)),
-            Err(e) => Ok(daemon_error_to_call_result(&e)),
+            Err(e) => Ok(connection_error_to_call_result(&e)),
         }
     }
 
@@ -527,7 +428,7 @@ impl RtsServer {
             .await
         {
             Ok(v) => Ok(success_json(&v)),
-            Err(e) => Ok(daemon_error_to_call_result(&e)),
+            Err(e) => Ok(connection_error_to_call_result(&e)),
         }
     }
 
@@ -551,7 +452,7 @@ impl RtsServer {
             .await
         {
             Ok(v) => Ok(success_json(&v)),
-            Err(e) => Ok(daemon_error_to_call_result(&e)),
+            Err(e) => Ok(connection_error_to_call_result(&e)),
         }
     }
 
@@ -581,7 +482,7 @@ impl RtsServer {
             .await
         {
             Ok(v) => Ok(success_json(&v)),
-            Err(e) => Ok(daemon_error_to_call_result(&e)),
+            Err(e) => Ok(connection_error_to_call_result(&e)),
         }
     }
 
@@ -615,7 +516,7 @@ impl RtsServer {
             .await
         {
             Ok(v) => Ok(success_json(&v)),
-            Err(e) => Ok(daemon_error_to_call_result(&e)),
+            Err(e) => Ok(connection_error_to_call_result(&e)),
         }
     }
 
@@ -654,7 +555,7 @@ impl RtsServer {
             .await
         {
             Ok(v) => Ok(success_json(&v)),
-            Err(e) => Ok(daemon_error_to_call_result(&e)),
+            Err(e) => Ok(connection_error_to_call_result(&e)),
         }
     }
 
@@ -677,7 +578,7 @@ impl RtsServer {
             .await
         {
             Ok(v) => Ok(success_json(&v)),
-            Err(e) => Ok(daemon_error_to_call_result(&e)),
+            Err(e) => Ok(connection_error_to_call_result(&e)),
         }
     }
 
@@ -730,7 +631,7 @@ impl RtsServer {
         }
         match self.call_daemon("Index.Grep", Value::Object(params)).await {
             Ok(v) => Ok(success_json(&v)),
-            Err(e) => Ok(daemon_error_to_call_result(&e)),
+            Err(e) => Ok(connection_error_to_call_result(&e)),
         }
     }
 
@@ -746,7 +647,7 @@ impl RtsServer {
             .await
         {
             Ok(v) => Ok(success_json(&v)),
-            Err(e) => Ok(daemon_error_to_call_result(&e)),
+            Err(e) => Ok(connection_error_to_call_result(&e)),
         }
     }
 }
@@ -770,20 +671,26 @@ fn success_json(value: &Value) -> CallToolResult {
     CallToolResult::success(vec![Content::text(text)])
 }
 
-/// Map a daemon-side `error` envelope to a `CallToolResult::error`. The
-/// agent gets a structured payload `{ code, message, data }` so it can act
-/// on `INDEX_NOT_READY` (poll later), `SYMBOL_NOT_FOUND` (rephrase), or
-/// `OUT_OF_ROOT` (drop the path) without parsing English text.
+/// Map a connection-or-daemon-side error to a `CallToolResult::error`.
+/// The agent gets a structured payload `{ code, message, data }` so it
+/// can act on:
 ///
-/// Note: per protocol-v0 §7.6, `find_symbol` empty results are a *success*
-/// path with `matches: []`, not an error — so this function only fires for
-/// real protocol errors.
-fn daemon_error_to_call_result(e: &DaemonError) -> CallToolResult {
+/// - `DAEMON_UNAVAILABLE` (transient; retry in `retry_after_ms`)
+/// - `DAEMON_DOWN` (sustained outage; surface to user)
+/// - `INDEX_NOT_READY` (poll), `SYMBOL_NOT_FOUND` (rephrase),
+///   `OUT_OF_ROOT` (drop the path), etc.
+///
+/// without parsing English text.
+///
+/// Per protocol-v0 §7.6, `find_symbol` empty results are a *success*
+/// path with `matches: []`, not an error — so this function only fires
+/// for real protocol or transport errors.
+fn connection_error_to_call_result(e: &ConnectionError) -> CallToolResult {
     let body = json!({
         "error": {
-            "code":    e.code,
-            "message": e.message,
-            "data":    e.data.clone().unwrap_or(Value::Null),
+            "code":    e.code(),
+            "message": e.message(),
+            "data":    e.data(),
         }
     });
     let text = serde_json::to_string(&body).unwrap_or_else(|_| e.to_string());

--- a/crates/rts-mcp/tests/connection_resilience.rs
+++ b/crates/rts-mcp/tests/connection_resilience.rs
@@ -1,0 +1,707 @@
+//! Integration tests for the MCP connection-manager resilience layer
+//! (Plan 004, `docs/plans/2026-05-19-004-feat-mcp-server-resilience-plan.md`).
+//!
+//! Four scenarios exercised end-to-end against real `rts-mcp` and
+//! `rts-daemon` binaries — no mocks for cross-crate interfaces, per
+//! `AGENTS.md` testing conventions:
+//!
+//! 1. **Daemon idle-shutdown survival.** Setting
+//!    `RTS_IDLE_SHUTDOWN_SECS=2` and idling longer than that should
+//!    NOT bring the daemon down while the MCP shim is attached — the
+//!    shim's heartbeat keeps `active_connections > 0`. The next tool
+//!    call still succeeds.
+//! 2. **Daemon SIGKILL recovery.** Killing the daemon mid-session
+//!    produces a `DAEMON_UNAVAILABLE` (`-32098`) error from concurrent
+//!    tool calls, then auto-reconnects + auto-spawns a fresh daemon
+//!    and resumes serving successfully.
+//! 3. **MCP shim crash leaves daemon alive.** A second `rts-mcp`
+//!    process connects to the same daemon after the first one is
+//!    killed; the daemon process keeps the same PID.
+//! 4. **Concurrent tool calls during reconnect.** 10 concurrent
+//!    `find_symbol` calls fired during a known disconnect window
+//!    all return `DAEMON_UNAVAILABLE` with consistent shape (no
+//!    thundering-herd on the daemon mutex; all 10 short-circuit on
+//!    the state check).
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout};
+
+fn rts_mcp_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-mcp"))
+}
+
+fn rts_daemon_bin() -> PathBuf {
+    let mcp = rts_mcp_bin();
+    let parent = mcp.parent().expect("CARGO_BIN_EXE_rts-mcp has parent dir");
+    parent.join("rts-daemon")
+}
+
+async fn read_one_response(reader: &mut BufReader<ChildStdout>) -> Result<Value> {
+    let mut buf = Vec::new();
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow!("timeout reading MCP response"))??;
+    if n == 0 {
+        anyhow::bail!("EOF before MCP response");
+    }
+    serde_json::from_slice(&buf).context("decode MCP response")
+}
+
+async fn send_request(stdin: &mut ChildStdin, req: &Value) -> Result<()> {
+    let mut bytes = serde_json::to_vec(req)?;
+    bytes.push(b'\n');
+    stdin.write_all(&bytes).await?;
+    stdin.flush().await?;
+    Ok(())
+}
+
+/// Standard MCP handshake: `initialize` + `notifications/initialized`.
+async fn handshake(stdin: &mut ChildStdin, reader: &mut BufReader<ChildStdout>) -> Result<()> {
+    send_request(
+        stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "resilience-itest", "version": "0.0.0" }
+            }
+        }),
+    )
+    .await?;
+    let _ = read_one_response(reader).await?;
+    send_request(
+        stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {}
+        }),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Poll `find_symbol` until the writer commits and the symbol appears.
+async fn poll_find_symbol_success(
+    stdin: &mut ChildStdin,
+    reader: &mut BufReader<ChildStdout>,
+    next_id: &mut u64,
+    name: &str,
+    deadline: Instant,
+) -> Result<()> {
+    while Instant::now() < deadline {
+        *next_id += 1;
+        send_request(
+            stdin,
+            &json!({
+                "jsonrpc": "2.0",
+                "id": *next_id,
+                "method": "tools/call",
+                "params": {
+                    "name": "find_symbol",
+                    "arguments": { "name": name }
+                }
+            }),
+        )
+        .await?;
+        let resp = read_one_response(reader).await?;
+        if resp["result"]["isError"] == Value::Bool(false) {
+            let body = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+            let parsed: Value = serde_json::from_str(body).unwrap_or(Value::Null);
+            if parsed["matches"]
+                .as_array()
+                .map(|a| !a.is_empty())
+                .unwrap_or(false)
+            {
+                return Ok(());
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    Err(anyhow!("symbol {name} never appeared via find_symbol"))
+}
+
+/// Per-workspace lockfile path matching the daemon's
+/// `socket::socket_path_for_workspace` (mirrored from the existing
+/// `mcp_round_trip` test). Used to find + kill the daemon process.
+fn ws_pid_path(
+    daemon_runtime_dir: &std::path::Path,
+    canonical_workspace: &std::path::Path,
+) -> PathBuf {
+    let bytes = canonical_workspace.as_os_str().as_encoded_bytes();
+    let hash = blake3::hash(bytes);
+    let short = hash.to_hex();
+    let short16 = &short.as_str()[..16];
+    daemon_runtime_dir.join(format!("ws-{short16}.sock.pid"))
+}
+
+fn daemon_runtime_dir(runtime_dir: &std::path::Path, home_dir: &std::path::Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        home_dir.join("Library").join("Caches").join("rts")
+    } else {
+        runtime_dir.join("rts")
+    }
+}
+
+/// Spawn rts-mcp with consistent test env. Defaults to fast heartbeat
+/// (`RTS_MCP_HEARTBEAT_INTERVAL_SECS=1`) so tests don't pay the 10s
+/// default per scenario.
+fn spawn_rts_mcp(
+    workspace: &std::path::Path,
+    runtime_dir: &std::path::Path,
+    state_dir: &std::path::Path,
+    home_dir: &std::path::Path,
+    daemon_bin: &std::path::Path,
+    extra_env: &[(&str, &str)],
+) -> Result<Child> {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir, std::fs::Permissions::from_mode(0o700));
+
+    let mut cmd = tokio::process::Command::new(rts_mcp_bin());
+    cmd.arg("--workspace")
+        .arg(workspace)
+        .env("XDG_RUNTIME_DIR", runtime_dir)
+        .env("XDG_STATE_HOME", state_dir)
+        .env("HOME", home_dir)
+        .env("RTS_LOG", "warn")
+        .env("RTS_DAEMON_BIN", daemon_bin)
+        // Fast heartbeat so test reconnect-window windows are
+        // measured in seconds, not tens of seconds.
+        .env("RTS_MCP_HEARTBEAT_INTERVAL_SECS", "1")
+        .env("RTS_MCP_HEARTBEAT_TIMEOUT_SECS", "2")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    cmd.spawn().context("spawn rts-mcp")
+}
+
+/// Scenario 1: Daemon idle-shutdown survival.
+///
+/// `RTS_IDLE_SHUTDOWN_SECS=2` would, in pre-resilience code, let the
+/// daemon shut itself down 2s after the last RPC if no connections
+/// were holding it open. With the connection manager, the heartbeat
+/// keeps `active_connections > 0` (one open UDS) AND issues
+/// `Daemon.Ping` every 1s in this test (refreshing `last_activity`),
+/// so idle-shutdown should NEVER fire. We idle for 5s — well past the
+/// 2s window — and verify the next tool call succeeds without a
+/// reconnect.
+///
+/// Intent: encodes Rule 9 — the heartbeat-defeats-idle-shutdown
+/// interaction is intentional and load-bearing. Regression here means
+/// long agent sessions silently lose their daemon.
+#[tokio::test(flavor = "current_thread")]
+async fn scenario_1_idle_shutdown_survival() -> Result<()> {
+    let daemon_bin = rts_daemon_bin();
+    assert!(daemon_bin.is_file(), "rts-daemon must be built first");
+
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    std::fs::write(workspace.path().join("lib.rs"), "pub fn idle_probe() {}\n")?;
+
+    let mut child = spawn_rts_mcp(
+        workspace.path(),
+        runtime_dir.path(),
+        state_dir.path(),
+        home_dir.path(),
+        &daemon_bin,
+        // Aggressive 2-second idle window. Daemon should be killable
+        // by idle-shutdown WITHOUT the heartbeat keeping it warm.
+        &[("RTS_IDLE_SHUTDOWN_SECS", "2")],
+    )?;
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    let mut reader = BufReader::new(child.stdout.take().expect("piped stdout"));
+
+    handshake(&mut stdin, &mut reader).await?;
+    let mut next_id: u64 = 10;
+    let deadline = Instant::now() + Duration::from_secs(10);
+    poll_find_symbol_success(
+        &mut stdin,
+        &mut reader,
+        &mut next_id,
+        "idle_probe",
+        deadline,
+    )
+    .await?;
+
+    // Idle 5 seconds — more than 2x the configured idle window. If
+    // the heartbeat path were broken (no active connection, no
+    // refresh of last_activity), the daemon would shut down here.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Second tool call. If it succeeds (with or without a transient
+    // reconnect), we know the manager survived idle-shutdown.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    poll_find_symbol_success(
+        &mut stdin,
+        &mut reader,
+        &mut next_id,
+        "idle_probe",
+        deadline,
+    )
+    .await?;
+
+    drop(stdin);
+    let _ = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
+    Ok(())
+}
+
+/// Scenario 2: Daemon SIGKILL recovery.
+///
+/// Kill the daemon mid-session, observe one of:
+/// (a) a `DAEMON_UNAVAILABLE` error from a tool call hitting the
+///     post-kill-pre-reconnect window, OR
+/// (b) a transient success that returns from the auto-spawned fresh
+///     daemon (the heartbeat task or the call's own demote-and-spawn
+///     path got there first).
+/// Then verify the manager fully recovers — subsequent tool calls
+/// succeed via the fresh daemon.
+///
+/// Intent: the agent-visible failure mode in PR #114's predecessor
+/// (the originating incident) was "tool call fails with broken pipe,
+/// session never recovers." The structured error code + reconnect
+/// loop closes both gaps.
+#[tokio::test(flavor = "current_thread")]
+async fn scenario_2_sigkill_recovery() -> Result<()> {
+    let daemon_bin = rts_daemon_bin();
+    assert!(daemon_bin.is_file(), "rts-daemon must be built first");
+
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    std::fs::write(workspace.path().join("lib.rs"), "pub fn kill_probe() {}\n")?;
+    let canonical_workspace = workspace.path().canonicalize()?;
+
+    let mut child = spawn_rts_mcp(
+        workspace.path(),
+        runtime_dir.path(),
+        state_dir.path(),
+        home_dir.path(),
+        &daemon_bin,
+        &[("RTS_IDLE_SHUTDOWN_SECS", "60")],
+    )?;
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    let mut reader = BufReader::new(child.stdout.take().expect("piped stdout"));
+
+    handshake(&mut stdin, &mut reader).await?;
+    let mut next_id: u64 = 10;
+    let deadline = Instant::now() + Duration::from_secs(10);
+    poll_find_symbol_success(
+        &mut stdin,
+        &mut reader,
+        &mut next_id,
+        "kill_probe",
+        deadline,
+    )
+    .await?;
+
+    // Find + SIGKILL the daemon.
+    let pid_path = ws_pid_path(
+        &daemon_runtime_dir(runtime_dir.path(), home_dir.path()),
+        &canonical_workspace,
+    );
+    assert!(
+        pid_path.exists(),
+        "daemon lockfile missing at {}",
+        pid_path.display()
+    );
+    let pid_text = std::fs::read_to_string(&pid_path)?;
+    let pid_line = pid_text.lines().next().expect("non-empty PID lockfile");
+    let pid: u32 = pid_line.trim().parse().context("parse daemon PID")?;
+    let kill_status = std::process::Command::new("kill")
+        .arg("-9")
+        .arg(pid.to_string())
+        .status()?;
+    assert!(kill_status.success(), "kill -9 {pid} failed");
+
+    // Brief settling delay so the kill has actually closed the socket.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Issue a tool call within the heartbeat-detection window. With
+    // the 1-second heartbeat interval set in spawn_rts_mcp, the
+    // manager should have demoted to Reconnecting by now and either
+    // surface DAEMON_UNAVAILABLE or have already reconnected via the
+    // background task.
+    next_id += 1;
+    send_request(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": next_id,
+            "method": "tools/call",
+            "params": {
+                "name": "find_symbol",
+                "arguments": { "name": "kill_probe" }
+            }
+        }),
+    )
+    .await?;
+    let resp = read_one_response(&mut reader).await?;
+    // Two acceptable shapes: DAEMON_UNAVAILABLE (during window) OR
+    // an immediate success (if the reconnect race resolved in our
+    // favor). Both prove the resilience layer is active.
+    let is_error = resp["result"]["isError"] == Value::Bool(true);
+    if is_error {
+        let body_str = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+        let parsed: Value = serde_json::from_str(body_str).unwrap_or(Value::Null);
+        let code = parsed["error"]["code"].as_str().unwrap_or("");
+        assert_eq!(
+            code, "DAEMON_UNAVAILABLE",
+            "expected DAEMON_UNAVAILABLE during disconnect window; got {parsed:?}"
+        );
+        // retry_after_ms hint MUST be present and non-negative; the
+        // whole point of the structured error is letting the agent
+        // back off.
+        let retry_after_ms = parsed["error"]["data"]["retry_after_ms"]
+            .as_u64()
+            .expect("retry_after_ms must be present");
+        // Should be within the backoff schedule (≤ ceiling). Use the
+        // default ceiling of 30 s (we didn't override it in env).
+        assert!(
+            retry_after_ms <= 30_000,
+            "retry_after_ms {retry_after_ms} > 30s ceiling"
+        );
+        assert_eq!(
+            parsed["error"]["data"]["transient"],
+            Value::Bool(true),
+            "transient flag must be true for DAEMON_UNAVAILABLE"
+        );
+    }
+
+    // Recovery path. The reconnect loop should bring up a fresh daemon
+    // within the bounded schedule. Poll until find_symbol succeeds via
+    // the new daemon. Bound the wait generously — cold-walk + Mount on
+    // the respawned daemon takes longer than steady-state.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    poll_find_symbol_success(
+        &mut stdin,
+        &mut reader,
+        &mut next_id,
+        "kill_probe",
+        deadline,
+    )
+    .await?;
+
+    drop(stdin);
+    let _ = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
+    Ok(())
+}
+
+/// Scenario 3: MCP shim crash leaves daemon alive.
+///
+/// Spawn a daemon (via one rts-mcp shim), kill the shim, spawn a
+/// fresh shim against the same workspace, verify it connects to the
+/// SAME daemon (PID unchanged in the lockfile).
+///
+/// Intent: the daemon's existence is the workspace's invariant, not
+/// the MCP shim's. A crashed MCP host (Claude Code restart, Cursor
+/// upgrade) must not bring the daemon down — the daemon's
+/// idle-shutdown path is gated on connection count AND activity
+/// window, neither of which trips instantly.
+///
+/// Note: this test does NOT verify `mount_refcount`/`active_connections`
+/// directly because `Daemon.Stats` doesn't currently expose those
+/// counters. We verify the observable invariant (same daemon PID
+/// across shim lifetimes), which is the load-bearing contract.
+#[tokio::test(flavor = "current_thread")]
+async fn scenario_3_shim_crash_leaves_daemon_alive() -> Result<()> {
+    let daemon_bin = rts_daemon_bin();
+    assert!(daemon_bin.is_file(), "rts-daemon must be built first");
+
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    std::fs::write(
+        workspace.path().join("lib.rs"),
+        "pub fn survive_probe() {}\n",
+    )?;
+    let canonical_workspace = workspace.path().canonicalize()?;
+
+    // Spawn the first MCP shim — this auto-spawns a daemon.
+    let mut child1 = spawn_rts_mcp(
+        workspace.path(),
+        runtime_dir.path(),
+        state_dir.path(),
+        home_dir.path(),
+        &daemon_bin,
+        // Long idle window so the daemon doesn't shut down between
+        // shim 1 and shim 2.
+        &[("RTS_IDLE_SHUTDOWN_SECS", "60")],
+    )?;
+    let mut stdin1 = child1.stdin.take().expect("piped stdin");
+    let mut reader1 = BufReader::new(child1.stdout.take().expect("piped stdout"));
+    handshake(&mut stdin1, &mut reader1).await?;
+    let mut next_id: u64 = 10;
+    let deadline = Instant::now() + Duration::from_secs(10);
+    poll_find_symbol_success(
+        &mut stdin1,
+        &mut reader1,
+        &mut next_id,
+        "survive_probe",
+        deadline,
+    )
+    .await?;
+
+    // Capture the daemon PID before we kill shim 1.
+    let pid_path = ws_pid_path(
+        &daemon_runtime_dir(runtime_dir.path(), home_dir.path()),
+        &canonical_workspace,
+    );
+    let pid_text_before = std::fs::read_to_string(&pid_path)?;
+    let daemon_pid_before: u32 = pid_text_before
+        .lines()
+        .next()
+        .expect("non-empty PID lockfile")
+        .trim()
+        .parse()
+        .context("parse daemon PID (before)")?;
+
+    // Kill the MCP shim. SIGKILL avoids the clean-shutdown stats
+    // dump but more closely models a real Claude Code/Cursor crash.
+    drop(stdin1); // close stdin first → service.waiting() returns
+    let _ = tokio::time::timeout(Duration::from_secs(3), child1.wait()).await;
+    // Give the daemon a moment to observe the dropped connection
+    // (active_connections decrement is async via the accept-loop's
+    // disconnect handler).
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Spawn shim 2 against the same workspace. It should reach the
+    // same daemon (same PID in the lockfile).
+    let mut child2 = spawn_rts_mcp(
+        workspace.path(),
+        runtime_dir.path(),
+        state_dir.path(),
+        home_dir.path(),
+        &daemon_bin,
+        &[("RTS_IDLE_SHUTDOWN_SECS", "60")],
+    )?;
+    let mut stdin2 = child2.stdin.take().expect("piped stdin");
+    let mut reader2 = BufReader::new(child2.stdout.take().expect("piped stdout"));
+    handshake(&mut stdin2, &mut reader2).await?;
+    let mut next_id: u64 = 10;
+    let deadline = Instant::now() + Duration::from_secs(10);
+    poll_find_symbol_success(
+        &mut stdin2,
+        &mut reader2,
+        &mut next_id,
+        "survive_probe",
+        deadline,
+    )
+    .await?;
+
+    // Verify the daemon PID didn't change — i.e. shim 2 is talking
+    // to the SAME daemon shim 1 was using.
+    let pid_text_after = std::fs::read_to_string(&pid_path)?;
+    let daemon_pid_after: u32 = pid_text_after
+        .lines()
+        .next()
+        .expect("non-empty PID lockfile")
+        .trim()
+        .parse()
+        .context("parse daemon PID (after)")?;
+    assert_eq!(
+        daemon_pid_before, daemon_pid_after,
+        "daemon PID changed across shim crash — daemon should outlive any single MCP shim"
+    );
+
+    drop(stdin2);
+    let _ = tokio::time::timeout(Duration::from_secs(5), child2.wait()).await;
+    Ok(())
+}
+
+/// Scenario 4: Concurrent tool calls during reconnect.
+///
+/// Kill the daemon, then fire 10 concurrent tool calls during the
+/// reconnect window. Each call should observe non-Connected state and
+/// return DAEMON_UNAVAILABLE quickly (without queuing on the daemon
+/// mutex). At least one of the 10 must hit the disconnect window
+/// before the reconnect loop recovers; calls that race the recovery
+/// and succeed are also acceptable. Critically: no call should hang.
+///
+/// Intent: pre-resilience, the inline retry-on-disconnect loop would
+/// serialize all 10 calls on the daemon mutex, each paying the
+/// auto-spawn wait. After resilience, calls in the Reconnecting
+/// window short-circuit at the read-lock state check — no
+/// thundering-herd on the daemon mutex.
+#[tokio::test(flavor = "current_thread")]
+async fn scenario_4_concurrent_calls_during_reconnect() -> Result<()> {
+    let daemon_bin = rts_daemon_bin();
+    assert!(daemon_bin.is_file(), "rts-daemon must be built first");
+
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    std::fs::write(workspace.path().join("lib.rs"), "pub fn herd_probe() {}\n")?;
+    let canonical_workspace = workspace.path().canonicalize()?;
+
+    let mut child = spawn_rts_mcp(
+        workspace.path(),
+        runtime_dir.path(),
+        state_dir.path(),
+        home_dir.path(),
+        &daemon_bin,
+        &[("RTS_IDLE_SHUTDOWN_SECS", "60")],
+    )?;
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    let mut reader = BufReader::new(child.stdout.take().expect("piped stdout"));
+    handshake(&mut stdin, &mut reader).await?;
+    let mut next_id: u64 = 10;
+    let deadline = Instant::now() + Duration::from_secs(10);
+    poll_find_symbol_success(
+        &mut stdin,
+        &mut reader,
+        &mut next_id,
+        "herd_probe",
+        deadline,
+    )
+    .await?;
+
+    // Kill daemon.
+    let pid_path = ws_pid_path(
+        &daemon_runtime_dir(runtime_dir.path(), home_dir.path()),
+        &canonical_workspace,
+    );
+    let pid_text = std::fs::read_to_string(&pid_path)?;
+    let pid: u32 = pid_text
+        .lines()
+        .next()
+        .expect("non-empty PID lockfile")
+        .trim()
+        .parse()
+        .context("parse daemon PID")?;
+    let kill_status = std::process::Command::new("kill")
+        .arg("-9")
+        .arg(pid.to_string())
+        .status()?;
+    assert!(kill_status.success());
+
+    // Don't wait for the heartbeat to detect the death — fire the
+    // herd immediately. The first call's own demote path will move
+    // the manager into Reconnecting; the remaining 9 should
+    // short-circuit on the state check. Stdio is serialized
+    // (single-connection MCP), so we send all 10 requests then read
+    // all 10 responses.
+    let herd_size = 10;
+    let request_send_start = Instant::now();
+    let mut request_ids = Vec::with_capacity(herd_size);
+    for _ in 0..herd_size {
+        next_id += 1;
+        request_ids.push(next_id);
+        send_request(
+            &mut stdin,
+            &json!({
+                "jsonrpc": "2.0",
+                "id": next_id,
+                "method": "tools/call",
+                "params": {
+                    "name": "find_symbol",
+                    "arguments": { "name": "herd_probe" }
+                }
+            }),
+        )
+        .await?;
+    }
+    let send_elapsed = request_send_start.elapsed();
+    // The whole herd should send in well under the auto-spawn
+    // deadline (5s). If the manager queued every call on the daemon
+    // mutex during reconnect, we'd see 5s+ of wall clock here even
+    // before reading responses.
+    assert!(
+        send_elapsed < Duration::from_secs(2),
+        "10 concurrent requests took {send_elapsed:?} to enqueue — \
+         transport-level back-pressure suggests they're serializing on the daemon mutex"
+    );
+
+    // Collect responses. Each must be a parseable MCP envelope; we
+    // count how many returned DAEMON_UNAVAILABLE vs success.
+    let mut unavailable_count = 0usize;
+    let mut success_count = 0usize;
+    let mut other_error_count = 0usize;
+    let mut retry_after_values: Vec<u64> = Vec::new();
+    for _ in 0..herd_size {
+        let resp = read_one_response(&mut reader).await?;
+        if resp["result"]["isError"] == Value::Bool(true) {
+            let body_str = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+            let parsed: Value = serde_json::from_str(body_str).unwrap_or(Value::Null);
+            let code = parsed["error"]["code"].as_str().unwrap_or("");
+            if code == "DAEMON_UNAVAILABLE" {
+                unavailable_count += 1;
+                if let Some(n) = parsed["error"]["data"]["retry_after_ms"].as_u64() {
+                    retry_after_values.push(n);
+                }
+            } else {
+                other_error_count += 1;
+            }
+        } else {
+            success_count += 1;
+        }
+    }
+
+    // We expect:
+    // - All 10 responses parseable (no hangs / no malformed shapes).
+    // - At least one DAEMON_UNAVAILABLE (the daemon was just killed;
+    //   the first transport error in the herd demotes state and the
+    //   rest short-circuit).
+    // - Zero `other_error_count`: the only error shape during a
+    //   disconnect window is DAEMON_UNAVAILABLE (or DAEMON_DOWN
+    //   after exhausting attempts, which doesn't happen in a 10-call
+    //   burst).
+    assert_eq!(
+        unavailable_count + success_count + other_error_count,
+        herd_size,
+        "all {herd_size} responses must arrive"
+    );
+    assert!(
+        unavailable_count >= 1,
+        "at least one call must hit the disconnect window; got \
+         unavailable={unavailable_count}, success={success_count}, other={other_error_count}"
+    );
+    assert_eq!(
+        other_error_count, 0,
+        "unexpected non-DAEMON_UNAVAILABLE error shape in the herd"
+    );
+
+    // retry_after_ms hints should all be in the same ballpark (≤ 30s
+    // ceiling). Consistency check: the spread across the 10 hints
+    // shouldn't be wider than the reconnect ceiling. This catches a
+    // future bug where one caller computed retry_after_ms from a
+    // stale state snapshot.
+    if let (Some(min), Some(max)) = (
+        retry_after_values.iter().min(),
+        retry_after_values.iter().max(),
+    ) {
+        assert!(
+            *max <= 30_000,
+            "retry_after_ms {max} > 30s ceiling — backoff schedule misconfigured"
+        );
+        assert!(
+            max - min <= 30_000,
+            "retry_after_ms spread {min}..={max} too wide; should be bounded by reconnect ceiling"
+        );
+    }
+
+    drop(stdin);
+    let _ = tokio::time::timeout(Duration::from_secs(10), child.wait()).await;
+    Ok(())
+}

--- a/docs/protocol-v0.md
+++ b/docs/protocol-v0.md
@@ -1190,6 +1190,44 @@ All errors use string codes (not JSON-RPC numeric codes — easier to grep, more
 
 `error.data` MAY carry structured detail (e.g. `{ "expected_uid": 501, "got_uid": 0 }` for the auth check, or `{ "files_done": 1234, "files_total": 5000 }` for `INDEX_NOT_READY` — same shape as `progress`).
 
+### 14.1 MCP-shim transport errors (`DAEMON_UNAVAILABLE` / `DAEMON_DOWN`)
+
+The `rts-mcp` shim's connection manager (Plan
+`docs/plans/2026-05-19-004-feat-mcp-server-resilience-plan.md`, v0.6+,
+capability `mcp_connection_resilience`) surfaces two **shim-emitted**
+error codes when the daemon socket is mid-reconnect. These are not
+daemon-side codes — the daemon never emits them; they originate in
+the shim and reach the MCP host with custom JSON-RPC numeric codes
+distinct from the application range:
+
+| String code | Numeric code | Meaning | Retriable? |
+|---|---|---|---|
+| `DAEMON_UNAVAILABLE` | `-32098` | Transient: the shim is in `Reconnecting` state. `error.data.retry_after_ms` carries the wall-clock hint until the next reconnect attempt. `error.data.attempt` is the current retry attempt (1-indexed). | Yes — wait `retry_after_ms` and retry. |
+| `DAEMON_DOWN` | `-32097` | Sustained: reconnect attempts exhausted after `RTS_MCP_RECONNECT_MAX_ATTEMPTS` (default 8); ceiling-interval (`RTS_MCP_RECONNECT_CEILING_SECS`, default 30) retries continue forever. `error.data.first_failure_ms_ago` carries how long the daemon has been unreachable. | Eventually — recovery promotes back to `Connected` automatically when the daemon returns; agents seeing this should surface to the user. |
+
+Both shapes set `error.data.transient: true|false` so agents can branch
+on a single boolean without parsing the code string.
+
+**Heartbeat ↔ idle-shutdown interaction.** The shim's heartbeat issues
+`Daemon.Ping` every `RTS_MCP_HEARTBEAT_INTERVAL_SECS` (default 10s).
+The daemon's idle-shutdown is already gated on `active_connections > 0`
+(§15.2), but the heartbeat additionally bumps `last_activity` so a
+future loosening of the connection-count gate still sees fresh
+traffic. **An MCP shim that's still attached keeps its daemon alive —
+this is intentional.**
+
+**Environment knobs** (all have documented defaults; nothing requires
+user setup):
+
+| Env var | Default | Effect |
+|---|---|---|
+| `RTS_MCP_HEARTBEAT_INTERVAL_SECS` | `10` | Wait between heartbeat `Daemon.Ping` calls. |
+| `RTS_MCP_HEARTBEAT_TIMEOUT_SECS` | `3` | Per-ping timeout; on timeout the manager demotes to `Reconnecting`. |
+| `RTS_MCP_RECONNECT_MAX_ATTEMPTS` | `8` | Bounded attempts before transitioning to `Down`. Retries continue at ceiling forever after. |
+| `RTS_MCP_RECONNECT_CEILING_SECS` | `30` | Backoff ceiling. Schedule is `1s, 2s, 4s, 8s, 16s, 30s, 30s, …`. |
+
+Source of truth: `crates/rts-mcp/src/connection.rs`.
+
 **`Index.Grep` v2 sub-codes (v0.6, capability `index_grep_v2`).** Every v2 validation/execution error returns the protocol-level code `INVALID_PARAMS` and carries a stable `data.code` string that lets agents branch without parsing free-form messages. The strings are documented in §7.8b's "v0.6 additions" table; the closed set is:
 
 `MULTILINE_REQUIRES_REGEX`, `STRUCTURAL_REQUIRES_LANGUAGE`, `NO_SEARCH_SOURCE_PROVIDED`, `INVALID_TEXT_LENGTH`, `STRUCTURAL_QUERY_INVALID`, `STRUCTURAL_QUERY_PREDICATE_NOT_ALLOWED`, `WITHIN_SYMBOL_NOT_FOUND`, `WITHIN_SYMBOL_TOO_MANY_DEFS`, `REGEX_TOO_COMPLEX`, `STRUCTURAL_QUERY_TIMEOUT`, `UNKNOWN_LANGUAGE`.
@@ -1640,6 +1678,7 @@ This appendix tracks every additive wire-shape change between Draft 1 (P5 delive
 | `alpha.34` | `pagerank_symbolwise` | **v0.3 U4**: symbol-level PageRank fills `rank_score` in `Index.FindSymbol` and `Index.FindCallers` responses (was a `0.0` placeholder). `Index.FindSymbol.matches[]` sorts by descending rank by default; `sort: "lexical"` opts out. Single-slot generation-keyed cache mirroring `OutlineCache` (alpha.20). | §4.1, §4.2, §7.6, §18.3 |
 | `alpha.35` | `impact_of` | **v0.3 U5** (final): new method `Index.ImpactOf(name, depth?, token_budget?, max_nodes?, exclude_test_paths?)` returns the transitive caller closure via BFS over reverse edges. Four independent truncation flags (`closure_truncated`, `wall_clock_truncated`, `depth_truncated`, `node_count_truncated`) tell the agent why a result is partial. Test-path exclusion (`/tests/`, `_test.rs`, `.spec.ts`) is on by default. Wire shape trimmed from the plan's 9 fields to 6 per Deepening §F3 (no `signature`, no nested `callers[]`). | §4.1, §4.2, §7, §7.7d, §18.4d |
 | `v0.6 alpha` | `index_grep_multiline`, `index_grep_structural`, `index_grep_within_symbol`, `index_grep_v2` | **`Index.Grep` v2** (`index_grep_v2` bundle): five additive optional input fields (`multiline`, `structural_query`, `within_symbol`, `within_symbol_allow_overload`, `language`); per-match `captures` on structural results; top-level `truncated`/`truncation_reason`/`rows_seen`/`rows_returned` on cap breaches; `partial_failures[]` on cross-language structural runs. 11 new `data.code` sub-codes under `INVALID_PARAMS`. Predicate whitelist (7 entries) on agent-supplied S-expression queries. Three new `Daemon.Stats` sub-counters. v1 callers unchanged byte-for-byte. | §4.1, §7.8b, §14 |
+| `v0.6 alpha` | (shim-only — no daemon capability) | **MCP shim resilience** (Plan 004): `rts-mcp` connection manager adds background heartbeat (`Daemon.Ping` every `RTS_MCP_HEARTBEAT_INTERVAL_SECS`, default 10s) and reconnect-with-backoff. Tool calls during a disconnect window return two new MCP-shim error codes: `DAEMON_UNAVAILABLE` (numeric `-32098`, transient — `error.data.retry_after_ms` hint) and `DAEMON_DOWN` (numeric `-32097`, sustained). Schedule: `1s, 2s, 4s, 8s, 16s, 30s, 30s, 30s`; ceiling-interval retries continue forever past the bounded-attempt cap. Daemon wire protocol unchanged. | §14.1 |
 
 Capability strings present in `Daemon.Ping.result.capabilities` after alpha.35 (canonical list, in advertisement order): `outline`, `find_symbol`, `read_symbol`, `read_range`, `rank_score`, `tree_shake`, `partial_responses`, `content_version`, `secrets_blocklist`, `pagerank_filewise`, `closure_walker`, `read_symbol_at`, `fuzzy_match`, `polling_fallback`, `find_callers`, `read_symbol.include_callers`, `pagerank_symbolwise`, `impact_of`. v0.6 alpha appends `index_grep_multiline`, `index_grep_structural`, `index_grep_within_symbol`, `index_grep_v2` (see §7.8b).
 


### PR DESCRIPTION
## Summary

Closes the Round-11 dogfood incident where the rts MCP server silently disconnected mid-session, the agent received only a "their MCP server disconnected" system reminder, and `mcp__rts__*` tools dropped off the tool list with no structured error and no recovery path.

Plan: [`docs/plans/2026-05-19-004-feat-mcp-server-resilience-plan.md`](../blob/main/docs/plans/2026-05-19-004-feat-mcp-server-resilience-plan.md).

### What lands

- **New `crates/rts-mcp/src/connection.rs` module.** `ConnectionManager` owns the per-workspace `DaemonClient` plus two background tokio tasks (heartbeat + reconnect). Three-state machine (`Connected | Reconnecting | Down`) wrapped in `Arc<RwLock<…>>` so concurrent tool calls during a disconnect window short-circuit on the read lock instead of queueing on the daemon mutex (no thundering-herd).
- **Heartbeat loop.** `Daemon.Ping` every `RTS_MCP_HEARTBEAT_INTERVAL_SECS` (default 10s) with `RTS_MCP_HEARTBEAT_TIMEOUT_SECS` (default 3s) per-call timeout. Failures demote state and wake the reconnect task via `Notify`.
- **Reconnect schedule.** `1s, 2s, 4s, 8s, 16s, 30s, 30s, 30s` (`RTS_MCP_RECONNECT_MAX_ATTEMPTS` default 8; `RTS_MCP_RECONNECT_CEILING_SECS` default 30). After the bounded cap, state transitions to `Down` but ceiling-interval retries continue forever — transient outages of arbitrary length still recover.
- **Two new shim-emitted JSON-RPC error codes:**
  - `DAEMON_UNAVAILABLE` (`-32098`, transient) — `error.data.retry_after_ms`, `error.data.attempt`, `error.data.transient: true`.
  - `DAEMON_DOWN` (`-32097`, sustained) — `error.data.first_failure_ms_ago`, `error.data.transient: false`.
- **Cross-binary parity.** The same `ConnectionManager` wires through both binaries:
  - `rts-mcp` (the long-lived MCP shim) enables the background heartbeat.
  - `rts` (the human-facing CLI from PR #113) disables the heartbeat — a single-shot CLI invocation shouldn't spawn a background task it'll abort 50 ms later — but still benefits from the foreground reconnect-on-transport-error path. CLI `render_connection_error` maps both new codes to the documented exit-code 3.
- **Heartbeat ↔ idle-shutdown interaction.** An attached MCP shim keeps its daemon alive (intentional). The daemon's idle-shutdown is already gated on `active_connections > 0`, but the heartbeat additionally refreshes `last_activity` so any future loosening of the connection-count gate still sees fresh traffic. Documented in code comments + protocol-v0 §14.1.
- **Protocol-v0 docs.** New §14.1 catalogues the shim-emitted error codes, their `error.data` shapes, and the four env vars. Appendix F gets a `v0.6 alpha` row pointing at the new section.
- **Changelog fragment** at `changelog.d/xxx-feat-mcp-connection-resilience.md`.

### Testing notes

The four scenarios from the plan are covered end-to-end in the new `crates/rts-mcp/tests/connection_resilience.rs` integration test against real `rts-mcp` and `rts-daemon` binaries (no mocks for cross-crate interfaces):

- [x] **Scenario 1: Daemon idle-shutdown survival.** `RTS_IDLE_SHUTDOWN_SECS=2`, idle 5s, next tool call succeeds.
- [x] **Scenario 2: Daemon SIGKILL recovery.** Kill daemon, observe `DAEMON_UNAVAILABLE` (or transient success on the reconnect race), subsequent calls succeed via auto-respawn.
- [x] **Scenario 3: MCP shim crash leaves daemon alive.** Kill shim 1, shim 2 connects to the SAME daemon PID (asserted via the per-workspace lockfile).
- [x] **Scenario 4: Concurrent tool calls during reconnect.** 10 concurrent calls return consistent `DAEMON_UNAVAILABLE` shapes with bounded `retry_after_ms` hints; no thundering-herd (per-call enqueue time under 2s, well under the auto-spawn deadline).
- [x] Unit tests for the backoff schedule, error-code round-trip, `ResilienceConfig` defaults.
- [x] Existing `mcp_round_trip` tests (including `mcp_reconnects_after_daemon_death` from PR #94) still pass — the retry-on-disconnect contract is preserved.
- [x] `cargo fmt --all` clean.
- [x] `cargo clippy -p rts-mcp --all-targets -- -D warnings` clean (the CI-gated subset of clippy).
- [x] `cargo test --workspace` passes.
- [x] No `unsafe` blocks (workspace `unsafe_code = "deny"`).

### Motivation

The originating incident is real and reproducible from this session's transcript (2026-05-19, Round-11). The agent was mid-orchestration on three parallel implementation PRs; the system reminder showed `MCP servers have disconnected: rts`; the rts MCP tools dropped off the tool list; no retry, no error, no path to recovery without a session restart.

For a project whose entire pitch is "AST-precise code retrieval for AI agents," a tool that abandons agents on first flake is a tool agents won't come back to. Disconnections compound: the agent works around once; the second disconnection in the same workspace teaches the agent to default to `Bash(grep)` permanently.

This change closes the gap with shapes proven in gRPC keepalive, HTTP/2 GOAWAY, and Tower's retry stack.

### Post-Deploy Monitoring & Validation

Monitor session telemetry for `MCP servers have disconnected` log lines; should drop to ~zero. No additional production infrastructure required.

### Out of scope

- **`Daemon.Stats` disconnection counters** (`disconnections.total`, etc.). Better folded into the opt-in telemetry plan than dragged into this PR — sibling-field pattern reserved for that landing.
- **MCP protocol-level reconnect** (shim → MCP host). That's the host's responsibility, not ours.
- **Multi-daemon failover.** Single-process daemon is the only supported topology in v0.6.

🤖 Generated with Claude Opus 4.7 (1M context) via Claude Code + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>