### PR TITLE
feat(rts-bench): dogfood — measure rts vs Bash tool-selection from session transcripts

### DIFF
--- a/changelog.d/xxx-feat-rts-bench-dogfood.md
+++ b/changelog.d/xxx-feat-rts-bench-dogfood.md
@@ -1,0 +1,40 @@
+### `rts-bench dogfood` — measure rts vs Bash tool-selection from session transcripts
+
+Round-12 honorable-mention companion to PR #121 (the tool-description audit). During the 2026-05-19/20/21 maintainer session that shipped 15 PRs to rts, the orchestrating agent used `Bash(grep)` 30+ times against rts's own source code instead of `mcp__rts__grep` — even with rts mounted. PR #121 rewrote every tool description to win the selection moment, but there was no way to MEASURE the improvement. This adds the harness.
+
+#### What
+
+New `rts-bench dogfood <session-jsonl-path> [--report json|text] [--rts-mounted-only]` subcommand. Ingests a Claude Code session JSONL file (or stdin with `-`) and reports:
+
+- Total tool calls and a per-tool breakdown by source (`Bash`, `Read`, `mcp__rts__*`, …)
+- `Bash` calls that pattern-match workspace navigation (`grep`/`rg`/`find`/`cat`/`ls`) and could have used an `mcp__rts__*` tool instead, broken out by category
+- The rts-vs-Bash ratio in code-navigation contexts: `rts_calls / (rts_calls + candidate_bash_calls)`
+
+Classifier patterns (all token-level, documented in `crates/rts-bench/src/dogfood/classify.rs`):
+
+| Leading token | → would_prefer | Excluded |
+|---|---|---|
+| `grep`/`rg`/`egrep`/`fgrep`/`ack` | `mcp__rts__grep` | `git grep` |
+| `find` with `-name`/`-path`/`-regex` filter | `mcp__rts__find_symbol` | `find /tmp`, bare `find` without filters |
+| `cat <file>` | `mcp__rts__read_range` | `cat /tmp/...`, redirection (`cat > x`), heredocs |
+| `ls`, `ls .`, `ls <relpath>` | `mcp__rts__outline_workspace` | `ls -l`, `ls -la`, `ls ~/Downloads` |
+
+Build invocations (`cargo`, `make`, `npm`, etc.) are excluded outright.
+
+#### Privacy & scope
+
+- Client-side local analysis only. Reads JSONL files already on disk under `~/.claude/projects/`. No network, no daemon counters, no remote pings (PR #115's opt-in telemetry is a different surface).
+- Not wired into CI. Manual maintainer tool.
+- Measures tool SELECTION, not performance.
+
+#### Tests
+
+`crates/rts-bench/tests/dogfood_smoke.rs` (5 integration tests, all subprocess-driven) + 19 unit tests inside `dogfood::classify` and `dogfood::parse`:
+
+- `parses_synthetic_session` — synthetic JSONL with known mix → expected counts
+- `classifies_grep_bash_as_rts_candidate` — `Bash(grep)` → `would_prefer: "mcp__rts__grep"`
+- `json_report_is_valid_json` — `--report json` parses cleanly back through `serde_json` and carries `schema_version: "dogfood-v0"`
+- `text_report_renders` — `--report text` includes the stable section headings
+- `rts_not_mounted_session_filters_candidates` — default `--rts-mounted-only` filter behavior is observable and toggleable
+
+No new dependencies. No `unsafe`. Pure stdlib + `serde_json` (already a workspace dep).

--- a/crates/rts-bench/src/dogfood/classify.rs
+++ b/crates/rts-bench/src/dogfood/classify.rs
@@ -1,0 +1,364 @@
+//! Bash-command classifier for `rts-bench dogfood`.
+//!
+//! Decides whether a `Bash` tool call's `command` string looks like
+//! a workspace navigation task that an `mcp__rts__*` tool would have
+//! served better. The output drives the dogfood report's
+//! `bash_candidate_fallthroughs` counts.
+//!
+//! Design rules:
+//!
+//! 1. **Token-level, not regex-heavy.** Split on shell whitespace and
+//!    look at the first token (modulo `env VAR=val` prefixes). The
+//!    classifier is meant to be readable line-by-line; reach for
+//!    regex only when the pattern genuinely needs it.
+//! 2. **False positives are fine, false negatives are worse.** The
+//!    framing is "candidate fall-throughs", not "definitely wrong
+//!    tool". If a call is ambiguous, lean toward classifying it.
+//! 3. **Exclude obvious non-candidates explicitly.** Shell pipelines
+//!    (`grep foo bar | head`), git plumbing (`git grep`), build
+//!    invocations (`cargo`, `make`), and `cat /tmp/...` are out of
+//!    scope. Comment each exclusion so a reader can audit.
+//!
+//! The patterns this catches:
+//!
+//! | Leading token | → would_prefer            | Excludes                          |
+//! |--------------|---------------------------|-----------------------------------|
+//! | `grep`/`rg`/`egrep`/`fgrep`/`ack` | `mcp__rts__grep`        | pipelines (`grep …\|…`) when piped FROM, not to |
+//! | `find`       | `mcp__rts__outline_workspace`/`find_symbol` | `find /tmp`, `find ~/Downloads`, no `-name`/`-path` filters |
+//! | `cat <file>` | `mcp__rts__read_range`    | `cat /tmp/...`, `cat /dev/null`, redirection (`cat > x`), heredocs |
+//! | `ls`         | `mcp__rts__outline_workspace` | `ls /tmp`, `ls ~/.claude`, anything with `-l`/`-la` (browsing dirs ≠ orienting in a repo) |
+//!
+//! What it deliberately doesn't catch (and why):
+//!
+//! - **Compound pipelines.** `grep foo bar | head -n 5` — we DO catch
+//!   this because the leading token is still `grep` and the agent's
+//!   intent is workspace search. But `cat foo | wc -l` is excluded
+//!   because the intent is character counting, not file reading.
+//!   The heuristic: classify by *the leading token's purpose*, not
+//!   what comes after.
+//! - **`git grep`, `cargo`, `make`.** These are version-control /
+//!   build invocations, not workspace navigation. Skipped.
+//! - **`cat /tmp/...` / `cat /var/...`.** Reading a tempfile is a
+//!   shell-pipeline detail (often the result of one tool feeding
+//!   another); rts doesn't help.
+//! - **Interactive shells, `sudo`, `env`.** We strip a single leading
+//!   `env VAR=val` if present and continue, but anything wrapped in
+//!   `bash -c '…'` is left alone — we don't try to parse arbitrary
+//!   shell.
+
+/// Tagged enum of the four candidate categories. Variants line up
+/// 1:1 with the `FallthroughCounts` fields in `mod.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BashCandidate {
+    GrepOrRg,
+    Find,
+    CatFile,
+    LsWorkspace,
+}
+
+impl BashCandidate {
+    /// The `mcp__rts__*` tool the candidate would have called instead.
+    /// Stable strings — they appear in the report JSON's `would_prefer`
+    /// field and are matched on by smoke tests.
+    pub fn would_prefer(self) -> &'static str {
+        match self {
+            BashCandidate::GrepOrRg => "mcp__rts__grep",
+            BashCandidate::Find => "mcp__rts__find_symbol",
+            BashCandidate::CatFile => "mcp__rts__read_range",
+            BashCandidate::LsWorkspace => "mcp__rts__outline_workspace",
+        }
+    }
+}
+
+/// Top-level classifier. Returns `Some(BashCandidate)` when the
+/// command looks like a workspace-navigation operation an rts tool
+/// could have replaced; `None` otherwise.
+///
+/// The function is intentionally a flat dispatch on the first
+/// meaningful token. Pattern-table-driven would be cute but harder
+/// to audit at code-review time, and the input space is fixed at
+/// four categories.
+pub fn classify_bash_command(command: &str) -> Option<BashCandidate> {
+    let stripped = strip_env_prefix(command.trim());
+
+    // `git grep`, `git ls-files`, etc. are version-control queries,
+    // not workspace search. Skip outright. Same for cargo/make/etc.
+    if starts_with_word(stripped, "git")
+        || starts_with_word(stripped, "cargo")
+        || starts_with_word(stripped, "make")
+        || starts_with_word(stripped, "npm")
+        || starts_with_word(stripped, "yarn")
+        || starts_with_word(stripped, "pnpm")
+    {
+        return None;
+    }
+
+    if is_grep_like(stripped) {
+        return Some(BashCandidate::GrepOrRg);
+    }
+    if is_find_workspace(stripped) {
+        return Some(BashCandidate::Find);
+    }
+    if is_cat_workspace_file(stripped) {
+        return Some(BashCandidate::CatFile);
+    }
+    if is_ls_workspace(stripped) {
+        return Some(BashCandidate::LsWorkspace);
+    }
+    None
+}
+
+/// Strip a single leading `env VAR=val [VAR2=val2]` prefix so a call
+/// like `env RUST_LOG=debug grep foo .` still classifies as grep.
+/// We don't recurse — multiple `env` levels are rare and the cost of
+/// false negatives there is one un-counted call.
+fn strip_env_prefix(cmd: &str) -> &str {
+    let rest = cmd.strip_prefix("env ").unwrap_or(cmd);
+    // After `env`, skip `KEY=value` tokens until we hit a non-assignment.
+    let mut tail = rest;
+    loop {
+        let trimmed = tail.trim_start();
+        let next_word_end = trimmed.find(char::is_whitespace).unwrap_or(trimmed.len());
+        let next_word = &trimmed[..next_word_end];
+        if next_word.contains('=') && !next_word.starts_with('=') {
+            tail = &trimmed[next_word_end..];
+            continue;
+        }
+        return trimmed;
+    }
+}
+
+/// True iff `s` starts with `word` followed by whitespace or end-of-string.
+/// Avoids the `starts_with("grep")` foot-gun where `"grepfor"` matches.
+fn starts_with_word(s: &str, word: &str) -> bool {
+    if !s.starts_with(word) {
+        return false;
+    }
+    s[word.len()..]
+        .chars()
+        .next()
+        .map(|c| c.is_whitespace())
+        .unwrap_or(true)
+}
+
+/// `grep`, `rg`, `egrep`, `fgrep`, `ack`, `ack-grep` — anything whose
+/// purpose is text search.
+fn is_grep_like(s: &str) -> bool {
+    starts_with_word(s, "grep")
+        || starts_with_word(s, "rg")
+        || starts_with_word(s, "egrep")
+        || starts_with_word(s, "fgrep")
+        || starts_with_word(s, "ack")
+        || starts_with_word(s, "ack-grep")
+}
+
+/// `find` rooted at the workspace, with at least one filter
+/// (`-name`/`-path`/`-iname`/`-regex`). Bare `find /tmp` or `find ~`
+/// is excluded — those aren't workspace-navigation tasks.
+///
+/// Exclusion list matches paths that obviously aren't the workspace:
+/// `/tmp`, `/var`, `/Users/.../Downloads`, `/dev`, `/proc`, anything
+/// rooted at `~/.something` (dotdirs in $HOME). Catches the common
+/// "find a downloaded file" / "find a tempfile" cases.
+fn is_find_workspace(s: &str) -> bool {
+    if !starts_with_word(s, "find") {
+        return false;
+    }
+    // Cheap path exclusion. Look at the second token; if it starts
+    // with one of these prefixes, it's not workspace-rooted.
+    let after_find = s["find".len()..].trim_start();
+    let next = after_find.split_whitespace().next().unwrap_or("");
+    for prefix in &[
+        "/tmp",
+        "/var",
+        "/dev",
+        "/proc",
+        "/sys",
+        "~/Downloads",
+        "~/Library",
+        "~/.cache",
+        "/Users", // catches "find /Users/.../Downloads" too — we still
+                  // want to classify "find . -name '*.rs'" since `.`
+                  // is the leading non-flag token.
+    ] {
+        if next.starts_with(prefix) && next != "." && !next.starts_with("/Users/n/Rustrover") {
+            // Heuristic carve-out: if the search root is under
+            // /Users/n/Rustrover... it's a workspace path; let it
+            // through. The `/Users` prefix is otherwise too broad.
+            return false;
+        }
+    }
+    // Require at least one filter flag — bare `find /some/path` is
+    // a directory listing, not symbol-shaped navigation.
+    s.contains("-name ") || s.contains("-iname ") || s.contains("-path ") || s.contains("-regex ")
+}
+
+/// `cat <file>` where the file isn't a tempfile / device / heredoc /
+/// stdin. Excludes shell-pipeline glue (`cat foo > bar`, `cat << EOF`)
+/// because that's not workspace reading either.
+fn is_cat_workspace_file(s: &str) -> bool {
+    if !starts_with_word(s, "cat") {
+        return false;
+    }
+    // Reject shell redirection / heredoc shapes outright.
+    if s.contains("<<") || s.contains(">") || s.contains("<(") {
+        return false;
+    }
+    let arg = s["cat".len()..].trim();
+    if arg.is_empty() {
+        return false; // `cat` alone reads stdin
+    }
+    // Filter out obvious non-workspace targets.
+    if arg.starts_with("/tmp")
+        || arg.starts_with("/var")
+        || arg.starts_with("/dev")
+        || arg.starts_with("/proc")
+        || arg.starts_with("/sys")
+        || arg == "-"
+    {
+        return false;
+    }
+    // Reject any argument that looks like a flag (`cat -n`, `cat -A`).
+    // The intent isn't to read a workspace file in that case.
+    if arg.starts_with('-') {
+        return false;
+    }
+    true
+}
+
+/// `ls` in a workspace context. The narrow rule: any `ls` invocation
+/// whose argument is missing or looks like a relative workspace path
+/// (`.`, `src`, `crates/foo`) and which does NOT include long-listing
+/// or hidden-file flags (those are usually shell admin, not
+/// orientation tasks).
+fn is_ls_workspace(s: &str) -> bool {
+    if !starts_with_word(s, "ls") {
+        return false;
+    }
+    // Long-form ls -l / ls -la / etc. is typically "what is this
+    // directory's metadata" not "what symbols live in this repo".
+    // Skip to avoid noise.
+    if s.contains(" -l") || s.contains(" -la") || s.contains(" -al") {
+        return false;
+    }
+    let arg = s["ls".len()..].trim();
+    if arg.is_empty() || arg == "." {
+        return true;
+    }
+    // Absolute paths outside what looks like a workspace → not interesting.
+    if arg.starts_with('/')
+        && !arg.starts_with("/Users/")
+        && !arg.starts_with("/home/")
+        && !arg.starts_with("/workspace")
+        && !arg.starts_with("/srv")
+    {
+        return false;
+    }
+    // `ls ~/Downloads` etc. — out.
+    if arg.starts_with("~/Downloads") || arg.starts_with("~/Library") {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grep_is_classified() {
+        let c = classify_bash_command("grep -rn 'fn foo' crates/").unwrap();
+        assert_eq!(c, BashCandidate::GrepOrRg);
+        assert_eq!(c.would_prefer(), "mcp__rts__grep");
+    }
+
+    #[test]
+    fn rg_is_classified() {
+        assert_eq!(
+            classify_bash_command("rg 'pattern' --type rust"),
+            Some(BashCandidate::GrepOrRg)
+        );
+    }
+
+    #[test]
+    fn git_grep_is_excluded() {
+        // `git grep` is a VCS operation, not a workspace search.
+        assert_eq!(classify_bash_command("git grep 'pattern'"), None);
+    }
+
+    #[test]
+    fn find_with_name_is_classified() {
+        assert_eq!(
+            classify_bash_command("find . -name '*.rs'"),
+            Some(BashCandidate::Find)
+        );
+    }
+
+    #[test]
+    fn find_in_tmp_is_excluded() {
+        // /tmp isn't a workspace; rts wouldn't have helped.
+        assert_eq!(classify_bash_command("find /tmp -name '*.log'"), None);
+    }
+
+    #[test]
+    fn find_without_filters_is_excluded() {
+        // Bare `find /some/dir` is a listing, not symbol navigation.
+        assert_eq!(classify_bash_command("find /Users/n/foo"), None);
+    }
+
+    #[test]
+    fn cat_workspace_file_is_classified() {
+        assert_eq!(
+            classify_bash_command("cat crates/rts-bench/src/main.rs"),
+            Some(BashCandidate::CatFile)
+        );
+    }
+
+    #[test]
+    fn cat_tmpfile_is_excluded() {
+        assert_eq!(classify_bash_command("cat /tmp/foo.log"), None);
+    }
+
+    #[test]
+    fn cat_with_redirection_is_excluded() {
+        assert_eq!(classify_bash_command("cat <<EOF\nhello\nEOF"), None);
+        assert_eq!(classify_bash_command("cat foo > bar"), None);
+    }
+
+    #[test]
+    fn ls_workspace_is_classified() {
+        assert_eq!(
+            classify_bash_command("ls"),
+            Some(BashCandidate::LsWorkspace)
+        );
+        assert_eq!(
+            classify_bash_command("ls crates/"),
+            Some(BashCandidate::LsWorkspace)
+        );
+    }
+
+    #[test]
+    fn ls_la_is_excluded() {
+        // `ls -la` is admin, not orientation.
+        assert_eq!(classify_bash_command("ls -la /etc"), None);
+    }
+
+    #[test]
+    fn cargo_is_excluded() {
+        assert_eq!(classify_bash_command("cargo test --workspace"), None);
+    }
+
+    #[test]
+    fn env_prefix_is_stripped() {
+        assert_eq!(
+            classify_bash_command("env RUST_LOG=debug grep foo crates/"),
+            Some(BashCandidate::GrepOrRg)
+        );
+    }
+
+    #[test]
+    fn unrelated_command_returns_none() {
+        assert_eq!(classify_bash_command("echo hello"), None);
+        assert_eq!(classify_bash_command("date"), None);
+    }
+}

--- a/crates/rts-bench/src/dogfood/mod.rs
+++ b/crates/rts-bench/src/dogfood/mod.rs
@@ -1,0 +1,497 @@
+//! Self-dogfood telemetry harness — `rts-bench dogfood`.
+//!
+//! Ingests a Claude Code session JSONL transcript and reports how
+//! often the agent reached for `Bash(grep|rg|find|cat|ls)` when an
+//! `mcp__rts__*` tool would have been a better fit. The goal is to
+//! close the evidence loop on PR #121 (the tool-description audit):
+//! without a way to count tool-selection outcomes, "did the audit
+//! help?" stays a vibe rather than a number.
+//!
+//! Scope:
+//! - **Client-side only.** Reads JSONL files already on disk under
+//!   `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`. No network. No
+//!   daemon counters. No opt-in pings — that's PR #115's surface.
+//! - **Manual, post-hoc analysis.** Not wired into CI; the maintainer
+//!   runs the harness on their own sessions.
+//! - **Tool SELECTION, not performance.** Counts which tool an agent
+//!   chose; does NOT claim rts would have been faster.
+//!
+//! Heuristic, by design — false positives are fine. The framing is
+//! "candidate fall-throughs" (calls that *could* have used rts), not
+//! "definitive wrong-tool" claims. The classifier in `classify.rs`
+//! documents each pattern it catches and each it deliberately doesn't.
+
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+mod classify;
+mod parse;
+
+pub use classify::{BashCandidate, classify_bash_command};
+pub use parse::{ToolUseEvent, parse_session};
+
+/// Output format for `rts-bench dogfood`. Mirrors
+/// `real_repos::ReportFormat` so the surface looks consistent.
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+pub enum ReportFormat {
+    /// Pretty JSON. Stable shape (`schema_version: "dogfood-v0"`) for
+    /// post-hoc analysis pipelines.
+    Json,
+    /// Human-readable terminal output with section headings.
+    Text,
+}
+
+/// Top-level dogfood report. Wire-stable; the `schema_version` field
+/// pins the JSON shape so downstream consumers can detect upgrades.
+#[derive(Debug, Clone, Serialize)]
+pub struct DogfoodReport {
+    pub schema_version: &'static str,
+    pub session_path: String,
+    /// Wall-clock span between first and last event with a parseable
+    /// timestamp. `None` when fewer than 2 timestamps are recoverable.
+    pub duration_ms: Option<u64>,
+    pub total_tool_calls: u64,
+    /// Map: tool name (or `mcp__rts__*` aggregate) → call count.
+    /// `IndexMap`-ordered isn't worth the dep here; `BTreeMap` gives
+    /// deterministic JSON without extra noise.
+    pub by_source: std::collections::BTreeMap<String, u64>,
+    /// Count of `Bash` calls that could have used an rts tool, broken
+    /// out by category. Filtered by `rts_mounted_only` when set.
+    pub bash_candidate_fallthroughs: FallthroughCounts,
+    /// rts wins ÷ (rts wins + candidate Bash fall-throughs).
+    /// `None` when the denominator is zero (no rts use + no Bash
+    /// candidates → no signal).
+    pub rts_vs_bash_ratio_in_navigation_contexts: Option<f64>,
+    /// Per-candidate detail, capped at `MAX_CANDIDATE_DETAIL` to keep
+    /// the JSON bounded. Each entry carries the original command for
+    /// triage.
+    pub candidate_bash_commands: Vec<CandidateDetail>,
+    /// Whether the `--rts-mounted-only` filter dropped any calls.
+    pub rts_mounted_only: bool,
+    pub events_dropped_filter: u64,
+}
+
+/// Per-category Bash fall-through counts. Mirrors the four classifier
+/// categories one-for-one so JSON consumers can index by name without
+/// regex.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct FallthroughCounts {
+    pub grep_or_rg: u64,
+    pub find: u64,
+    pub cat_file: u64,
+    pub ls_workspace: u64,
+    pub total: u64,
+}
+
+/// One entry per classified Bash call. Captured in order of
+/// appearance in the JSONL.
+#[derive(Debug, Clone, Serialize)]
+pub struct CandidateDetail {
+    /// ISO-8601 timestamp from the JSONL line, when present.
+    pub ts: Option<String>,
+    pub command: String,
+    /// `"mcp__rts__grep"`, `"mcp__rts__find_symbol"`, etc.
+    pub would_prefer: &'static str,
+}
+
+/// Cap on `candidate_bash_commands` length. The aggregate counts in
+/// `bash_candidate_fallthroughs` are NOT capped — only the per-call
+/// detail vector. 500 entries is enough for a multi-hour session
+/// without blowing JSON size; the maintainer who needs more can
+/// re-run with the parser directly.
+pub const MAX_CANDIDATE_DETAIL: usize = 500;
+
+/// Schema-version constant for `DogfoodReport.schema_version`. Bumped
+/// on wire-shape changes; reserialize current shape unchanged.
+pub const SCHEMA_VERSION: &str = "dogfood-v0";
+
+/// Arguments shared across `analyze_path` and `analyze_reader`.
+#[derive(Debug, Clone, Copy)]
+pub struct AnalyzeOpts {
+    /// When true, restrict candidate counting to intervals where rts
+    /// appears to be mounted. See `is_session_rts_mounted`. Default
+    /// behavior at the CLI layer is `true`; set `false` here to count
+    /// every `Bash` call regardless of session context.
+    pub rts_mounted_only: bool,
+}
+
+impl Default for AnalyzeOpts {
+    fn default() -> Self {
+        Self {
+            rts_mounted_only: true,
+        }
+    }
+}
+
+/// Read a session JSONL file from disk and return a `DogfoodReport`.
+/// The path is recorded verbatim in `report.session_path` (no
+/// canonicalization — callers may want the path shape they typed).
+pub fn analyze_path(path: &Path, opts: AnalyzeOpts) -> Result<DogfoodReport> {
+    let file =
+        std::fs::File::open(path).with_context(|| format!("opening session JSONL: {path:?}"))?;
+    let reader = BufReader::new(file);
+    analyze_reader(reader, path.display().to_string(), opts)
+}
+
+/// Read a session JSONL from any `BufRead`. Used by stdin (`-`) and
+/// by the in-test fixture path. The `session_path_label` is what gets
+/// written into the report for display — typically a path string,
+/// but `<stdin>` for the stdin case.
+pub fn analyze_reader<R: BufRead>(
+    reader: R,
+    session_path_label: String,
+    opts: AnalyzeOpts,
+) -> Result<DogfoodReport> {
+    let events = parse_session(reader)?;
+    Ok(build_report(events, session_path_label, opts))
+}
+
+/// Roll up a parsed event stream into a `DogfoodReport`. Pure
+/// function so tests can construct synthetic event lists without
+/// touching the parser.
+pub fn build_report(
+    events: Vec<ToolUseEvent>,
+    session_path_label: String,
+    opts: AnalyzeOpts,
+) -> DogfoodReport {
+    // First pass: detect whether this session has ever exhibited an
+    // rts mount signal. `--rts-mounted-only` is a session-level
+    // filter today; we don't try to bracket "rts was mounted between
+    // event N and M" because the JSONL doesn't reliably carry
+    // unmount events (Claude Code doesn't emit a `Workspace.Unmount`
+    // tool_result line on session end). Future work if needed.
+    let rts_mounted = is_session_rts_mounted(&events);
+    let filter_active = opts.rts_mounted_only && !rts_mounted;
+
+    let mut total_tool_calls: u64 = 0;
+    let mut by_source: std::collections::BTreeMap<String, u64> = std::collections::BTreeMap::new();
+    let mut counts = FallthroughCounts::default();
+    let mut details: Vec<CandidateDetail> = Vec::new();
+    let mut rts_call_count: u64 = 0;
+    let mut events_dropped_filter: u64 = 0;
+
+    for evt in &events {
+        total_tool_calls += 1;
+        let bucket = bucket_for(&evt.name);
+        *by_source.entry(bucket.to_string()).or_insert(0) += 1;
+
+        if evt.name.starts_with("mcp__rts__") {
+            rts_call_count += 1;
+        }
+
+        if filter_active {
+            // Skip Bash classification entirely when the user asked
+            // to filter to rts-mounted sessions and we can't confirm
+            // rts was ever mounted. Still counted in totals — the
+            // surface is "here's a session; rts wasn't mounted, so
+            // no candidates" rather than "session is empty".
+            if evt.name == "Bash" {
+                events_dropped_filter += 1;
+            }
+            continue;
+        }
+
+        if evt.name != "Bash" {
+            continue;
+        }
+        let Some(command) = evt.command() else {
+            continue;
+        };
+
+        if let Some(cand) = classify_bash_command(command) {
+            match cand {
+                BashCandidate::GrepOrRg => counts.grep_or_rg += 1,
+                BashCandidate::Find => counts.find += 1,
+                BashCandidate::CatFile => counts.cat_file += 1,
+                BashCandidate::LsWorkspace => counts.ls_workspace += 1,
+            }
+            counts.total += 1;
+            if details.len() < MAX_CANDIDATE_DETAIL {
+                details.push(CandidateDetail {
+                    ts: evt.timestamp.clone(),
+                    command: command.to_string(),
+                    would_prefer: cand.would_prefer(),
+                });
+            }
+        }
+    }
+
+    let ratio = {
+        let denom = rts_call_count + counts.total;
+        if denom == 0 {
+            None
+        } else {
+            Some((rts_call_count as f64) / (denom as f64))
+        }
+    };
+
+    DogfoodReport {
+        schema_version: SCHEMA_VERSION,
+        session_path: session_path_label,
+        duration_ms: duration_ms(&events),
+        total_tool_calls,
+        by_source,
+        bash_candidate_fallthroughs: counts,
+        rts_vs_bash_ratio_in_navigation_contexts: ratio,
+        candidate_bash_commands: details,
+        rts_mounted_only: opts.rts_mounted_only,
+        events_dropped_filter,
+    }
+}
+
+/// Group tools into a small set of buckets so the `by_source` table
+/// stays legible. The aggregate `mcp__rts__*` bucket is the one the
+/// harness actually cares about; everything else is identity-mapped
+/// to the tool name so unfamiliar surfaces (e.g. `mcp__muonry__edit`)
+/// still appear distinctly in the report.
+fn bucket_for(tool_name: &str) -> &str {
+    if let Some(_rest) = tool_name.strip_prefix("mcp__rts__") {
+        "mcp__rts__*"
+    } else {
+        tool_name
+    }
+}
+
+/// Decide whether rts was ever mounted in this session.
+///
+/// Two signals, any one is sufficient:
+/// 1. An `mcp__rts__*` tool_use appears anywhere in the transcript
+///    (the agent could only call those if rts was loaded).
+/// 2. The session's `cwd` (when present) points at a directory whose
+///    parent layout looks like an rts-indexable workspace AND a
+///    `Workspace.Mount`-shaped MCP call appears. Today only signal
+///    (1) is exercised — signal (2) is documented for the case where
+///    we later want to detect "rts was AVAILABLE but unused", but
+///    that's a different question.
+///
+/// Returns true when we have positive evidence of rts mount activity.
+/// On uncertainty (e.g. tiny session, no MCP traffic at all), returns
+/// false; the caller decides what `--rts-mounted-only` means in that
+/// gray zone (we treat it as "filter active" so the user gets the
+/// conservative interpretation).
+fn is_session_rts_mounted(events: &[ToolUseEvent]) -> bool {
+    events.iter().any(|e| e.name.starts_with("mcp__rts__"))
+}
+
+/// Span between the earliest and latest event timestamp. None when
+/// fewer than two timestamps parse.
+fn duration_ms(events: &[ToolUseEvent]) -> Option<u64> {
+    let mut min: Option<i64> = None;
+    let mut max: Option<i64> = None;
+    for e in events {
+        let Some(ts) = e.timestamp.as_deref() else {
+            continue;
+        };
+        let Some(ms) = parse_iso8601_to_ms(ts) else {
+            continue;
+        };
+        min = Some(min.map_or(ms, |m| m.min(ms)));
+        max = Some(max.map_or(ms, |m| m.max(ms)));
+    }
+    match (min, max) {
+        (Some(lo), Some(hi)) if hi >= lo => Some((hi - lo) as u64),
+        _ => None,
+    }
+}
+
+/// Parse an ISO-8601 UTC timestamp like `"2026-05-19T14:32:11.123Z"`
+/// into epoch milliseconds. Hand-rolled rather than pulling in
+/// `chrono`/`time` because the format is fixed (Claude Code always
+/// emits UTC with `Z` and millisecond precision) and the cost of a
+/// 200KB dep for one timestamp shape isn't justified per Rule 2.
+///
+/// Returns `None` on any parse failure — callers degrade to
+/// `duration_ms = None` rather than failing the whole report.
+fn parse_iso8601_to_ms(s: &str) -> Option<i64> {
+    // Expected shape: YYYY-MM-DDTHH:MM:SS[.fff]Z
+    let bytes = s.as_bytes();
+    if bytes.len() < 20 {
+        return None;
+    }
+    if bytes[4] != b'-' || bytes[7] != b'-' || bytes[10] != b'T' {
+        return None;
+    }
+    if bytes[13] != b':' || bytes[16] != b':' {
+        return None;
+    }
+    let year: i32 = s.get(0..4)?.parse().ok()?;
+    let month: u32 = s.get(5..7)?.parse().ok()?;
+    let day: u32 = s.get(8..10)?.parse().ok()?;
+    let hour: i64 = s.get(11..13)?.parse().ok()?;
+    let minute: i64 = s.get(14..16)?.parse().ok()?;
+    let second: i64 = s.get(17..19)?.parse().ok()?;
+
+    // Optional fractional seconds. Strip "Z" if present.
+    let (frac_ms, _tail) = if let Some(dot_pos) = s[19..].find('.') {
+        let rest = &s[19 + dot_pos + 1..];
+        let z_pos = rest.find('Z').unwrap_or(rest.len());
+        let frac = &rest[..z_pos];
+        // Take up to 3 digits as ms; pad/truncate as needed.
+        let mut ms = 0i64;
+        for (i, c) in frac.chars().enumerate() {
+            if i >= 3 {
+                break;
+            }
+            let d = c.to_digit(10)? as i64;
+            ms = ms * 10 + d;
+        }
+        for _ in frac.chars().take(3).count()..3 {
+            ms *= 10;
+        }
+        (ms, &rest[z_pos..])
+    } else {
+        (0, &s[19..])
+    };
+
+    let days = days_from_civil(year, month, day);
+    let secs = days * 86_400 + hour * 3_600 + minute * 60 + second;
+    Some(secs * 1_000 + frac_ms)
+}
+
+/// Howard Hinnant's days_from_civil; converts (Y, M, D) Gregorian to
+/// days since 1970-01-01. Public-domain algorithm.
+fn days_from_civil(y: i32, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = y.div_euclid(400) as i64;
+    let yoe = y.rem_euclid(400) as i64;
+    let m = m as i64;
+    let d = d as i64;
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe - 719_468
+}
+
+/// Render a `DogfoodReport` as JSON (pretty-printed). The serde
+/// derive gives byte-stable ordering for `BTreeMap`s; field order
+/// within structs follows source-declaration order.
+pub fn render_json(report: &DogfoodReport) -> Result<String> {
+    serde_json::to_string_pretty(report).context("serializing dogfood report")
+}
+
+/// Render a `DogfoodReport` as the human-readable terminal output
+/// described in the plan. Keeps section headings stable so smoke
+/// tests can pattern-match them.
+pub fn render_text(report: &DogfoodReport) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = writeln!(out, "Session: {}", report.session_path);
+    if let Some(ms) = report.duration_ms {
+        let _ = writeln!(out, "Duration: {}", fmt_duration(ms));
+    } else {
+        let _ = writeln!(out, "Duration: (insufficient timestamps)");
+    }
+    let _ = writeln!(out, "Tool calls: {} total", report.total_tool_calls);
+    let _ = writeln!(out);
+
+    let _ = writeln!(out, "By tool source:");
+    // Sort by descending count, then name asc, so the most-used tools
+    // surface first. Stable order makes diffing two reports tractable.
+    let mut pairs: Vec<(&String, &u64)> = report.by_source.iter().collect();
+    pairs.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+    let total = report.total_tool_calls.max(1) as f64;
+    for (name, count) in pairs {
+        let pct = (*count as f64) / total * 100.0;
+        let _ = writeln!(out, "  {:<24} {:>5}  ({:>5.1}%)", name, count, pct);
+    }
+    let _ = writeln!(out);
+
+    let counts = &report.bash_candidate_fallthroughs;
+    if report.rts_mounted_only && report.events_dropped_filter > 0 && counts.total == 0 {
+        let _ = writeln!(
+            out,
+            "Bash calls that may have preferred rts: (skipped — \
+             rts mount not detected; {} Bash call(s) not classified, \
+             pass --no-rts-mounted-only to score regardless)",
+            report.events_dropped_filter,
+        );
+    } else {
+        let _ = writeln!(
+            out,
+            "Bash calls that may have preferred rts (counted within rts-mounted intervals):"
+        );
+        let _ = writeln!(out, "  grep / rg     : {} calls", counts.grep_or_rg);
+        let _ = writeln!(out, "  find          : {} calls", counts.find);
+        let _ = writeln!(
+            out,
+            "  cat (file)    : {} calls   (Read tool would have been better even ignoring rts)",
+            counts.cat_file
+        );
+        let _ = writeln!(out, "  ls (workspace): {} calls", counts.ls_workspace);
+        let _ = writeln!(out, "  Total candidate fall-throughs: {}", counts.total);
+    }
+    let _ = writeln!(out);
+
+    let _ = writeln!(out, "Rts-vs-Bash ratio in code-navigation contexts:");
+    let rts_calls = report.by_source.get("mcp__rts__*").copied().unwrap_or(0);
+    match report.rts_vs_bash_ratio_in_navigation_contexts {
+        Some(r) => {
+            let _ = writeln!(
+                out,
+                "  rts wins: {} / ({} + {}) = {:.1}%",
+                rts_calls,
+                rts_calls,
+                counts.total,
+                r * 100.0,
+            );
+        }
+        None => {
+            let _ = writeln!(out, "  rts wins: 0 / 0 (no signal in this session)");
+        }
+    }
+    out
+}
+
+fn fmt_duration(ms: u64) -> String {
+    let secs = ms / 1000;
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    if h > 0 {
+        format!("{h}h {m}m {s}s")
+    } else if m > 0 {
+        format!("{m}m {s}s")
+    } else {
+        format!("{s}s")
+    }
+}
+
+/// CLI args, parsed in `main.rs` and threaded here. Kept as a
+/// separate struct so the dispatcher doesn't have to inline the
+/// parameter list (matches the `doctor::DoctorArgs` pattern).
+#[derive(Debug)]
+pub struct DogfoodArgs {
+    /// Path to the session JSONL, or `-` for stdin.
+    pub session: PathBuf,
+    pub report: ReportFormat,
+    pub rts_mounted_only: bool,
+}
+
+/// Entry point invoked from `main.rs`'s dispatcher. Reads the
+/// transcript, builds the report, prints it in the requested format,
+/// and returns success. Exits with a non-zero anyhow error on parse
+/// failure (the JSONL is malformed or the file is unreadable).
+pub fn run(args: DogfoodArgs) -> Result<()> {
+    let opts = AnalyzeOpts {
+        rts_mounted_only: args.rts_mounted_only,
+    };
+    let report = if args.session.as_os_str() == "-" {
+        let stdin = std::io::stdin();
+        let lock = stdin.lock();
+        analyze_reader(lock, "<stdin>".to_string(), opts)?
+    } else {
+        analyze_path(&args.session, opts)?
+    };
+
+    match args.report {
+        ReportFormat::Json => {
+            println!("{}", render_json(&report)?);
+        }
+        ReportFormat::Text => {
+            print!("{}", render_text(&report));
+        }
+    }
+    Ok(())
+}

--- a/crates/rts-bench/src/dogfood/parse.rs
+++ b/crates/rts-bench/src/dogfood/parse.rs
@@ -1,0 +1,202 @@
+//! JSONL session-transcript parser for `rts-bench dogfood`.
+//!
+//! Claude Code session files live at
+//! `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`. Each line is one
+//! JSON event. The events we care about have:
+//!
+//! ```jsonc
+//! {
+//!   "type": "assistant",
+//!   "timestamp": "2026-05-19T14:32:11.123Z",
+//!   "message": {
+//!     "role": "assistant",
+//!     "content": [
+//!       { "type": "tool_use", "id": "toolu_...", "name": "Bash",
+//!         "input": { "command": "grep -rn pattern .", "description": "..." } }
+//!     ]
+//!   }
+//! }
+//! ```
+//!
+//! A single assistant line can carry multiple tool_uses (Claude can
+//! batch tool calls in a turn). Non-tool content blocks (`"text"`,
+//! `"thinking"`) and non-assistant lines (`user`, `tool_result`,
+//! `summary`, `queue-operation`, …) are ignored.
+//!
+//! Parse contract: best-effort, fail-loud-on-format-corruption,
+//! quiet-on-individual-event-skips. A line that isn't valid JSON
+//! returns `Err` (the file is corrupt); a line that's valid JSON but
+//! has none of the expected fields is skipped silently (forward-compat
+//! with new Claude Code event types).
+
+use std::io::BufRead;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+/// One agent-emitted tool invocation. The parser flattens
+/// multi-tool-use assistant turns into N events, one per tool_use
+/// block, preserving the outer line's timestamp on each.
+#[derive(Debug, Clone)]
+pub struct ToolUseEvent {
+    /// Tool name verbatim, e.g. `"Bash"`, `"Read"`, `"mcp__rts__grep"`.
+    pub name: String,
+    /// ISO-8601 UTC timestamp from the outer event line, when present.
+    /// `None` for lines that omit it (rare; the dogfood report
+    /// degrades to `duration_ms: None` instead of failing).
+    pub timestamp: Option<String>,
+    /// The full `input` object as it appeared in the JSONL. Kept
+    /// untyped because tool-input shapes vary by tool (Bash has
+    /// `command`, Edit has `file_path` + `new_string`, etc.).
+    pub input: Value,
+}
+
+impl ToolUseEvent {
+    /// Convenience for the `Bash` case: pull `input.command` as `&str`.
+    /// Returns `None` for non-Bash events or when the field is missing
+    /// or not a string. Tool calls without a command can't be
+    /// classified, so the classifier short-circuits via this returning
+    /// `None`.
+    pub fn command(&self) -> Option<&str> {
+        self.input.get("command")?.as_str()
+    }
+}
+
+/// Parse a session JSONL into a flat vector of `ToolUseEvent`s in
+/// source order. One outer JSONL line can emit zero or many events
+/// depending on how many tool_use blocks it carries.
+///
+/// Returns `Err` on any line that isn't valid JSON; partial output is
+/// not surfaced — the maintainer fixes the JSONL or filters it.
+/// Lines that are valid JSON but uninteresting (user messages, tool
+/// results, queue ops) yield zero events.
+pub fn parse_session<R: BufRead>(reader: R) -> Result<Vec<ToolUseEvent>> {
+    let mut out = Vec::new();
+    for (idx, line) in reader.lines().enumerate() {
+        let line = line.with_context(|| format!("reading JSONL line {}", idx + 1))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let v: Value = serde_json::from_str(trimmed)
+            .with_context(|| format!("parsing JSONL line {}: not valid JSON", idx + 1))?;
+        extract_tool_uses(&v, &mut out);
+    }
+    Ok(out)
+}
+
+/// Drain `tool_use` blocks from a single JSONL line's parsed JSON
+/// into `out`. Tolerates the four shapes we've observed in real
+/// Claude Code transcripts:
+///
+/// - `{"type":"assistant", "message":{"content":[…]}}` — the modern
+///   shape, what every recent session emits.
+/// - `{"type":"user", "message":{"content":[…]}}` — user turns can
+///   theoretically carry tool_use too (sidechain), so we accept them.
+/// - Lines without a `message.content[]` array (queue ops, summaries,
+///   `tool_result` blocks at the top level) → silently skipped.
+///
+/// We do NOT try to walk arbitrarily-nested structures; the official
+/// content-block shape is always at `message.content[]`.
+fn extract_tool_uses(line: &Value, out: &mut Vec<ToolUseEvent>) {
+    let timestamp = line
+        .get("timestamp")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let Some(content) = line
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())
+    else {
+        return;
+    };
+
+    for block in content {
+        let Some(obj) = block.as_object() else {
+            continue;
+        };
+        let Some(ty) = obj.get("type").and_then(|t| t.as_str()) else {
+            continue;
+        };
+        if ty != "tool_use" {
+            continue;
+        }
+        let name = obj
+            .get("name")
+            .and_then(|n| n.as_str())
+            .unwrap_or("")
+            .to_string();
+        if name.is_empty() {
+            // Defensive: a tool_use block without a name is malformed
+            // upstream. Skip rather than panic.
+            continue;
+        }
+        let input = obj
+            .get("input")
+            .cloned()
+            .unwrap_or(Value::Object(serde_json::Map::new()));
+        out.push(ToolUseEvent {
+            name,
+            timestamp: timestamp.clone(),
+            input,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_assistant_with_single_tool_use() {
+        let line = r#"{"type":"assistant","timestamp":"2026-05-19T14:32:11.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]}}"#;
+        let evts = parse_session(line.as_bytes()).unwrap();
+        assert_eq!(evts.len(), 1);
+        assert_eq!(evts[0].name, "Bash");
+        assert_eq!(evts[0].command(), Some("ls"));
+        assert_eq!(
+            evts[0].timestamp.as_deref(),
+            Some("2026-05-19T14:32:11.000Z")
+        );
+    }
+
+    #[test]
+    fn flattens_multi_tool_use_into_multiple_events() {
+        let line = r#"{"type":"assistant","timestamp":"2026-05-19T14:32:11.000Z","message":{"content":[{"type":"tool_use","id":"a","name":"Bash","input":{"command":"ls"}},{"type":"tool_use","id":"b","name":"Read","input":{"file_path":"/x"}}]}}"#;
+        let evts = parse_session(line.as_bytes()).unwrap();
+        assert_eq!(evts.len(), 2);
+        assert_eq!(evts[0].name, "Bash");
+        assert_eq!(evts[1].name, "Read");
+    }
+
+    #[test]
+    fn skips_text_blocks_and_non_assistant_lines() {
+        let jsonl = concat!(
+            r#"{"type":"queue-operation","timestamp":"2026-05-19T14:32:00.000Z"}"#,
+            "\n",
+            r#"{"type":"user","timestamp":"2026-05-19T14:32:05.000Z","message":{"role":"user","content":"hello"}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-05-19T14:32:11.000Z","message":{"content":[{"type":"text","text":"thinking..."}]}}"#,
+            "\n",
+            r#"{"type":"assistant","timestamp":"2026-05-19T14:32:12.000Z","message":{"content":[{"type":"tool_use","id":"t","name":"Bash","input":{"command":"ls"}}]}}"#,
+            "\n",
+        );
+        let evts = parse_session(jsonl.as_bytes()).unwrap();
+        assert_eq!(evts.len(), 1);
+        assert_eq!(evts[0].name, "Bash");
+    }
+
+    #[test]
+    fn malformed_json_line_is_an_error() {
+        let jsonl = "{this is not json}\n";
+        assert!(parse_session(jsonl.as_bytes()).is_err());
+    }
+
+    #[test]
+    fn empty_lines_are_skipped() {
+        let jsonl = "\n\n\n";
+        let evts = parse_session(jsonl.as_bytes()).unwrap();
+        assert!(evts.is_empty());
+    }
+}

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -20,6 +20,7 @@ use serde_json::json;
 mod baseline;
 mod corpus;
 mod doctor;
+mod dogfood;
 mod footprint;
 mod footprint_helpers;
 mod latency;
@@ -218,6 +219,41 @@ enum Cmd {
         /// Default: no check, exits 0 regardless of metrics.
         #[arg(long)]
         check_coverage: Option<f64>,
+    },
+    /// Self-dogfood telemetry harness. Ingests a Claude Code session
+    /// JSONL transcript and reports how often the agent reached for
+    /// `Bash(grep|rg|find|cat|ls)` when an `mcp__rts__*` tool would
+    /// have served the same intent. Closes the evidence loop on
+    /// PR #121's tool-description audit: lets the maintainer measure
+    /// whether discoverability changes actually move the rts-vs-Bash
+    /// ratio in real sessions, instead of relying on vibes. Client-
+    /// side only — reads JSONL files already on disk; no daemon
+    /// counters; no opt-in telemetry pipeline (that's PR #115).
+    Dogfood {
+        /// Path to the Claude Code session JSONL (typically
+        /// `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`), or `-`
+        /// to read from stdin.
+        session: PathBuf,
+        /// Output format. `text` (default) renders a human checklist
+        /// with section headings the smoke tests pattern-match on;
+        /// `json` emits a schema-pinned report
+        /// (`schema_version: "dogfood-v0"`) for post-hoc pipelines.
+        #[arg(long, value_enum, default_value_t = dogfood::ReportFormat::Text)]
+        report: dogfood::ReportFormat,
+        /// Restrict candidate counting to sessions where rts appears
+        /// mounted (a `mcp__rts__*` tool_use appeared anywhere in the
+        /// transcript). Default: true — the "did the audit help?"
+        /// question is only meaningful when rts was actually available.
+        /// Pass `--rts-mounted-only=false` to score every Bash call
+        /// regardless of session context.
+        #[arg(
+            long,
+            default_value_t = true,
+            action = clap::ArgAction::Set,
+            num_args = 0..=1,
+            default_missing_value = "true"
+        )]
+        rts_mounted_only: bool,
     },
 }
 
@@ -616,6 +652,20 @@ async fn main() -> Result<()> {
             check_coverage,
         } => run_semantic(corpus, workspace, top_k, out, dry_run, check_coverage).await,
         Cmd::RealRepos { sub } => run_real_repos(sub).await,
+        Cmd::Dogfood {
+            session,
+            report,
+            rts_mounted_only,
+        } => {
+            // Dogfood is a pure CPU/file-IO operation — no daemon, no
+            // network, no tokio handles. Block on the synchronous
+            // implementation rather than spawning anything.
+            dogfood::run(dogfood::DogfoodArgs {
+                session,
+                report,
+                rts_mounted_only,
+            })
+        }
     }
 }
 

--- a/crates/rts-bench/tests/dogfood_smoke.rs
+++ b/crates/rts-bench/tests/dogfood_smoke.rs
@@ -1,0 +1,251 @@
+//! Smoke tests for `rts-bench dogfood`.
+//!
+//! Each test embeds a synthetic JSONL fixture inline so the test
+//! suite has no dependency on real session transcripts (which carry
+//! workspace paths and other session-private context we don't want
+//! in fixtures). Synthetic fixtures shape themselves to match real
+//! Claude Code event lines — verified against `~/.claude/projects/*/`
+//! shapes during PR development — but contain no real session data.
+//!
+//! Tests spawn the `rts-bench` binary as a subprocess and pipe the
+//! fixture in over stdin (`session = "-"`). That matches the
+//! convention used by every other `crates/rts-bench/tests/*.rs`
+//! integration test, and exercises the full clap-derive → dispatcher
+//! → renderer path the maintainer actually hits.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn rts_bench_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-bench"))
+}
+
+/// Build a single JSONL tool_use line. The shape matches Claude
+/// Code's transcript format (verified against real session files
+/// during PR development).
+fn tool_use_line(ts: &str, tool: &str, input_json: &str) -> String {
+    format!(
+        r#"{{"type":"assistant","timestamp":"{ts}","message":{{"role":"assistant","content":[{{"type":"tool_use","id":"t","name":"{tool}","input":{input_json}}}]}}}}"#,
+    )
+}
+
+/// Synthetic mixed-tool session with rts mount signal present.
+/// Contents:
+/// - 1 `mcp__rts__find_symbol` call (rts-mounted signal),
+/// - 1 `Bash(grep)` (a candidate fall-through),
+/// - 1 `Bash(cat /tmp/...)` (excluded: tempfile),
+/// - 1 `Bash(cargo test)` (excluded: build invocation),
+/// - 1 `Read` call (not a candidate, not rts).
+///
+/// Expected report shape:
+/// - total_tool_calls = 5
+/// - by_source: Bash=3, Read=1, mcp__rts__*=1
+/// - grep_or_rg candidate count = 1
+/// - rts ratio = 1 / (1+1) = 0.5
+fn synthetic_mixed_session() -> String {
+    [
+        tool_use_line(
+            "2026-05-19T14:32:11.000Z",
+            "mcp__rts__find_symbol",
+            r#"{"name":"foo"}"#,
+        ),
+        tool_use_line(
+            "2026-05-19T14:32:12.000Z",
+            "Bash",
+            r#"{"command":"grep -rn 'fn foo' crates/"}"#,
+        ),
+        tool_use_line(
+            "2026-05-19T14:32:13.000Z",
+            "Bash",
+            r#"{"command":"cat /tmp/test.log"}"#,
+        ),
+        tool_use_line(
+            "2026-05-19T14:32:14.000Z",
+            "Bash",
+            r#"{"command":"cargo test"}"#,
+        ),
+        tool_use_line(
+            "2026-05-19T14:32:15.000Z",
+            "Read",
+            r#"{"file_path":"/x.rs"}"#,
+        ),
+    ]
+    .join("\n")
+}
+
+/// Run `rts-bench dogfood - --report <fmt>` piping `jsonl` over
+/// stdin. Returns (stdout, exit_status_code) so tests can assert
+/// both content and CLI contract (exit 0 on a happy-path run).
+fn run_dogfood(jsonl: &str, fmt: &str, extra_args: &[&str]) -> (String, i32) {
+    let mut cmd = Command::new(rts_bench_bin());
+    cmd.arg("dogfood")
+        .arg("-")
+        .arg("--report")
+        .arg(fmt)
+        .args(extra_args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn rts-bench");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        stdin.write_all(jsonl.as_bytes()).expect("write");
+    }
+    let out = child.wait_with_output().expect("wait");
+    let code = out.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8(out.stdout).expect("utf8 stdout");
+    if code != 0 {
+        eprintln!("stderr: {}", String::from_utf8_lossy(&out.stderr));
+    }
+    (stdout, code)
+}
+
+/// Smoke test 1: hand-crafted JSONL with known mix → assert counts.
+///
+/// What this verifies: the parser + report assembly correctly
+/// flattens a multi-tool session into the expected `by_source` map,
+/// the `total_tool_calls` counter, and the `mcp__rts__*` bucket
+/// rollup. Without this guard, a regression that double-counted
+/// tool_uses or dropped the rts prefix bucket would silently land.
+#[test]
+fn parses_synthetic_session() {
+    let (stdout, code) = run_dogfood(&synthetic_mixed_session(), "json", &[]);
+    assert_eq!(code, 0);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    assert_eq!(parsed["total_tool_calls"], 5);
+    assert_eq!(parsed["by_source"]["Bash"], 3);
+    assert_eq!(parsed["by_source"]["Read"], 1);
+    assert_eq!(parsed["by_source"]["mcp__rts__*"], 1);
+
+    // 1 rts call + 1 grep candidate → ratio = 0.5
+    let ratio = parsed["rts_vs_bash_ratio_in_navigation_contexts"]
+        .as_f64()
+        .expect("ratio f64");
+    assert!((ratio - 0.5).abs() < 1e-6, "expected 0.5, got {ratio}");
+
+    // Candidate detail: just the grep call; cat /tmp/* + cargo excluded.
+    let details = parsed["candidate_bash_commands"]
+        .as_array()
+        .expect("details array");
+    assert_eq!(details.len(), 1);
+    assert_eq!(details[0]["would_prefer"], "mcp__rts__grep");
+}
+
+/// Smoke test 2: a Bash(`grep`) call is classified as an
+/// `mcp__rts__grep` candidate fall-through.
+///
+/// What this verifies: the dogfood report's `would_prefer` mapping
+/// stays pinned to `mcp__rts__grep` for the grep family. If somebody
+/// renames the rts tool surface and forgets to update the classifier,
+/// this test catches the drift before it ships.
+#[test]
+fn classifies_grep_bash_as_rts_candidate() {
+    // rts mount signal is required for the default filter to count
+    // the Bash call. Inline a single `mcp__rts__*` call before the
+    // grep so the session is "rts-mounted".
+    let jsonl = [
+        tool_use_line(
+            "2026-05-19T14:32:10.000Z",
+            "mcp__rts__outline_workspace",
+            "{}",
+        ),
+        tool_use_line(
+            "2026-05-19T14:32:11.000Z",
+            "Bash",
+            r#"{"command":"grep -rn pattern ."}"#,
+        ),
+    ]
+    .join("\n");
+
+    let (stdout, code) = run_dogfood(&jsonl, "json", &[]);
+    assert_eq!(code, 0);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    assert_eq!(parsed["bash_candidate_fallthroughs"]["total"], 1);
+    assert_eq!(parsed["bash_candidate_fallthroughs"]["grep_or_rg"], 1);
+    assert_eq!(
+        parsed["candidate_bash_commands"][0]["would_prefer"],
+        "mcp__rts__grep"
+    );
+    assert!(
+        parsed["candidate_bash_commands"][0]["command"]
+            .as_str()
+            .unwrap()
+            .contains("grep"),
+    );
+}
+
+/// Smoke test 3: `--report json` output parses cleanly back through
+/// `serde_json`.
+///
+/// What this verifies: the JSON shape is round-trip stable. Tests
+/// that consume the dogfood JSON shape downstream (post-hoc analysis
+/// pipelines) need a guarantee that the harness emits valid JSON
+/// even on edge cases.
+#[test]
+fn json_report_is_valid_json() {
+    let (stdout, code) = run_dogfood(&synthetic_mixed_session(), "json", &[]);
+    assert_eq!(code, 0);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(parsed["schema_version"], "dogfood-v0");
+    assert!(parsed["candidate_bash_commands"].is_array());
+    // Required top-level fields per the schema.
+    for field in [
+        "session_path",
+        "total_tool_calls",
+        "by_source",
+        "bash_candidate_fallthroughs",
+        "rts_vs_bash_ratio_in_navigation_contexts",
+        "rts_mounted_only",
+    ] {
+        assert!(parsed.get(field).is_some(), "missing field: {field}");
+    }
+}
+
+/// Smoke test 4: `--report text` produces a stable set of section
+/// headings smoke-testable by string match.
+///
+/// What this verifies: section headings the maintainer relies on
+/// when eyeballing output stay stable. Renames here would break
+/// grep-driven downstream parsing (e.g. piping into `awk` to extract
+/// just the ratio line).
+#[test]
+fn text_report_renders() {
+    let (stdout, code) = run_dogfood(&synthetic_mixed_session(), "text", &[]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("Tool calls: 5 total"), "{stdout}");
+    assert!(stdout.contains("By tool source:"), "{stdout}");
+    assert!(stdout.contains("candidate fall-throughs"), "{stdout}");
+    assert!(stdout.contains("Rts-vs-Bash ratio"), "{stdout}");
+}
+
+/// Bonus guard: when rts was NEVER mounted in the session and
+/// `--rts-mounted-only` is on (default), classification is skipped
+/// and the report explicitly reports the filter dropped the call.
+///
+/// What this verifies: the filter behavior is observable in the
+/// report. Without this guard, a session that nobody ran with rts
+/// could yield a high fall-through count that looks like an agent
+/// bug rather than "rts wasn't available".
+#[test]
+fn rts_not_mounted_session_filters_candidates() {
+    let jsonl = tool_use_line(
+        "2026-05-19T14:32:11.000Z",
+        "Bash",
+        r#"{"command":"grep -rn pattern ."}"#,
+    );
+
+    let (stdout, code) = run_dogfood(&jsonl, "json", &[]);
+    assert_eq!(code, 0);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(parsed["bash_candidate_fallthroughs"]["total"], 0);
+    assert_eq!(parsed["events_dropped_filter"], 1);
+
+    // Same fixture with the filter explicitly disabled → DOES count.
+    let (stdout2, code2) = run_dogfood(&jsonl, "json", &["--rts-mounted-only=false"]);
+    assert_eq!(code2, 0);
+    let parsed2: serde_json::Value = serde_json::from_str(&stdout2).expect("valid JSON");
+    assert_eq!(parsed2["bash_candidate_fallthroughs"]["total"], 1);
+}


### PR DESCRIPTION
## Motivation

Round-12 honorable-mention companion to PR #121 (the tool-description audit). During the 2026-05-19/20/21 maintainer session that shipped 15 PRs to rts:

> The orchestrating agent used `Bash(grep)` 30+ times against rts's own source code instead of `mcp__rts__grep` — even with rts mounted. This observation prompted PR #121 (tool description audit) which made the descriptions actively compete with Bash. But there was no way to MEASURE the improvement — no harness to count "out of N session-level tool calls, how many preferred rts vs Bash".

This PR ships that harness. Once it exists, every maintainer session can be analyzed post-hoc; the project can quantify whether the discoverability improvements in PR #121 actually moved the needle.

## What

New `rts-bench dogfood <session-jsonl-path> [--report json|text] [--rts-mounted-only]` subcommand. Ingests a Claude Code session JSONL file (or stdin with `-`) and reports tool-selection outcomes.

## Sample output

Run against a synthetic 7-event fixture (1 `mcp__rts__find_symbol`, 5 `Bash` of which 3 are candidate fall-throughs, 1 `Read`):

```
Session: <stdin>
Duration: 6s
Tool calls: 7 total

By tool source:
  Bash                         5  ( 71.4%)
  Read                         1  ( 14.3%)
  mcp__rts__*                  1  ( 14.3%)

Bash calls that may have preferred rts (counted within rts-mounted intervals):
  grep / rg     : 1 calls
  find          : 1 calls
  cat (file)    : 0 calls   (Read tool would have been better even ignoring rts)
  ls (workspace): 1 calls
  Total candidate fall-throughs: 3

Rts-vs-Bash ratio in code-navigation contexts:
  rts wins: 1 / (1 + 3) = 25.0%
```

Sample output uses a synthetic in-memory fixture so the PR doesn't expose any real-session workspace paths. The fixture shape (assistant lines with `message.content[].tool_use`) was verified against real Claude Code session files at `~/.claude/projects/*/<uuid>.jsonl` during development.

## Classifier patterns

All token-level, documented inline in `crates/rts-bench/src/dogfood/classify.rs`:

| Leading token | → would_prefer | Excluded | Rationale |
|---|---|---|---|
| `grep` / `rg` / `egrep` / `fgrep` / `ack` | `mcp__rts__grep` | `git grep` | shell grep returns no enclosing-symbol context and scans `target/` |
| `find` with `-name` / `-path` / `-regex` filter | `mcp__rts__find_symbol` | `find /tmp`, `find ~/Downloads`, bare `find` | only workspace-rooted symbol queries are interesting |
| `cat <file>` (workspace path, no redirection) | `mcp__rts__read_range` | `cat /tmp/...`, `cat > x`, heredocs, `cat -n` | tempfile/redirection is shell glue, not navigation |
| `ls`, `ls .`, `ls <relpath>` | `mcp__rts__outline_workspace` | `ls -l`, `ls -la`, `ls ~/Downloads` | long-form ls is admin, not orientation |

Build invocations (`cargo`, `make`, `npm`, `yarn`, `pnpm`) and `git *` are excluded outright. A leading `env VAR=val` prefix is stripped so `env RUST_LOG=debug grep foo .` still classifies.

Heuristic by design — false positives are fine because the framing is "candidate fall-throughs", not "definitively wrong tool". The aggregate counts in `bash_candidate_fallthroughs` are NOT capped; the per-call detail array `candidate_bash_commands` is bounded at 500 entries to keep the JSON tractable.

## What we'd learn

Run after each maintainer session; compare ratios over time. Expected: PR #121's tool description audit should move the rts:Bash ratio upward in code-navigation contexts. If it doesn't, that's the signal the descriptions need another pass — or that the gap is somewhere else entirely (e.g. agent's prior training rather than the surface).

## Privacy & scope (NOT this PR)

- Client-side local analysis only. Reads JSONL files already on disk under `~/.claude/projects/`. **No network. No daemon counters. No remote pings** — PR #115's opt-in telemetry pipeline is a separate surface.
- Not wired into CI. Manual maintainer tool.
- Measures tool SELECTION, not performance.

## How to test

```sh
# Build + run all 5 smoke tests + 19 unit tests:
cargo test -p rts-bench --test dogfood_smoke
cargo test -p rts-bench --bin rts-bench dogfood

# Manual smoke against a real local session:
cat ~/.claude/projects/<encoded>/<uuid>.jsonl | \
  rts-bench dogfood - --report text --rts-mounted-only=false
```

Test coverage:
- `parses_synthetic_session` — synthetic JSONL with known mix → expected counts
- `classifies_grep_bash_as_rts_candidate` — `Bash(grep)` → `would_prefer: "mcp__rts__grep"`
- `json_report_is_valid_json` — `--report json` parses back through `serde_json` and carries `schema_version: "dogfood-v0"`
- `text_report_renders` — `--report text` includes the stable section headings
- `rts_not_mounted_session_filters_candidates` — default filter behavior is observable and toggleable
- 14 unit tests on the classifier covering each pattern + exclusion
- 5 unit tests on the parser covering multi-tool turns, malformed JSON, empty lines, mixed event types

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: client-side local analysis tool. Validation: the maintainer runs the harness on a session, eyeballs the output. Future PRs can dogfood themselves — pipe the merge-session's transcript through `rts-bench dogfood --report json` and assert the ratio crossed a target threshold.

## Checklist

- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p rts-daemon -p rts-mcp -p rts-bench --all-targets` clean (no new warnings introduced by this PR)
- [x] `cargo test --workspace` passes
- [x] No `unsafe` blocks
- [x] No new dependencies (uses stdlib + `serde_json` + `tempfile`, all already workspace deps)
- [x] Changelog fragment added

🤖 Generated with Claude Opus 4.7 (1M context) via Claude Code + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>