### PR TITLE
feat(rts-daemon): export JSON Schema for every protocol-v0 method

### DIFF
--- a/.github/workflows/schemas-check.yml
+++ b/.github/workflows/schemas-check.yml
@@ -1,0 +1,50 @@
+name: protocol-v0 schemas check
+
+# Runs the `protocol_schemas` test suite (both the static-file
+# tests and the daemon-round-trip tests) on every PR. The
+# `--include-ignored` flag opts back into the two #[ignore]-by-default
+# tests that spawn the daemon binary — these are the ones that catch
+# schema-vs-code drift.
+#
+# Dedicated workflow file so concurrent PRs touching `.github/workflows/ci.yml`
+# don't conflict here. See `schemas/v0/README.md` for the
+# schema-versioning convention this guards.
+
+on:
+  push:
+    branches: [main, master, feature/**, feat/**]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+jobs:
+  schemas:
+    name: protocol-v0 schemas drift check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo/target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-schemas-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build rts-daemon (so the round-trip test can spawn it)
+        run: cargo build -p rts-daemon --bin rts-daemon
+
+      - name: Schemas check (static parse + dispatcher coverage)
+        run: cargo test -p rts-daemon --test protocol_schemas
+
+      - name: Schemas check (live daemon round-trip)
+        run: cargo test -p rts-daemon --test protocol_schemas -- --include-ignored

--- a/changelog.d/xxx-feat-protocol-v0-json-schemas.md
+++ b/changelog.d/xxx-feat-protocol-v0-json-schemas.md
@@ -1,0 +1,44 @@
+### Machine-readable JSON Schemas for the `protocol-v0` wire contract
+
+`schemas/v0/` exports a JSON Schema 2020-12 document for every `params` and `result` shape the daemon serves. Non-Rust agent harnesses (TS, Python, Go, …) can now validate calls against the protocol-v0 contract statically — no more hand-translating `docs/protocol-v0.md` into types and hoping the prose hasn't drifted.
+
+#### What
+
+`schemas/v0/` ships with:
+- `envelope.schema.json` — the JSON-RPC envelope (id, method, params, result, error, cancel_id), with a `oneOf` discriminating request / success / error / notification shapes.
+- `error.schema.json` — the error object, including the closed `code` enum from §14 + §14.1.
+- `methods/<Method>.req.schema.json` + `methods/<Method>.resp.schema.json` for all 17 methods the daemon dispatcher routes (`Daemon.*`, `Workspace.*`, `Session.*`, `Index.*`). 34 method-schema files total.
+- `README.md` documenting the directory layout and the schema-versioning convention (additive within `v0/`, breaking requires `v1/` + `protocol`-major bump).
+
+`crates/rts-daemon/tests/protocol_schemas.rs` enforces four properties:
+
+1. Every method in the dispatcher has both a `.req` and `.resp` schema file. A new method that ships without schema files fails CI.
+2. Every schema file under `schemas/v0/` parses as a valid JSON Schema 2020-12 document.
+3. (CI-only) Every method's real response (against a fixture workspace) validates against its `.resp` schema. Catches drift between schemas and runtime emit.
+4. (CI-only) Error responses match `error.schema.json`. Locks in the v0 error shape.
+
+Properties 3 and 4 are `#[ignore]`-by-default so the regular `cargo test --workspace` path stays fast; CI opts back in via `cargo test -p rts-daemon --test protocol_schemas -- --include-ignored`. A dedicated `.github/workflows/schemas-check.yml` runs the full suite on every PR.
+
+#### Why this matters
+
+The protocol surface was canonical-prose-only. Today, a TS or Python harness that wants to validate its requests had to either (a) hand-translate the spec and risk drift, or (b) parse the Markdown. After 13 PRs of v0.6 work the wire shape has stabilised enough to lock in via schema files and golden-file regression tests.
+
+Locking the contract via schemas means:
+- **Future protocol changes are visible in PR diffs** — a schema change is a visible review surface; a prose-only change is not.
+- **Non-Rust agent harnesses get type-safe call sites for free** — `json-schema-to-typescript`, `datamodel-code-generator`, `quicktype`, etc. all consume these files directly.
+- **Schema-evolution rules become enforceable** — additive within `v0/`, breaking requires a new directory + `protocol`-major bump per `protocol-v0.md` §Appendix E.
+
+#### Approach decision
+
+**Option B (static files + drift test) was chosen over Option A (`schemars`-derive on Rust types).** Rationale: smaller blast radius across the daemon and MCP crates today; the round-trip test catches the same drift class a derive macro would prevent at compile time. A `schemars`-based regeneration pipeline can land as a follow-up if/when the round-trip test starts firing more often than once a release.
+
+#### Out of scope (follow-ups)
+
+- Code generation of TS/Python/Go types from these schemas (downstream tooling).
+- An OpenRPC / JSON-RPC OpenAPI super-document combining all methods and their schemas.
+- Schema-evolution linting (detecting breaking changes between schema versions, gating on capability advertisement).
+- `schemars`-derive regeneration of these files from the Rust types.
+
+#### Wire shape impact
+
+None. The schemas DESCRIBE the existing shape; no daemon code changed.

--- a/crates/rts-daemon/Cargo.toml
+++ b/crates/rts-daemon/Cargo.toml
@@ -107,3 +107,8 @@ default = []
 telemetry = []
 
 [dev-dependencies]
+# Static-file JSON Schema validation for the protocol-v0 schema export
+# (`schemas/v0/`). Test-only — see `tests/protocol_schemas.rs`. The
+# 0.x line speaks JSON Schema 2020-12, which is what
+# `schemas/v0/*.schema.json` declare via `$schema`.
+jsonschema = { version = "0.46", default-features = false }

--- a/crates/rts-daemon/tests/protocol_schemas.rs
+++ b/crates/rts-daemon/tests/protocol_schemas.rs
@@ -1,0 +1,429 @@
+//! Drift-defense for `schemas/v0/` against the daemon's runtime
+//! wire shape.
+//!
+//! Three properties are enforced here. The first two run on every
+//! `cargo test` invocation — they're cheap (read JSON, parse JSON,
+//! match strings). The third spawns a daemon, mounts a fixture
+//! workspace, and round-trips each RPC; it's gated behind
+//! `#[ignore]` so the default test path stays under the workspace's
+//! existing budget. CI opts back in via
+//! `cargo test -p rts-daemon --test protocol_schemas -- --include-ignored`.
+//!
+//! Why static-file schemas with this drift test (not `schemars`-derive
+//! on the typed params/results): smaller blast radius across the daemon
+//! crates, and the round-trip check catches the same kind of drift a
+//! derive macro would prevent at compile time. If schemas start
+//! drifting more often than once a release, the schemars approach is
+//! the right migration; until then, static files keep the diff
+//! reviewable.
+//!
+//! See `schemas/v0/README.md` for the schema-versioning convention.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+/// Every method the daemon's dispatcher routes. Source of truth:
+/// `crates/rts-daemon/src/methods/mod.rs::dispatch`. New methods that
+/// land without a `schemas/v0/methods/<name>.{req,resp}.schema.json`
+/// pair fail the `every_method_has_request_and_response_schemas` test.
+const PROTOCOL_METHODS: &[&str] = &[
+    "Daemon.Ping",
+    "Daemon.Stats",
+    "Daemon.Telemetry",
+    "Daemon.Cancel",
+    "Workspace.Mount",
+    "Workspace.Status",
+    "Workspace.Unmount",
+    "Session.Open",
+    "Session.Close",
+    "Index.FindSymbol",
+    "Index.FindCallers",
+    "Index.ImpactOf",
+    "Index.ReadRange",
+    "Index.ReadSymbol",
+    "Index.ReadSymbolAt",
+    "Index.Outline",
+    "Index.Grep",
+];
+
+fn schemas_root() -> PathBuf {
+    // `CARGO_MANIFEST_DIR` is `crates/rts-daemon/`. The schemas live at
+    // the repo root in `schemas/v0/`. Two `..` segments and we're there.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("schemas")
+        .join("v0")
+}
+
+fn read_schema_file(path: &Path) -> Value {
+    let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+/// Compile a JSON Schema 2020-12 document. Panics with a readable
+/// pointer when compilation fails — saves the reader a `grep` round
+/// trip if a schema file goes bad.
+fn compile_schema(schema_path: &Path) -> jsonschema::Validator {
+    let schema = read_schema_file(schema_path);
+    jsonschema::draft202012::new(&schema).unwrap_or_else(|e| {
+        panic!(
+            "{} did not compile as JSON Schema 2020-12: {e}",
+            schema_path.display()
+        )
+    })
+}
+
+/// **Property 1.** Every method in the dispatcher has both `.req` and
+/// `.resp` schema files. A new method that ships without schema files
+/// fails this test, which gives the next agent a clear "you owe two
+/// schema files" signal.
+#[test]
+fn every_method_has_request_and_response_schemas() {
+    let root = schemas_root();
+    let methods_dir = root.join("methods");
+    assert!(
+        methods_dir.is_dir(),
+        "missing {} — schemas were not committed?",
+        methods_dir.display()
+    );
+
+    let mut missing = Vec::new();
+    for method in PROTOCOL_METHODS {
+        for suffix in ["req", "resp"] {
+            let file = methods_dir.join(format!("{method}.{suffix}.schema.json"));
+            if !file.exists() {
+                missing.push(file.display().to_string());
+            }
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "missing schema files (one .req + .resp per method): {missing:#?}"
+    );
+}
+
+/// **Property 2.** Every schema file under `schemas/v0/` loads cleanly
+/// as a JSON Schema 2020-12 document. Guards against typos that would
+/// silently break the contract.
+#[test]
+fn schemas_parse_as_valid_json_schema_2020_12() {
+    let root = schemas_root();
+
+    // Envelope and error first — the shared schemas every method
+    // implicitly depends on for the envelope/error shape.
+    let envelope = root.join("envelope.schema.json");
+    let error = root.join("error.schema.json");
+    let _ = compile_schema(&envelope);
+    let _ = compile_schema(&error);
+
+    // Then every method schema.
+    let methods_dir = root.join("methods");
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(&methods_dir)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", methods_dir.display()))
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension().and_then(|x| x.to_str()) == Some("json")
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.ends_with(".schema.json"))
+                    .unwrap_or(false)
+        })
+        .collect();
+    entries.sort();
+    assert!(!entries.is_empty(), "no method schemas found");
+    for path in &entries {
+        let _ = compile_schema(path);
+    }
+}
+
+// ----------------------------------------------------------------------
+// The remaining two tests spawn the real daemon binary, mount a
+// fixture workspace, and validate live RPC responses against their
+// schema. They're behind `#[ignore]` so the default `cargo test
+// --workspace` path stays under the workspace's existing budget; CI
+// runs them via `-- --include-ignored`.
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(10), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// **Property 3.** Spin up a real daemon, mount a fixture workspace,
+/// fire every method with valid params, and validate the live response
+/// against its `.resp` schema. This is the test that catches
+/// schema-vs-code drift.
+///
+/// Per-method params are picked to exercise the happy path — agents
+/// reading the schemas will recognise these as the canonical request
+/// shape. Any method whose response shape changes without a matching
+/// schema bump fails this test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "spawns the daemon binary; opt-in via --include-ignored"]
+async fn response_matches_schema_for_each_method() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    // Plant a small fixture so Index.* methods have something to
+    // chew on. A single `.rs` file with one fn + a comment is enough
+    // to exercise FindSymbol / Grep / ReadSymbol / ReadRange / etc.
+    let fixture_src = workspace.path().join("src");
+    std::fs::create_dir_all(&fixture_src)?;
+    std::fs::write(
+        fixture_src.join("lib.rs"),
+        "/// Compute the answer to life, the universe, and everything.\n\
+         pub fn answer() -> u32 {\n    42\n}\n\
+         \n\
+         /// A second fn so FindCallers has someone to point at.\n\
+         pub fn call_answer() -> u32 {\n    answer() + 1\n}\n",
+    )?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill_on_drop = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    // Pre-compile every response schema once so we don't pay the
+    // compile cost per RPC.
+    let root = schemas_root();
+    let methods_dir = root.join("methods");
+    let resp_schema = |method: &str| -> jsonschema::Validator {
+        compile_schema(&methods_dir.join(format!("{method}.resp.schema.json")))
+    };
+
+    // Mount first so Index.* and Workspace.Status see a workspace.
+    let mount = round_trip(
+        &mut stream,
+        "mnt",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    let mount_validator = resp_schema("Workspace.Mount");
+    assert_valid(&mount_validator, "Workspace.Mount", &mount["result"]);
+
+    // Now run every other method.
+    let methods: &[(&str, Value)] = &[
+        ("Daemon.Ping", json!({})),
+        ("Daemon.Stats", json!({})),
+        ("Daemon.Telemetry", json!({})),
+        ("Workspace.Status", json!({})),
+        ("Session.Open", json!({"client_name": "schema-test"})),
+        ("Index.FindSymbol", json!({"name": "answer"})),
+        ("Index.FindCallers", json!({"name": "answer"})),
+        ("Index.ImpactOf", json!({"name": "answer"})),
+        ("Index.Outline", json!({"token_budget": 4096})),
+        ("Index.Grep", json!({"text": "answer"})),
+        (
+            "Index.ReadRange",
+            json!({"file": "src/lib.rs", "start_line": 1, "end_line": 4}),
+        ),
+        ("Index.ReadSymbol", json!({"name": "answer"})),
+        (
+            "Index.ReadSymbolAt",
+            json!({"file": "src/lib.rs", "line": 2}),
+        ),
+    ];
+
+    let mut session_id: Option<String> = None;
+    for (i, (method, params)) in methods.iter().enumerate() {
+        let id = format!("{}", 10 + i);
+        let resp = round_trip(&mut stream, &id, method, params.clone()).await?;
+
+        // We expect every probe to succeed — pick easy params. A
+        // non-null `error` here means the test params drifted out of
+        // sync with the daemon, NOT that the schema is wrong; surface
+        // both so the failure mode is obvious.
+        if !resp["error"].is_null() {
+            panic!("{method} returned error (schema test sends valid params): {resp:?}");
+        }
+
+        let validator = resp_schema(method);
+        assert_valid(&validator, method, &resp["result"]);
+
+        if *method == "Session.Open" {
+            session_id = resp["result"]["session_id"].as_str().map(|s| s.to_string());
+        }
+    }
+
+    // Session.Close needs the id from Session.Open. Validate
+    // separately to keep the loop's param list clean.
+    if let Some(sid) = session_id {
+        let close = round_trip(
+            &mut stream,
+            "close",
+            "Session.Close",
+            json!({ "session_id": sid }),
+        )
+        .await?;
+        let validator = resp_schema("Session.Close");
+        assert_valid(&validator, "Session.Close", &close["result"]);
+    }
+
+    // Workspace.Unmount + Daemon.Cancel — Unmount tears down the watcher,
+    // and Cancel against an unregistered id returns `{ cancelled: false }`.
+    let unmount = round_trip(&mut stream, "um", "Workspace.Unmount", json!({})).await?;
+    let validator = resp_schema("Workspace.Unmount");
+    assert_valid(&validator, "Workspace.Unmount", &unmount["result"]);
+
+    let cancel = round_trip(
+        &mut stream,
+        "ca",
+        "Daemon.Cancel",
+        json!({ "cancel_id": "nope" }),
+    )
+    .await?;
+    let validator = resp_schema("Daemon.Cancel");
+    assert_valid(&validator, "Daemon.Cancel", &cancel["result"]);
+
+    Ok(())
+}
+
+fn assert_valid(validator: &jsonschema::Validator, method: &str, payload: &Value) {
+    if let Err(err) = validator.validate(payload) {
+        panic!(
+            "{method} response did not match its schema: {err}\n\npayload: {}",
+            serde_json::to_string_pretty(payload).unwrap()
+        );
+    }
+}
+
+/// **Property 4 (bonus).** A method invoked with invalid params
+/// produces an error envelope whose `error` object matches
+/// `error.schema.json`. Locks in the v0 error shape.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "spawns the daemon binary; opt-in via --include-ignored"]
+async fn error_responses_match_error_schema() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill_on_drop = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let error_validator = compile_schema(&schemas_root().join("error.schema.json"));
+
+    // Unknown method → INVALID_PARAMS per dispatcher's unknown arm.
+    let bad = round_trip(&mut stream, "1", "Index.NotARealVerb", json!({})).await?;
+    assert!(
+        !bad["error"].is_null(),
+        "expected error envelope, got {bad:?}"
+    );
+    if let Err(err) = error_validator.validate(&bad["error"]) {
+        panic!("error object did not match error.schema.json: {err}\n\npayload: {bad:?}");
+    }
+
+    // Daemon.Cancel with an empty cancel_id → INVALID_PARAMS too.
+    let bad_cancel =
+        round_trip(&mut stream, "2", "Daemon.Cancel", json!({"cancel_id": ""})).await?;
+    assert!(!bad_cancel["error"].is_null());
+    if let Err(err) = error_validator.validate(&bad_cancel["error"]) {
+        panic!("Daemon.Cancel empty-id error did not match error.schema.json: {err}");
+    }
+
+    Ok(())
+}

--- a/schemas/v0/README.md
+++ b/schemas/v0/README.md
@@ -1,0 +1,112 @@
+# `schemas/v0/` — machine-readable JSON Schemas for `protocol-v0`
+
+JSON Schema 2020-12 documents describing the `rts-daemon` JSON-RPC wire
+contract. Prose source-of-truth lives in
+[`docs/protocol-v0.md`](../../docs/protocol-v0.md); these files are
+the machine-readable mirror so non-Rust agent harnesses (TS, Python,
+Go, …) get type-safe call sites without parsing Markdown.
+
+## Layout
+
+```
+schemas/v0/
+  README.md                         this file
+  envelope.schema.json              JSON-RPC envelope (id, method, params, result, error, cancel_id)
+  error.schema.json                 error object (code, message, data)
+  methods/
+    Daemon.Ping.req.schema.json     request `params`  for Daemon.Ping
+    Daemon.Ping.resp.schema.json    response `result` for Daemon.Ping
+    …                               one .req / .resp pair per method
+```
+
+Each method schema validates the **inner `params` / `result` object**,
+not the full envelope. To validate an entire request:
+
+1. Validate the outer envelope against `envelope.schema.json`.
+2. Look up `methods/<envelope.method>.req.schema.json`.
+3. Validate `envelope.params` against that file.
+
+…and symmetrically for responses against `.resp.schema.json` +
+`envelope.result`.
+
+## What's covered
+
+Every method in the v0 dispatcher
+(`crates/rts-daemon/src/methods/mod.rs::dispatch`):
+
+| Namespace | Methods |
+|---|---|
+| `Daemon.*` | `Ping`, `Stats`, `Telemetry`, `Cancel` |
+| `Workspace.*` | `Mount`, `Status`, `Unmount` |
+| `Session.*` | `Open`, `Close` |
+| `Index.*` | `FindSymbol`, `FindCallers`, `ImpactOf`, `ReadRange`, `ReadSymbol`, `ReadSymbolAt`, `Outline`, `Grep` |
+
+= 17 methods × 2 schemas = **34** method-schema files, plus the
+envelope, error, and this README.
+
+## Schema versioning
+
+The directory name (`v0/`) tracks `protocol-v0.md`'s wire-version
+major. Evolution rules mirror [§Appendix E of
+`protocol-v0.md`](../../docs/protocol-v0.md):
+
+- **Additive changes** (new optional `params` field, new optional
+  result field, new capability) bump the affected schema's `$id`
+  query-string version (e.g. `?v=2`) but stay under `v0/`. The schema
+  must keep the existing field set so clients written against the
+  earlier shape stay valid. Reviewers can spot the change in the PR
+  diff and decide whether it warrants a new capability string.
+- **Breaking changes** (rename, remove, change semantics) require a
+  new top-level directory (`schemas/v1/`) AND a `protocol`-major bump
+  in `Daemon.Ping.result.protocol` ("0" → "1"). The daemon advertises
+  the new version via capability strings; clients negotiate per
+  §4.3.
+- **Runtime feature gating** stays the responsibility of
+  `Daemon.Ping.capabilities` — the schemas are the *static* type
+  contract, the capability array is the *runtime* feature contract.
+  Agents MUST gate on the capability string before sending a field
+  that only newer daemons recognize, even when the schema permits it.
+
+## Use from non-Rust harnesses
+
+Examples of downstream codegen tools that consume these files:
+
+- TypeScript: [`json-schema-to-typescript`](https://github.com/bcherny/json-schema-to-typescript)
+- Python: [`datamodel-code-generator`](https://github.com/koxudaxi/datamodel-code-generator)
+- Go: [`quicktype`](https://quicktype.io/), or `go-jsonschema`
+- Cross-language: [`quicktype`](https://quicktype.io/)
+
+Codegen is intentionally out of scope for this PR — schemas are the
+input, generators run downstream.
+
+## Drift defense
+
+`crates/rts-daemon/tests/protocol_schemas.rs` enforces three
+properties:
+
+1. Every method in the daemon's dispatcher has both a `.req` and a
+   `.resp` schema file. A new method that ships without schema files
+   fails CI.
+2. Every schema file parses as a valid JSON Schema 2020-12 document.
+3. Every method's real response (against a fixture workspace)
+   validates against its `.resp` schema. Catches schema-vs-code
+   drift on every PR.
+
+CI runs the schema tests on every push to `feat/**`, `main`, and
+every pull request via `.github/workflows/schemas-check.yml`.
+
+## Out of scope
+
+- **Code generation of TS/Python/Go types** — downstream tooling; not
+  baked into this repo.
+- **OpenRPC / JSON-RPC OpenAPI document** — a single super-document
+  combining all methods and their schemas. Useful follow-up, not
+  blocking.
+- **Schema-evolution linting** (detecting breaking changes between
+  schema versions and gating on capability-string advertisement).
+  Useful follow-up, not v1.
+- **`schemars`-derive regeneration** — generating these schemas from
+  Rust types via `#[derive(JsonSchema)]`. The static-file approach
+  was chosen for v1 to keep the blast radius small; a schemars-based
+  pipeline can land later if the round-trip test starts catching
+  drift more often than once a release.

--- a/schemas/v0/envelope.schema.json
+++ b/schemas/v0/envelope.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/envelope.schema.json",
+  "title": "JSON-RPC envelope (protocol-v0)",
+  "description": "Per protocol-v0.md §3.4. Newline-delimited JSON; one envelope per line. `id` is a decimal-u64 string (string, not number, to survive JS float-precision round-tripping). Requests carry `method` + `params`; responses carry `result` xor `error`; notifications omit `id` entirely.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Monotonic per-connection request id. Decimal u64 as a JSON string.",
+      "type": "string",
+      "pattern": "^[0-9]+$"
+    },
+    "method": {
+      "description": "Capability + verb, dot-separated. Per protocol-v0.md §3.4: `^[A-Z][A-Za-z]+\\.[A-Z][A-Za-z]+$`.",
+      "type": "string",
+      "pattern": "^[A-Z][A-Za-z]+\\.[A-Z][A-Za-z]+$"
+    },
+    "params": {
+      "description": "Method-specific parameters object. MUST be an object (never null, array, or scalar) per §3.4.",
+      "type": "object"
+    },
+    "cancel_id": {
+      "description": "Optional client-chosen cancellation token (v0.6+, capability `cancellable_queries`). 1..=256 chars. See protocol-v0.md §7.1b.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "result": {
+      "description": "Method-specific success payload. Object on every v0 verb."
+    },
+    "error": {
+      "description": "Error object. See error.schema.json for the standalone definition; inlined here for self-containment so this envelope schema compiles without an external retriever. Mutually exclusive with `result`.",
+      "type": "object",
+      "properties": {
+        "code":    { "type": "string" },
+        "message": { "type": "string" },
+        "data":    {}
+      },
+      "required": ["code", "message"]
+    },
+    "partial": {
+      "description": "Optional best-effort flag on retrieval results when the index is mid-build (protocol-v0.md §3.5).",
+      "type": "boolean"
+    },
+    "progress": {
+      "description": "Optional progress sub-object emitted alongside `partial: true` (protocol-v0.md §3.5).",
+      "type": "object",
+      "properties": {
+        "files_done": { "type": "integer", "minimum": 0 },
+        "files_total": { "type": "integer", "minimum": 0 },
+        "phase": { "type": "string" }
+      },
+      "required": ["files_done", "files_total", "phase"]
+    }
+  },
+  "oneOf": [
+    {
+      "title": "Request",
+      "required": ["id", "method", "params"],
+      "not": { "anyOf": [ { "required": ["result"] }, { "required": ["error"] } ] }
+    },
+    {
+      "title": "Response (success)",
+      "required": ["id", "result"],
+      "not": { "anyOf": [ { "required": ["method"] }, { "required": ["error"] } ] }
+    },
+    {
+      "title": "Response (error)",
+      "required": ["id", "error"],
+      "not": { "anyOf": [ { "required": ["method"] }, { "required": ["result"] } ] }
+    },
+    {
+      "title": "Notification (no id)",
+      "required": ["method", "params"],
+      "not": { "anyOf": [ { "required": ["id"] }, { "required": ["result"] }, { "required": ["error"] } ] }
+    }
+  ]
+}

--- a/schemas/v0/error.schema.json
+++ b/schemas/v0/error.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/error.schema.json",
+  "title": "Error object (protocol-v0)",
+  "description": "Per protocol-v0.md §3.4 + §14. String `code` (not JSON-RPC numeric) plus a human-readable `message`. Optional `data` carries structured detail (e.g. `{expected_uid, got_uid}` or `{files_done, files_total}`).",
+  "type": "object",
+  "properties": {
+    "code": {
+      "description": "Closed-set error code string. See protocol-v0.md §14 + §14.1 + §7.8b for the canonical catalog. Custom JSON-RPC numeric `-32099` (CANCELLED), `-32098` (DAEMON_UNAVAILABLE), `-32097` (DAEMON_DOWN) overlap the string codes one-to-one.",
+      "type": "string",
+      "enum": [
+        "INVALID_FRAME",
+        "MESSAGE_TOO_LARGE",
+        "INVALID_PARAMS",
+        "INVALID_WORKSPACE_PATH",
+        "MOUNT_HAS_SYMLINK",
+        "WORKSPACE_VANISHED",
+        "WORKSPACE_MISMATCH",
+        "WORKSPACE_ON_NETWORK_MOUNT",
+        "OUT_OF_ROOT",
+        "PATH_TRAVERSAL",
+        "INDEX_NOT_READY",
+        "SYMBOL_NOT_FOUND",
+        "AMBIGUOUS_SYMBOL",
+        "FILE_NOT_INDEXED",
+        "RANGE_OUT_OF_BOUNDS",
+        "BUDGET_TOO_SMALL",
+        "BUDGET_TOO_LARGE",
+        "BUSY",
+        "STORAGE_FULL",
+        "SCHEMA_VERSION_NEWER",
+        "DEADLINE_EXCEEDED",
+        "CANCELLED",
+        "INCOMPATIBLE_VERSION",
+        "INTERNAL_ERROR",
+        "OUT_OF_ALLOWED_BODY_EXTENSIONS",
+        "DAEMON_UNAVAILABLE",
+        "DAEMON_DOWN"
+      ]
+    },
+    "message": {
+      "description": "Human-readable reason. Not machine-parsed; agents branch on `code` (and `data.code` for `INVALID_PARAMS` sub-codes per §7.8b).",
+      "type": "string"
+    },
+    "data": {
+      "description": "Optional structured detail. For Index.Grep v2 errors this carries a `code` sub-string from the closed set in §7.8b ('MULTILINE_REQUIRES_REGEX', 'STRUCTURAL_REQUIRES_LANGUAGE', etc.). For shim-emitted transport errors (§14.1) it carries `transient`, `retry_after_ms`, `attempt`, `first_failure_ms_ago`."
+    }
+  },
+  "required": ["code", "message"]
+}

--- a/schemas/v0/methods/Daemon.Cancel.req.schema.json
+++ b/schemas/v0/methods/Daemon.Cancel.req.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Daemon.Cancel.req.schema.json",
+  "title": "Daemon.Cancel request params",
+  "description": "v0.6+, capability `cancellable_queries`. Trip the in-flight request that registered the given `cancel_id`. Idempotent (unknown id returns `{ cancelled: false }`). See protocol-v0.md §7.1b.",
+  "type": "object",
+  "properties": {
+    "cancel_id": {
+      "description": "The same id the targeted request set on its envelope. 1..=256 chars, client-chosen (UUID, monotonic counter, etc.).",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    }
+  },
+  "required": ["cancel_id"],
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Daemon.Cancel.resp.schema.json
+++ b/schemas/v0/methods/Daemon.Cancel.resp.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Daemon.Cancel.resp.schema.json",
+  "title": "Daemon.Cancel result",
+  "description": "`cancelled: true` when a registered token was tripped; `cancelled: false` for stale / unknown ids (no error). Per protocol-v0.md §7.1b.",
+  "type": "object",
+  "properties": {
+    "cancelled": { "type": "boolean" }
+  },
+  "required": ["cancelled"]
+}

--- a/schemas/v0/methods/Daemon.Ping.req.schema.json
+++ b/schemas/v0/methods/Daemon.Ping.req.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Daemon.Ping.req.schema.json",
+  "title": "Daemon.Ping request params",
+  "description": "Per protocol-v0.md §7.1. Heartbeat + capability discovery. Idempotent, cheap, no side effects.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Daemon.Ping.resp.schema.json
+++ b/schemas/v0/methods/Daemon.Ping.resp.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Daemon.Ping.resp.schema.json",
+  "title": "Daemon.Ping result",
+  "description": "Per protocol-v0.md §4.1 + §7.1. Capability negotiation surface. `capabilities` is an additive array — new strings appear; old strings never disappear without a protocol-major bump.",
+  "type": "object",
+  "properties": {
+    "protocol": {
+      "description": "Semver-style major version of this wire protocol. `\"0\"` for the v0 draft.",
+      "type": "string",
+      "enum": ["0"]
+    },
+    "daemon": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "git_sha": { "type": "string" }
+      },
+      "required": ["name", "version", "git_sha"]
+    },
+    "capabilities": {
+      "description": "Closed set of feature strings the daemon advertises. Clients gate on these before sending opt-in params.",
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    },
+    "uptime_ms": {
+      "description": "Milliseconds since the daemon process started.",
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": ["protocol", "daemon", "capabilities", "uptime_ms"]
+}

--- a/schemas/v0/methods/Daemon.Stats.req.schema.json
+++ b/schemas/v0/methods/Daemon.Stats.req.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Daemon.Stats.req.schema.json",
+  "title": "Daemon.Stats request params",
+  "description": "v0.5.7+, capability `daemon_stats`. Per-session call counters + workspace metadata.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Daemon.Stats.resp.schema.json
+++ b/schemas/v0/methods/Daemon.Stats.resp.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Daemon.Stats.resp.schema.json",
+  "title": "Daemon.Stats result",
+  "description": "v0.5.7 base shape + v0.6 v2 fields (capability `daemon_stats_v2`). Pre-mount Stats omits the v2 fields entirely; post-mount Stats carries the pinned workspace context.",
+  "type": "object",
+  "properties": {
+    "uptime_ms":     { "type": "integer", "minimum": 0 },
+    "version":       { "type": "string" },
+    "total_calls":   { "type": "integer", "minimum": 0 },
+    "calls": {
+      "description": "Map of method-name -> call count for this daemon process. Per protocol-v0 the keys are bounded to the closed method enum.",
+      "type": "object",
+      "additionalProperties": { "type": "integer", "minimum": 0 }
+    },
+    "cancellations": {
+      "description": "v0.6+, capability `cancellable_queries`. `total` = cumulative successful cancels (stale cancels not counted); `in_flight` = point-in-time gauge of registered cancellable requests.",
+      "type": "object",
+      "properties": {
+        "total":     { "type": "integer", "minimum": 0 },
+        "in_flight": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["total", "in_flight"]
+    },
+    "pinned_workspace_path": {
+      "description": "v0.6+ (capability `daemon_stats_v2`). Present only when a workspace is mounted.",
+      "type": "string"
+    },
+    "workspace_id": {
+      "description": "v0.6+ (capability `daemon_stats_v2`). 16-char hex blake3 fingerprint. Present only when a workspace is mounted.",
+      "type": "string"
+    },
+    "index_generation": {
+      "description": "v0.6+ (capability `daemon_stats_v2`). Bumps on every committed write.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "cold_walk_completed_at_ms": {
+      "description": "v0.6+ (capability `daemon_stats_v2`). Unix-epoch ms when the writer's ColdWalkComplete flush committed, or null if cold walk hasn't finished.",
+      "type": ["integer", "null"]
+    },
+    "mount_source": {
+      "description": "v0.6+ (capability `daemon_stats_v2`). Persisted-cold-mount decision: 'cold_walk' | 'cold_walk_after_invalidation' | 'cold_walk_after_crash' | 'rehydrate'.",
+      "type": "string"
+    },
+    "rehydrate_attempts_total": {
+      "description": "v0.6+. Cumulative count of Workspace.Mount calls (resets on daemon restart).",
+      "type": "integer",
+      "minimum": 0
+    },
+    "rehydrate_successes_total": {
+      "description": "v0.6+. Cumulative count of mounts that took the Rehydrate fast path.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "rehydrate_invalidations_by_reason": {
+      "description": "v0.6+. Per-reason tally of why a rehydrate was rejected ('crash', 'EmptyOrMissingFingerprint', etc.).",
+      "type": "object",
+      "additionalProperties": { "type": "integer", "minimum": 0 }
+    },
+    "reconciliation": {
+      "description": "v0.6+ (capability `reconciliation_worker`). Most-recent reconciliation pass stats.",
+      "type": "object"
+    }
+  },
+  "required": ["uptime_ms", "version", "total_calls", "calls", "cancellations"]
+}

--- a/schemas/v0/methods/Daemon.Telemetry.req.schema.json
+++ b/schemas/v0/methods/Daemon.Telemetry.req.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Daemon.Telemetry.req.schema.json",
+  "title": "Daemon.Telemetry request params",
+  "description": "v0.6+, capability `daemon_telemetry`. Returns raw collector inputs that feed the opt-in telemetry pipeline; the bounded-enum filter runs on the rts-mcp side. Also emitted as a notification (no `id`) when a connection opts in via `Workspace.Mount.enable_telemetry`.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Daemon.Telemetry.resp.schema.json
+++ b/schemas/v0/methods/Daemon.Telemetry.resp.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Daemon.Telemetry.resp.schema.json",
+  "title": "Daemon.Telemetry result",
+  "description": "v0.6+, capability `daemon_telemetry`. Raw collector snapshot. Keys are sourced from closed-enum strings — no user-controlled identifiers reach the wire.",
+  "type": "object",
+  "properties": {
+    "uptime_secs":            { "type": "integer", "minimum": 0 },
+    "languages_indexed":      { "type": "array", "items": { "type": "string" } },
+    "method_counts": {
+      "description": "Map of method-name -> call count. Zero counts and `unknown_method` are dropped.",
+      "type": "object",
+      "additionalProperties": { "type": "integer", "minimum": 0 }
+    },
+    "method_latency_p50_ms":  { "type": "object", "additionalProperties": { "type": "integer", "minimum": 0 } },
+    "method_latency_p99_ms":  { "type": "object", "additionalProperties": { "type": "integer", "minimum": 0 } },
+    "error_counts":           { "type": "object", "additionalProperties": { "type": "integer", "minimum": 0 } },
+    "cache_hit_rate": {
+      "description": "Aggregate cache hit rate in [0.0, 1.0]; `null` when no cache observations have been recorded.",
+      "type": ["number", "null"]
+    },
+    "cold_walk_ms_p50": {
+      "description": "p50 cold-walk duration in ms; `null` until at least one cold walk has completed.",
+      "type": ["integer", "null"]
+    },
+    "workspace_files":        { "type": "integer", "minimum": 0 }
+  },
+  "required": [
+    "uptime_secs",
+    "languages_indexed",
+    "method_counts",
+    "method_latency_p50_ms",
+    "method_latency_p99_ms",
+    "error_counts",
+    "cache_hit_rate",
+    "cold_walk_ms_p50",
+    "workspace_files"
+  ]
+}

--- a/schemas/v0/methods/Index.FindCallers.req.schema.json
+++ b/schemas/v0/methods/Index.FindCallers.req.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.FindCallers.req.schema.json",
+  "title": "Index.FindCallers request params",
+  "description": "Per protocol-v0.md §7.7c + §18.4c. v0.3 alpha.32+, capability `find_callers`.",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "kind": {
+      "type": "string",
+      "enum": ["fn", "struct", "enum", "type", "trait", "const", "static", "impl", "method", "class", "interface", "module"]
+    },
+    "file": { "type": "string" }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Index.FindCallers.resp.schema.json
+++ b/schemas/v0/methods/Index.FindCallers.resp.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.FindCallers.resp.schema.json",
+  "title": "Index.FindCallers result",
+  "description": "Per protocol-v0.md §7.7c. Direct callers of the named symbol. Capped at 256 entries.",
+  "type": "object",
+  "properties": {
+    "callers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "enclosing_qualified_name": { "type": ["string", "null"] },
+          "kind":                     { "type": ["string", "null"] },
+          "file":                     { "type": "string" },
+          "range": {
+            "type": "object",
+            "properties": {
+              "start_byte": { "type": "integer", "minimum": 0 },
+              "end_byte":   { "type": "integer", "minimum": 0 },
+              "start_line": { "type": "integer", "minimum": 0 },
+              "end_line":   { "type": "integer", "minimum": 0 }
+            },
+            "required": ["start_byte", "end_byte", "start_line", "end_line"]
+          },
+          "enclosing_def_range": {
+            "description": "Null when caller_sid is None (file-scope call).",
+            "oneOf": [
+              { "type": "null" },
+              {
+                "type": "object",
+                "properties": {
+                  "start_byte": { "type": "integer", "minimum": 0 },
+                  "end_byte":   { "type": "integer", "minimum": 0 },
+                  "start_line": { "type": "integer", "minimum": 0 },
+                  "end_line":   { "type": "integer", "minimum": 0 }
+                },
+                "required": ["start_byte", "end_byte", "start_line", "end_line"]
+              }
+            ]
+          },
+          "rank_score": { "type": "number" }
+        },
+        "required": ["enclosing_qualified_name", "kind", "file", "range", "enclosing_def_range", "rank_score"]
+      }
+    },
+    "truncated": { "type": "boolean" }
+  },
+  "required": ["callers", "truncated"]
+}

--- a/schemas/v0/methods/Index.FindSymbol.req.schema.json
+++ b/schemas/v0/methods/Index.FindSymbol.req.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.FindSymbol.req.schema.json",
+  "title": "Index.FindSymbol request params",
+  "description": "Per protocol-v0.md §7.6 + §18.3. `name` xor `pattern`; both is INVALID_PARAMS. Doc/limit/signature fields gate on the matching capability strings — pre-cap daemons silently drop unknown fields.",
+  "type": "object",
+  "properties": {
+    "name":              { "type": "string", "minLength": 1, "maxLength": 256 },
+    "pattern":           { "type": "string", "minLength": 1, "maxLength": 256 },
+    "kind": {
+      "type": "string",
+      "enum": ["fn", "struct", "enum", "type", "trait", "const", "static", "impl", "method", "class", "interface", "module"]
+    },
+    "file":              { "type": "string" },
+    "sort":              { "type": "string", "enum": ["rank", "lexical"] },
+    "limit":             { "type": "integer", "minimum": 1, "maximum": 4096 },
+    "doc_contains":      { "type": "string" },
+    "include_signature": { "type": "boolean" }
+  },
+  "additionalProperties": false,
+  "oneOf": [
+    { "required": ["name"],    "not": { "required": ["pattern"] } },
+    { "required": ["pattern"], "not": { "required": ["name"] } }
+  ]
+}

--- a/schemas/v0/methods/Index.FindSymbol.resp.schema.json
+++ b/schemas/v0/methods/Index.FindSymbol.resp.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.FindSymbol.resp.schema.json",
+  "title": "Index.FindSymbol result",
+  "description": "Per protocol-v0.md §7.6. List of matched symbols with location, optional signature/doc, and PageRank score.",
+  "type": "object",
+  "properties": {
+    "matches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "qualified_name": { "type": "string" },
+          "kind": {
+            "type": "string",
+            "enum": ["fn", "struct", "enum", "type", "trait", "const", "static", "impl", "method", "class", "interface", "module", "unknown"]
+          },
+          "file": { "type": "string" },
+          "range": {
+            "type": "object",
+            "properties": {
+              "start_line": { "type": "integer", "minimum": 0 },
+              "end_line":   { "type": "integer", "minimum": 0 },
+              "start_byte": { "type": "integer", "minimum": 0 },
+              "end_byte":   { "type": "integer", "minimum": 0 }
+            },
+            "required": ["start_line", "end_line", "start_byte", "end_byte"]
+          },
+          "signature":  { "type": ["string", "null"] },
+          "doc":        { "type": ["string", "null"] },
+          "visibility": { "type": "string" },
+          "rank_score": { "type": "number" }
+        },
+        "required": ["qualified_name", "kind", "file", "range", "signature", "doc", "visibility", "rank_score"]
+      }
+    },
+    "truncated":        { "type": "boolean" },
+    "pre_filter_count": {
+      "description": "v0.5.2+, capability `find_symbol_pre_filter_count`. Present iff at least one filter (kind/file/doc_contains) was active.",
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": ["matches", "truncated"]
+}

--- a/schemas/v0/methods/Index.Grep.req.schema.json
+++ b/schemas/v0/methods/Index.Grep.req.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.Grep.req.schema.json",
+  "title": "Index.Grep request params",
+  "description": "Per protocol-v0.md §7.8b. v0.5.4+ literal/regex search; v0.6+ adds multiline, structural_query, within_symbol, and language filters under the `index_grep_v2` capability bundle. v1 callers (just `text`) see byte-identical behavior. At least one of `text` or `structural_query` is required.",
+  "type": "object",
+  "properties": {
+    "text":                         { "type": "string", "minLength": 1, "maxLength": 1024 },
+    "limit":                        { "type": "integer", "minimum": 1, "maximum": 4096 },
+    "case_insensitive":             { "type": "boolean" },
+    "regex":                        { "type": "boolean" },
+    "file_glob":                    { "type": "string" },
+    "multiline":                    { "type": "boolean" },
+    "structural_query":             { "type": "string" },
+    "within_symbol":                { "type": "string" },
+    "within_symbol_allow_overload": { "type": "boolean" },
+    "language": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false,
+  "anyOf": [
+    { "required": ["text"] },
+    { "required": ["structural_query"] }
+  ]
+}

--- a/schemas/v0/methods/Index.Grep.resp.schema.json
+++ b/schemas/v0/methods/Index.Grep.resp.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.Grep.resp.schema.json",
+  "title": "Index.Grep result",
+  "description": "Per protocol-v0.md §7.8b. v1 result shape (match locations + line_text). v0.6 additions: per-match `captures` on structural results, top-level `truncation_reason`/`rows_seen`/`rows_returned` on cap breaches, optional `partial_failures` on cross-language structural runs.",
+  "type": "object",
+  "properties": {
+    "matches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "file": { "type": "string" },
+          "range": {
+            "type": "object",
+            "properties": {
+              "start_line": { "type": "integer", "minimum": 0 },
+              "end_line":   { "type": "integer", "minimum": 0 },
+              "start_byte": { "type": "integer", "minimum": 0 },
+              "end_byte":   { "type": "integer", "minimum": 0 }
+            },
+            "required": ["start_line", "end_line", "start_byte", "end_byte"]
+          },
+          "line_text": { "type": "string" },
+          "captures": {
+            "description": "v0.6+ structural-only. Map of capture-name -> array of capture spans.",
+            "type": "object"
+          }
+        },
+        "required": ["file", "range"]
+      }
+    },
+    "truncated":          { "type": "boolean" },
+    "files_scanned":      { "type": "integer", "minimum": 0 },
+    "files_with_matches": { "type": "integer", "minimum": 0 },
+    "truncation_reason":  { "type": "string", "enum": ["rows_seen_exceeded_max", "wall_clock", "capture_bytes"] },
+    "rows_seen":          { "type": "integer", "minimum": 0 },
+    "rows_returned":      { "type": "integer", "minimum": 0 },
+    "partial_failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "language": { "type": "string" },
+          "error":    { "type": "string" }
+        },
+        "required": ["language", "error"]
+      }
+    }
+  },
+  "required": ["matches", "truncated", "files_scanned", "files_with_matches"]
+}

--- a/schemas/v0/methods/Index.ImpactOf.req.schema.json
+++ b/schemas/v0/methods/Index.ImpactOf.req.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.ImpactOf.req.schema.json",
+  "title": "Index.ImpactOf request params",
+  "description": "Per protocol-v0.md §7.7d + §18.4d. v0.3 alpha.35+, capability `impact_of`. Out-of-window depth/max_nodes are clamped, not rejected.",
+  "type": "object",
+  "properties": {
+    "name":               { "type": "string", "minLength": 1, "maxLength": 256 },
+    "depth":              { "type": "integer", "minimum": 1, "maximum": 4 },
+    "token_budget":       { "type": "integer", "minimum": 50, "maximum": 200000 },
+    "max_nodes":          { "type": "integer", "minimum": 1, "maximum": 10000 },
+    "exclude_test_paths": { "type": "boolean" }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Index.ImpactOf.resp.schema.json
+++ b/schemas/v0/methods/Index.ImpactOf.resp.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.ImpactOf.resp.schema.json",
+  "title": "Index.ImpactOf result",
+  "description": "Per protocol-v0.md §7.7d. Transitive caller closure via BFS over reverse edges. Four independent truncation flags tell agents why a result is partial.",
+  "type": "object",
+  "properties": {
+    "impact": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "qualified_name": { "type": "string" },
+          "kind":           { "type": "string" },
+          "file":           { "type": "string" },
+          "range": {
+            "type": "object",
+            "properties": {
+              "start_byte": { "type": "integer", "minimum": 0 },
+              "end_byte":   { "type": "integer", "minimum": 0 },
+              "start_line": { "type": "integer", "minimum": 0 },
+              "end_line":   { "type": "integer", "minimum": 0 }
+            },
+            "required": ["start_byte", "end_byte", "start_line", "end_line"]
+          },
+          "depth":      { "type": "integer", "minimum": 1 },
+          "rank_score": { "type": "number" }
+        },
+        "required": ["qualified_name", "kind", "file", "range", "depth", "rank_score"]
+      }
+    },
+    "closure_truncated":    { "type": "boolean" },
+    "wall_clock_truncated": { "type": "boolean" },
+    "depth_truncated":      { "type": "boolean" },
+    "node_count_truncated": { "type": "boolean" },
+    "tokens_returned":      { "type": "integer", "minimum": 0 },
+    "token_counter":        { "type": "string" }
+  },
+  "required": ["impact", "closure_truncated", "wall_clock_truncated", "depth_truncated", "node_count_truncated", "tokens_returned", "token_counter"]
+}

--- a/schemas/v0/methods/Index.Outline.req.schema.json
+++ b/schemas/v0/methods/Index.Outline.req.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.Outline.req.schema.json",
+  "title": "Index.Outline request params",
+  "description": "Per protocol-v0.md §7.5 + §18.2. Token-budgeted structural map; `mentioned_files` / `mentioned_idents` bias PageRank personalisation.",
+  "type": "object",
+  "properties": {
+    "token_budget":     { "type": "integer", "minimum": 50, "maximum": 200000 },
+    "glob":             { "type": "string" },
+    "mentioned_files":  { "type": "array", "items": { "type": "string" } },
+    "mentioned_idents": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Index.Outline.resp.schema.json
+++ b/schemas/v0/methods/Index.Outline.resp.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.Outline.resp.schema.json",
+  "title": "Index.Outline result",
+  "description": "Per protocol-v0.md §7.5. grep-ast-style dotted plain text (`outline_text`) plus a structured sidecar (`outline_json`).",
+  "type": "object",
+  "properties": {
+    "outline_text":     { "type": "string" },
+    "outline_json": {
+      "type": "object",
+      "properties": {
+        "files": { "type": "array" }
+      }
+    },
+    "tokens_returned":   { "type": "integer", "minimum": 0 },
+    "token_counter":     { "type": "string" },
+    "files_considered":  { "type": "integer", "minimum": 0 },
+    "files_included":    { "type": "integer", "minimum": 0 }
+  },
+  "required": ["outline_text", "outline_json", "tokens_returned", "token_counter", "files_considered", "files_included"]
+}

--- a/schemas/v0/methods/Index.ReadRange.req.schema.json
+++ b/schemas/v0/methods/Index.ReadRange.req.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.ReadRange.req.schema.json",
+  "title": "Index.ReadRange request params",
+  "description": "Per protocol-v0.md §7.8 + §18.5. Reads explicit line range from a file (stack traces, diff hunks, exact spans). Daemons may validate `start_line <= end_line` semantically; cross-field constraints are informational in the schema.",
+  "type": "object",
+  "properties": {
+    "file":         { "type": "string", "minLength": 1 },
+    "start_line":   { "type": "integer", "minimum": 1 },
+    "end_line":     { "type": "integer", "minimum": 1 },
+    "token_budget": { "type": "integer", "minimum": 50, "maximum": 200000 }
+  },
+  "required": ["file", "start_line", "end_line"],
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Index.ReadRange.resp.schema.json
+++ b/schemas/v0/methods/Index.ReadRange.resp.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.ReadRange.resp.schema.json",
+  "title": "Index.ReadRange result",
+  "description": "Per protocol-v0.md §7.8. Same shape as Index.ReadSymbol body, but `qualified_name: null` and no `dependencies` / closure info.",
+  "type": "object",
+  "properties": {
+    "qualified_name": { "type": "null" },
+    "kind":           { "type": "null" },
+    "file":           { "type": "string" },
+    "range": {
+      "type": "object",
+      "properties": {
+        "start_line": { "type": "integer", "minimum": 0 },
+        "end_line":   { "type": "integer", "minimum": 0 },
+        "start_byte": { "type": "integer", "minimum": 0 },
+        "end_byte":   { "type": "integer", "minimum": 0 }
+      },
+      "required": ["start_line", "end_line", "start_byte", "end_byte"]
+    },
+    "shape":           { "type": "string" },
+    "text":            { "type": "string" },
+    "content_version": { "type": "string" },
+    "tokens_returned": { "type": "integer", "minimum": 0 },
+    "token_counter":   { "type": "string" },
+    "truncated":       { "type": "boolean" }
+  },
+  "required": ["qualified_name", "kind", "file", "range", "shape", "text", "content_version", "tokens_returned", "token_counter", "truncated"]
+}

--- a/schemas/v0/methods/Index.ReadSymbol.req.schema.json
+++ b/schemas/v0/methods/Index.ReadSymbol.req.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.ReadSymbol.req.schema.json",
+  "title": "Index.ReadSymbol request params",
+  "description": "Per protocol-v0.md §7.7 + §18.4. `include_callers` gates on capability `read_symbol.include_callers` (v0.3 alpha.32+). `force_resend` is accepted but inert until v1.1's session_dedup ships.",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "file": { "type": "string" },
+    "kind": {
+      "type": "string",
+      "enum": ["fn", "struct", "enum", "type", "trait", "const", "static", "impl", "method", "class", "interface", "module"]
+    },
+    "shape":                { "type": "string", "enum": ["signature", "body", "both"] },
+    "token_budget":         { "type": "integer", "minimum": 50, "maximum": 200000 },
+    "include_dependencies": { "type": "boolean" },
+    "include_callers":      { "type": "boolean" },
+    "force_resend":         { "type": "boolean" }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Index.ReadSymbol.resp.schema.json
+++ b/schemas/v0/methods/Index.ReadSymbol.resp.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.ReadSymbol.resp.schema.json",
+  "title": "Index.ReadSymbol result",
+  "description": "Per protocol-v0.md §7.7. Body / signature / both shape for a named symbol. `dependencies[]` populated when include_dependencies; `callers[]` populated when include_callers (v0.3 alpha.32+). `truncated_symbols[]` blends ambiguous-anchor extras + closure-deps that didn't fit.",
+  "type": "object",
+  "properties": {
+    "qualified_name": { "type": "string" },
+    "kind":           { "type": "string" },
+    "file":           { "type": "string" },
+    "range": {
+      "type": "object",
+      "properties": {
+        "start_line": { "type": "integer", "minimum": 0 },
+        "end_line":   { "type": "integer", "minimum": 0 },
+        "start_byte": { "type": "integer", "minimum": 0 },
+        "end_byte":   { "type": "integer", "minimum": 0 }
+      },
+      "required": ["start_line", "end_line", "start_byte", "end_byte"]
+    },
+    "shape":           { "type": "string", "enum": ["signature", "body", "both"] },
+    "text":            { "type": "string" },
+    "signature":       { "type": ["string", "null"] },
+    "visibility":      { "type": "string" },
+    "content_version": { "type": "string" },
+    "tokens_returned": { "type": "integer", "minimum": 0 },
+    "token_counter":   { "type": "string" },
+    "dependencies": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "closure_truncated": { "type": "boolean" },
+    "callers": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "callers_truncated": { "type": "boolean" },
+    "truncated":         { "type": "boolean" },
+    "truncated_symbols": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["qualified_name", "kind", "file", "range", "shape", "text", "content_version", "tokens_returned", "token_counter", "truncated", "truncated_symbols"]
+}

--- a/schemas/v0/methods/Index.ReadSymbolAt.req.schema.json
+++ b/schemas/v0/methods/Index.ReadSymbolAt.req.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.ReadSymbolAt.req.schema.json",
+  "title": "Index.ReadSymbolAt request params",
+  "description": "Per protocol-v0.md §7.7b + §18.4b. v0 alpha.24+, capability `read_symbol_at`. The compiler-error flow primitive: resolves `(file, line)` to the innermost enclosing def. `column` is accepted but inert in v0 (lands with v1.1 incremental parser reuse).",
+  "type": "object",
+  "properties": {
+    "file":                 { "type": "string", "minLength": 1 },
+    "line":                 { "type": "integer", "minimum": 1 },
+    "column":               { "type": "integer", "minimum": 1 },
+    "shape":                { "type": "string", "enum": ["signature", "body", "both"] },
+    "token_budget":         { "type": "integer", "minimum": 50, "maximum": 200000 },
+    "include_dependencies": { "type": "boolean" },
+    "include_callers":      { "type": "boolean" },
+    "force_resend":         { "type": "boolean" }
+  },
+  "required": ["file", "line"],
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Index.ReadSymbolAt.resp.schema.json
+++ b/schemas/v0/methods/Index.ReadSymbolAt.resp.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.ReadSymbolAt.resp.schema.json",
+  "title": "Index.ReadSymbolAt result",
+  "description": "Per protocol-v0.md §7.7b. Same wire shape as Index.ReadSymbol — re-uses the shared response builder.",
+  "type": "object",
+  "properties": {
+    "qualified_name": { "type": "string" },
+    "kind":           { "type": "string" },
+    "file":           { "type": "string" },
+    "range": {
+      "type": "object",
+      "properties": {
+        "start_line": { "type": "integer", "minimum": 0 },
+        "end_line":   { "type": "integer", "minimum": 0 },
+        "start_byte": { "type": "integer", "minimum": 0 },
+        "end_byte":   { "type": "integer", "minimum": 0 }
+      },
+      "required": ["start_line", "end_line", "start_byte", "end_byte"]
+    },
+    "shape":           { "type": "string", "enum": ["signature", "body", "both"] },
+    "text":            { "type": "string" },
+    "signature":       { "type": ["string", "null"] },
+    "visibility":      { "type": "string" },
+    "content_version": { "type": "string" },
+    "tokens_returned": { "type": "integer", "minimum": 0 },
+    "token_counter":   { "type": "string" },
+    "dependencies":      { "type": "array", "items": { "type": "object" } },
+    "closure_truncated": { "type": "boolean" },
+    "callers":           { "type": "array", "items": { "type": "object" } },
+    "callers_truncated": { "type": "boolean" },
+    "truncated":         { "type": "boolean" },
+    "truncated_symbols": { "type": "array", "items": { "type": "string" } }
+  },
+  "required": ["qualified_name", "kind", "file", "range", "shape", "text", "content_version", "tokens_returned", "token_counter", "truncated", "truncated_symbols"]
+}

--- a/schemas/v0/methods/Session.Close.req.schema.json
+++ b/schemas/v0/methods/Session.Close.req.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Session.Close.req.schema.json",
+  "title": "Session.Close request params",
+  "description": "Per protocol-v0.md §7.10 + §18.7. Releases the session immediately.",
+  "type": "object",
+  "properties": {
+    "session_id": { "type": "string", "pattern": "^sess_[0-9a-f]{16,}$" }
+  },
+  "required": ["session_id"],
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Session.Close.resp.schema.json
+++ b/schemas/v0/methods/Session.Close.resp.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Session.Close.resp.schema.json",
+  "title": "Session.Close result",
+  "description": "Per protocol-v0.md §7.10. Inert payload — empty object on success.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Session.Open.req.schema.json
+++ b/schemas/v0/methods/Session.Open.req.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Session.Open.req.schema.json",
+  "title": "Session.Open request params",
+  "description": "Per protocol-v0.md §7.9 + §18.6. `client_name` / `client_version` are observability metadata only — agent-controllable, NOT authoritative for access decisions (peer-cred check at §12.2 is the real identity).",
+  "type": "object",
+  "properties": {
+    "client_name":    { "type": "string", "maxLength": 128 },
+    "client_version": { "type": "string", "maxLength": 128 }
+  },
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Session.Open.resp.schema.json
+++ b/schemas/v0/methods/Session.Open.resp.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Session.Open.resp.schema.json",
+  "title": "Session.Open result",
+  "description": "Per protocol-v0.md §7.9. Opaque 128-bit session id (`sess_` + 16 hex chars).",
+  "type": "object",
+  "properties": {
+    "session_id":          { "type": "string", "pattern": "^sess_[0-9a-f]{16,}$" },
+    "reconnect_window_ms": { "type": "integer", "minimum": 0 },
+    "dedup_ttl_ms":        { "type": "integer", "minimum": 0 }
+  },
+  "required": ["session_id", "reconnect_window_ms", "dedup_ttl_ms"]
+}

--- a/schemas/v0/methods/Workspace.Mount.req.schema.json
+++ b/schemas/v0/methods/Workspace.Mount.req.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Workspace.Mount.req.schema.json",
+  "title": "Workspace.Mount request params",
+  "description": "Per protocol-v0.md §7.2 + §18.1. Establish (or join) the workspace this connection will operate on. `root` MUST be an absolute path; the daemon canonicalises per §5.1.",
+  "type": "object",
+  "properties": {
+    "root":             { "type": "string", "minLength": 1 },
+    "enable_telemetry": { "type": "boolean", "default": false }
+  },
+  "required": ["root"],
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Workspace.Mount.resp.schema.json
+++ b/schemas/v0/methods/Workspace.Mount.resp.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Workspace.Mount.resp.schema.json",
+  "title": "Workspace.Mount result",
+  "description": "Per protocol-v0.md §7.2 + §7.4. Mount returns the same shape as Workspace.Status — clients can use either response interchangeably.",
+  "type": "object",
+  "properties": {
+    "workspace_id":     { "type": "string" },
+    "state":            { "type": "string", "enum": ["indexing", "ready", "degraded", "no_workspace"] },
+    "progress": {
+      "type": "object",
+      "properties": {
+        "files_done":  { "type": "integer", "minimum": 0 },
+        "files_total": { "type": "integer", "minimum": 0 },
+        "phase":       { "type": "string" }
+      },
+      "required": ["files_done", "files_total", "phase"]
+    },
+    "index_generation":    { "type": "integer", "minimum": 0 },
+    "languages":           { "type": "array", "items": { "type": "string" } },
+    "parse_failed_files":  { "type": "integer", "minimum": 0 },
+    "watcher_status":      { "type": "string", "enum": ["ok", "polling_fallback", "overflowed_rewalking", "no_watcher"] },
+    "uptime_ms":           { "type": "integer", "minimum": 0 },
+    "memory_rss_bytes":    { "type": "integer", "minimum": 0 }
+  },
+  "required": ["workspace_id", "state", "progress", "index_generation", "languages"]
+}

--- a/schemas/v0/methods/Workspace.Status.req.schema.json
+++ b/schemas/v0/methods/Workspace.Status.req.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Workspace.Status.req.schema.json",
+  "title": "Workspace.Status request params",
+  "description": "Per protocol-v0.md §7.4. Poll the indexing state. Cheap; safe to call between every other request.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Workspace.Status.resp.schema.json
+++ b/schemas/v0/methods/Workspace.Status.resp.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Workspace.Status.resp.schema.json",
+  "title": "Workspace.Status result",
+  "description": "Per protocol-v0.md §7.4. Shares its shape with Workspace.Mount's response (post-mount). When no workspace is mounted, state='no_workspace' and the workspace_id / languages fields are absent.",
+  "type": "object",
+  "properties": {
+    "workspace_id":   { "type": "string" },
+    "state":          { "type": "string", "enum": ["indexing", "ready", "degraded", "no_workspace"] },
+    "progress": {
+      "type": "object",
+      "properties": {
+        "files_done":  { "type": "integer", "minimum": 0 },
+        "files_total": { "type": "integer", "minimum": 0 },
+        "phase":       { "type": "string" }
+      },
+      "required": ["files_done", "files_total", "phase"]
+    },
+    "index_generation":    { "type": "integer", "minimum": 0 },
+    "languages":           { "type": "array", "items": { "type": "string" } },
+    "parse_failed_files":  { "type": "integer", "minimum": 0 },
+    "watcher_status":      { "type": "string", "enum": ["ok", "polling_fallback", "overflowed_rewalking", "no_watcher"] },
+    "uptime_ms":           { "type": "integer", "minimum": 0 },
+    "memory_rss_bytes":    { "type": "integer", "minimum": 0 }
+  },
+  "required": ["state", "progress", "index_generation", "parse_failed_files", "watcher_status", "uptime_ms", "memory_rss_bytes"]
+}

--- a/schemas/v0/methods/Workspace.Unmount.req.schema.json
+++ b/schemas/v0/methods/Workspace.Unmount.req.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Workspace.Unmount.req.schema.json",
+  "title": "Workspace.Unmount request params",
+  "description": "Per protocol-v0.md §7.3. Tells the daemon this client is done with the workspace. Last-unmount starts the idle-shutdown timer.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Workspace.Unmount.resp.schema.json
+++ b/schemas/v0/methods/Workspace.Unmount.resp.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Workspace.Unmount.resp.schema.json",
+  "title": "Workspace.Unmount result",
+  "description": "Per protocol-v0.md §7.3.",
+  "type": "object",
+  "properties": {
+    "drained": { "type": "boolean" }
+  },
+  "required": ["drained"]
+}


### PR DESCRIPTION
## Motivation

The `protocol-v0` surface is documented in [`docs/protocol-v0.md`](docs/protocol-v0.md). Today, a TS or Python agent harness that wants to validate its requests against `rts` has to either (a) hand-translate the prose into types and risk drift, or (b) parse the Markdown — fragile. After 13 PRs of v0.6 work (#109 through #121), the wire shape has stabilized enough to lock in via schema files and golden-file regression tests.

Locking the contract via schemas means:

- **Future protocol changes are visible in PR diffs.** A schema-file change is a review surface; a prose-only change is not.
- **Non-Rust agent harnesses get type-safe call sites for free.** `json-schema-to-typescript`, `datamodel-code-generator`, `quicktype`, `go-jsonschema`, etc. all consume these files directly.
- **Schema-evolution rules become enforceable.** Additive-within-`v0/` vs breaking-needs-`v1/`+`protocol`-major bump per [Appendix E](docs/protocol-v0.md#appendix-e--wire-protocol-versioning-policy) is now testable.

## Approach decision

Two paths were considered:

**Option A — `schemars`-derive on Rust types.** Add `#[derive(JsonSchema)]` to every method's typed `params` / `result`. Schemas regenerate from code; types stay the source of truth. Touches many type definitions across `rts-daemon` (and `rts-mcp` for the MCP-side types) — high initial change surface, more durable long-term.

**Option B — hand-written schemas in `schemas/v0/`, validated by golden-file tests against real daemon responses.** Schemas live as JSON files; a test mounts a fixture workspace, fires each method, and validates each response against its schema (via the `jsonschema` crate). Smaller initial surface; schemas could drift from code if someone forgets to update them — caught by the round-trip test.

**This PR picks B.** Smaller blast radius across many crates; lets us lock in the contract today without a sprawling derive-attribute pass. A `schemars`-based regeneration pipeline can land as a follow-up if/when schemas need to track code changes more tightly. The round-trip drift test catches the same class of error a derive macro would prevent at compile time — just at test time instead.

## File inventory

`schemas/v0/` adds **37 schema-related files**:

| Path | Count | Purpose |
|---|---|---|
| `schemas/v0/envelope.schema.json` | 1 | JSON-RPC envelope (`id`, `method`, `params`, `result`, `error`, `cancel_id`) with `oneOf` discriminating request / success / error / notification shapes |
| `schemas/v0/error.schema.json` | 1 | Error object (closed `code` enum from §14 + §14.1, optional structured `data`) |
| `schemas/v0/methods/<Method>.req.schema.json` | 17 | Per-method request `params` schemas |
| `schemas/v0/methods/<Method>.resp.schema.json` | 17 | Per-method response `result` schemas |
| `schemas/v0/README.md` | 1 | Layout, schema-versioning convention, drift-defense doc |

Plus:
- `crates/rts-daemon/tests/protocol_schemas.rs` — drift-defense test suite (4 properties; 2 static, 2 `#[ignore]`-by-default integration).
- `crates/rts-daemon/Cargo.toml` — adds `jsonschema = "0.46"` as a test-only dev-dependency (default-features = false).
- `.github/workflows/schemas-check.yml` — dedicated CI workflow gating PRs on the schema drift test.
- `changelog.d/xxx-feat-protocol-v0-json-schemas.md` — changelog fragment.

Total: 17 methods × 2 schemas = 34 method schemas (matches the spec's ~36 expectation — the spec counted 18 methods but `Daemon.Telemetry` is one request + one notification using the same shape).

## Sample schema

`schemas/v0/methods/Index.FindSymbol.resp.schema.json`:

```json
{
  "\$schema": "https://json-schema.org/draft/2020-12/schema",
  "\$id": "https://rts.local/schemas/v0/methods/Index.FindSymbol.resp.schema.json",
  "title": "Index.FindSymbol result",
  "description": "Per protocol-v0.md §7.6. List of matched symbols with location, optional signature/doc, and PageRank score.",
  "type": "object",
  "properties": {
    "matches": {
      "type": "array",
      "items": {
        "type": "object",
        "properties": {
          "qualified_name": { "type": "string" },
          "kind": {
            "type": "string",
            "enum": ["fn", "struct", "enum", "type", "trait", "const", "static", "impl", "method", "class", "interface", "module", "unknown"]
          },
          "file": { "type": "string" },
          "range": {
            "type": "object",
            "properties": {
              "start_line": { "type": "integer", "minimum": 0 },
              "end_line":   { "type": "integer", "minimum": 0 },
              "start_byte": { "type": "integer", "minimum": 0 },
              "end_byte":   { "type": "integer", "minimum": 0 }
            },
            "required": ["start_line", "end_line", "start_byte", "end_byte"]
          },
          "signature":  { "type": ["string", "null"] },
          "doc":        { "type": ["string", "null"] },
          "visibility": { "type": "string" },
          "rank_score": { "type": "number" }
        },
        "required": ["qualified_name", "kind", "file", "range", "signature", "doc", "visibility", "rank_score"]
      }
    },
    "truncated":        { "type": "boolean" },
    "pre_filter_count": {
      "description": "v0.5.2+, capability \`find_symbol_pre_filter_count\`. Present iff at least one filter (kind/file/doc_contains) was active.",
      "type": "integer",
      "minimum": 0
    }
  },
  "required": ["matches", "truncated"]
}
```

## Schema-versioning convention

Documented in [`schemas/v0/README.md`](schemas/v0/README.md). Summary:

- The directory name (`v0/`) tracks `protocol-v0.md`'s wire-version major.
- **Additive changes** (new optional `params` field, new optional `result` field, new capability) keep the schema under `v0/`. Schemas keep their existing field set so clients written against the earlier shape stay valid. The PR diff makes the change visible.
- **Breaking changes** (rename, remove, change semantics) require a new top-level directory (`schemas/v1/`) AND a `protocol`-major bump in `Daemon.Ping.result.protocol` (`"0"` → `"1"`).
- **Runtime feature gating** stays the responsibility of `Daemon.Ping.capabilities` — the schemas are the *static* type contract, the capability array is the *runtime* feature contract. Agents MUST gate on the capability string before sending a field that only newer daemons recognize.

## Drift defense

`crates/rts-daemon/tests/protocol_schemas.rs` enforces four properties:

1. `every_method_has_request_and_response_schemas` — walks `schemas/v0/methods/`; a new dispatcher method shipped without schemas fails CI.
2. `schemas_parse_as_valid_json_schema_2020_12` — every schema loads cleanly as a JSON Schema 2020-12 document.
3. `response_matches_schema_for_each_method` (`#[ignore]`) — spawns the real daemon, mounts a fixture workspace with a small `.rs` file, fires every method, validates each live response against its schema.
4. `error_responses_match_error_schema` (`#[ignore]`) — invalid params produce an error envelope whose `error` object matches `error.schema.json`.

The two integration tests are `#[ignore]`-by-default so the default `cargo test --workspace` path stays under the existing budget. CI opts back in via `cargo test -p rts-daemon --test protocol_schemas -- --include-ignored` via the new dedicated `schemas-check.yml` workflow.

## Out-of-scope follow-ups

- **Codegen of TS/Python/Go types from these schemas.** Downstream tooling; agent authors can wire `json-schema-to-typescript` / `datamodel-code-generator` / `quicktype` against `schemas/v0/methods/` immediately.
- **OpenRPC / JSON-RPC OpenAPI super-document** combining all methods + their schemas into one file. Compounds on this PR; not blocking.
- **`schemars`-derive migration (Option A).** Can land later if the round-trip test starts catching drift more often than once a release.
- **Schema linting / breaking-change diffing in CI** beyond "do schemas match real responses". Detect semver-breaking schema changes and gate on capability advertisement. Useful but not v1.

## How to test

\`\`\`sh
# Static tests (parse + dispatcher coverage). Cheap; runs by default.
cargo test -p rts-daemon --test protocol_schemas

# Full drift test (live daemon round-trip). Spawns the binary.
cargo build -p rts-daemon
cargo test -p rts-daemon --test protocol_schemas -- --include-ignored

# Sanity-check broader workspace.
cargo test --workspace
cargo fmt --all -- --check
cargo clippy --workspace --all-targets
\`\`\`

Local verification: 866 passed / 0 failed / 6 ignored across `cargo test --workspace`. Lefthook-scoped clippy clean (advisory baseline; pre-existing warnings unrelated to this PR). \`cargo fmt --all -- --check\` clean.

## Wire impact

**None.** The schemas DESCRIBE the existing shape; no daemon code changed.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: schemas are static files; the test enforces they match real responses. CI will fail if drift appears.

## Coordination note

Touched files outside \`schemas/\` are: \`crates/rts-daemon/Cargo.toml\` (dev-dep), \`crates/rts-daemon/tests/protocol_schemas.rs\` (new test), \`changelog.d/xxx-feat-...\` (fragment), and \`.github/workflows/schemas-check.yml\` (new file, NOT \`ci.yml\`). The dedicated workflow file avoids overlap with the parallel \`feat/real-repo-ci-fixture\` agent.

🤖 Generated with Claude Opus 4.7 (1M context) via Claude Code + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>