### PR TITLE
feat(rts-daemon): expose unresolved_refs_count in Daemon.Telemetry

### DIFF
--- a/changelog.d/xxx-feat-daemon-unresolved-refs-count.md
+++ b/changelog.d/xxx-feat-daemon-unresolved-refs-count.md
@@ -1,0 +1,27 @@
+### Daemon: expose `unresolved_refs_count` in `Daemon.Telemetry`
+
+PR #123 wired the real-repo CI regression bench against `tokio` / `flask` / `gin` but had to mark `unresolved_refs_count` as `Option<u64>` with a TODO note because the daemon's `Daemon.Telemetry` RPC didn't surface the counter yet. This PR closes that gap.
+
+#### What
+
+`crates/rts-daemon/src/store/mod.rs` gains one new helper, `Store::unresolved_refs_count() -> Result<u64, redb::Error>`, that returns the size of the `UNRESOLVED_REFS` multimap via `MultimapTable::len()` (O(1)). `crates/rts-daemon/src/methods/daemon.rs::telemetry` reads it under the same workspace-mutex acquisition that already covers `language_tag_counts()`, and emits the value as a new top-level `unresolved_refs_count: u64` field in the response. `schemas/v0/methods/Daemon.Telemetry.resp.schema.json` adds the field as required; `docs/protocol-v0.md` documents the RPC shape and the new field under a new §7.11b sub-section. Capability advertisement: `daemon_telemetry_unresolved_refs_count`.
+
+#### Why
+
+`unresolved_refs_count` is the metric that would have caught the PR #118 PHP `method_declaration` extractor gap early — a regression that breaks an extractor surfaces as the count jumping up for that language's fixtures. With it on the wire, PR #123's real-repo bench can drop its `Option<u64>` wrapping in a follow-up sweep.
+
+#### Test guard
+
+- `crates/rts-daemon/src/store/mod.rs::unresolved_refs_count_reflects_table_size` — unit test against a temp store: 0 on empty, 1 after a cross-batch unresolved ref is committed, back to 0 after the callee def lands and Pass 3 drains the deferred row.
+- `crates/rts-daemon/tests/protocol_schemas.rs::unresolved_refs_count_appears_in_telemetry_response` — live RPC round-trip against the real daemon binary; asserts the field is present and well-typed.
+- The existing `response_matches_schema_for_each_method` drift gate validates the live `Daemon.Telemetry` response against the updated JSON Schema, so a code-vs-schema divergence in either direction fails CI.
+
+#### Out of scope
+
+- No changes to the resolver logic. The count is read-only on top of existing state.
+- No new RPC. The field rides in `Daemon.Telemetry`.
+- The `rts-bench` `Option<u64>` wrapping cleanup is a separate sweep — this PR unblocks it but doesn't perform it (parallel agent assignment).
+
+#### Post-deploy monitoring
+
+No additional operational monitoring required: pure additive wire field. The schema-drift test gates accidental removal; opt-in clients (`rts-bench`'s real-repo runner) read the new field immediately, pre-v0.6 daemons continue to omit it without breaking older `rts-bench` callers.

--- a/crates/rts-daemon/src/methods/daemon.rs
+++ b/crates/rts-daemon/src/methods/daemon.rs
@@ -135,6 +135,15 @@ const DAEMON_CAPABILITIES: &[&str] = &[
     // without forcing the CLI to mount the workspace twice. Clients
     // that don't ship the telemetry feature ignore the capability.
     "daemon_telemetry",
+    // v0.6+ — `Daemon.Telemetry.unresolved_refs_count` (u64): the
+    // size of the UNRESOLVED_REFS multimap at snapshot time. Each
+    // row is a reference the resolver couldn't bind to a defined
+    // symbol — forward references awaiting a later commit, or true
+    // externals (stdlib `Vec`, `println!`, etc). A regression that
+    // breaks an extractor surfaces as the count jumping up; the
+    // real-repo CI bench gates on this. Lets clients gate on the
+    // field's presence without protocol version sniffing.
+    "daemon_telemetry_unresolved_refs_count",
 ];
 
 /// `Daemon.Ping` — heartbeat + capability advertisement (protocol-v0 §4.1, §7.1).
@@ -353,9 +362,19 @@ pub async fn stats(
 ///   "error_counts":           { "INVALID_PARAMS": 3 },
 ///   "cache_hit_rate":         0.84,
 ///   "cold_walk_ms_p50":       230,
-///   "workspace_files":        47123
+///   "workspace_files":        47123,
+///   "unresolved_refs_count":  117
 /// }
 /// ```
+///
+/// `unresolved_refs_count` (u64, capability
+/// `daemon_telemetry_unresolved_refs_count`) is the size of the
+/// UNRESOLVED_REFS multimap at snapshot time: references the resolver
+/// couldn't bind to a defined symbol. Forward references decrement the
+/// count when their callee finally lands in a later commit; true
+/// externals (stdlib `Vec`, `println!`, etc.) accumulate permanently.
+/// Lower is better. Real-repo CI bench (PR #123) gates regressions on
+/// this metric.
 ///
 /// Method counts use the same `CallCounters::snapshot` map shape as
 /// `Daemon.Stats`; the `unknown_method` synthetic key is filtered
@@ -399,8 +418,12 @@ pub async fn telemetry(
     // tags, map each to its telemetry-bounded enum string. Unknown
     // tags (corrupt META, schema-newer rows) silently drop —
     // defense in depth against bounded-enum violations.
+    //
+    // unresolved_refs_count comes from the same store snapshot so we
+    // amortize the workspace-mutex lock to one acquisition.
     let mut languages_indexed: std::collections::BTreeSet<&'static str> = Default::default();
     let mut workspace_files: u64 = 0;
+    let mut unresolved_refs_count: u64 = 0;
     if let Ok(store_guard) = state.store.lock() {
         if let Some(store) = store_guard.as_ref() {
             if let Ok(tag_counts) = store.language_tag_counts() {
@@ -410,6 +433,9 @@ pub async fn telemetry(
                     }
                     workspace_files = workspace_files.saturating_add(*count);
                 }
+            }
+            if let Ok(n) = store.unresolved_refs_count() {
+                unresolved_refs_count = n;
             }
         }
     }
@@ -425,6 +451,7 @@ pub async fn telemetry(
         "cache_hit_rate":        cache_hit_rate,
         "cold_walk_ms_p50":      cold_walk_ms_p50,
         "workspace_files":       workspace_files,
+        "unresolved_refs_count": unresolved_refs_count,
     }))
 }
 

--- a/crates/rts-daemon/src/store/mod.rs
+++ b/crates/rts-daemon/src/store/mod.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use anyhow::{Context, anyhow};
 use postcard::{from_bytes, to_allocvec};
-use redb::{Database, Durability, ReadableMultimapTable, ReadableTable};
+use redb::{Database, Durability, ReadableMultimapTable, ReadableTable, ReadableTableMetadata};
 
 use schema::{
     DEFS, FID_DEFS, FID_REFS, FID_TO_PATH, FID_UNRESOLVED, FILES, META, NAME_TO_SID, PATH_TO_FID,
@@ -1370,6 +1370,30 @@ impl Store {
             count += 1;
         }
         Ok(count)
+    }
+
+    /// Count of entries in the UNRESOLVED_REFS multimap. Used by the
+    /// telemetry collector to surface call-graph completeness — every
+    /// row is a reference the resolver couldn't bind to a defined
+    /// symbol (forward reference awaiting a later commit, or a true
+    /// external like stdlib `Vec` / `println!`).
+    ///
+    /// O(1): redb's `MultimapTable::len()` returns the
+    /// `num_values` counter the table maintains across commits, so
+    /// the cost is one read-txn + one table-open. Point-in-time
+    /// snapshot — same semantics as `files_count`.
+    ///
+    /// Best-effort: returns `0` if the table is missing (pre-Mount,
+    /// or a schema-1/2 store predating UNRESOLVED_REFS) rather than
+    /// erroring.
+    pub fn unresolved_refs_count(&self) -> Result<u64, redb::Error> {
+        let read_txn = self.db.begin_read()?;
+        let table = match read_txn.open_multimap_table(schema::UNRESOLVED_REFS) {
+            Ok(t) => t,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(0),
+            Err(e) => return Err(e.into()),
+        };
+        Ok(table.len()?)
     }
 }
 
@@ -2767,6 +2791,70 @@ mod tests {
         assert!(
             callers.is_empty(),
             "after caller.rs removal, no zombie ref should resurface; got {callers:?}"
+        );
+    }
+
+    #[test]
+    fn unresolved_refs_count_reflects_table_size() {
+        // The telemetry helper must return the live UNRESOLVED_REFS row
+        // count: 0 on an empty store, 1 after a single unresolved ref
+        // is committed, back to 0 after the callee def is interned
+        // (Pass-3 drains the deferred entry).
+        let (_tmp, store) = temp_store();
+
+        // Empty store: helper returns 0 without erroring even though
+        // the table was just opened for the first time.
+        assert_eq!(store.unresolved_refs_count().unwrap(), 0);
+
+        // Commit a ref to `target` before any def of `target` exists.
+        // Pass 2 defers the row to UNRESOLVED_REFS — the helper
+        // should now see exactly 1.
+        let caller = FileBatchEntry {
+            path: std::path::PathBuf::from("caller.rs"),
+            meta: rust_meta(blake3::hash(b"caller").into()),
+            defs: vec![(
+                "make_call".to_string(),
+                fn_def(0, 100, 1, 10),
+                SymbolKind::Function,
+            )],
+            refs: vec![RefHit {
+                name: "target".to_string(),
+                start: 50,
+                end: 56,
+                start_line: 5,
+                end_line: 5,
+            }],
+            docs: Vec::new(),
+        };
+        store
+            .commit_batch(vec![caller], vec![], Durability::Immediate)
+            .unwrap();
+        assert_eq!(
+            store.unresolved_refs_count().unwrap(),
+            1,
+            "deferred ref to undefined `target` should bump the count"
+        );
+
+        // Land the callee def. Pass 3 drains the deferred entry into
+        // REFS; the unresolved count drops back to 0.
+        let target = FileBatchEntry {
+            path: std::path::PathBuf::from("target.rs"),
+            meta: rust_meta(blake3::hash(b"target").into()),
+            defs: vec![(
+                "target".to_string(),
+                fn_def(0, 50, 1, 5),
+                SymbolKind::Function,
+            )],
+            refs: Vec::new(),
+            docs: Vec::new(),
+        };
+        store
+            .commit_batch(vec![target], vec![], Durability::Immediate)
+            .unwrap();
+        assert_eq!(
+            store.unresolved_refs_count().unwrap(),
+            0,
+            "Pass-3 drain on callee landing should clear the deferred row"
         );
     }
 

--- a/crates/rts-daemon/tests/protocol_schemas.rs
+++ b/crates/rts-daemon/tests/protocol_schemas.rs
@@ -427,3 +427,91 @@ async fn error_responses_match_error_schema() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// **Property 5 (telemetry-specific).** `Daemon.Telemetry` exposes
+/// `unresolved_refs_count` as a non-negative integer. The real-repo CI
+/// bench (PR #123) gates regressions on this field — if the daemon
+/// stops emitting it, that bench's `Option<u64>` collapses to `None`
+/// and the regression check silently no-ops.
+///
+/// We assert the field's presence + type live (not just via the
+/// schema-drift property), because the schema property only fires
+/// under `--include-ignored`. This test runs there too — but the
+/// assertion is direct so the failure message points at the missing
+/// field rather than a generic "schema mismatch".
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "spawns the daemon binary; opt-in via --include-ignored"]
+async fn unresolved_refs_count_appears_in_telemetry_response() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    // Plant a tiny Rust fixture so the workspace mounts cleanly.
+    // The exact contents don't matter for this assertion — we only
+    // care that the field is present and well-typed.
+    let fixture_src = workspace.path().join("src");
+    std::fs::create_dir_all(&fixture_src)?;
+    std::fs::write(
+        fixture_src.join("lib.rs"),
+        "pub fn answer() -> u32 { 42 }\n",
+    )?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill_on_drop = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "mnt",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(
+        mount["error"].is_null(),
+        "Workspace.Mount unexpectedly errored: {mount:?}"
+    );
+
+    let resp = round_trip(&mut stream, "t", "Daemon.Telemetry", json!({})).await?;
+    assert!(
+        resp["error"].is_null(),
+        "Daemon.Telemetry errored: {resp:?}"
+    );
+    let result = &resp["result"];
+    let count = result
+        .get("unresolved_refs_count")
+        .unwrap_or_else(|| panic!("missing unresolved_refs_count in {result}"));
+    let n = count
+        .as_u64()
+        .unwrap_or_else(|| panic!("unresolved_refs_count not a u64: {count:?}"));
+    // Implicit >=0 via u64; explicit assert for the human reader.
+    let _ = n;
+
+    Ok(())
+}

--- a/docs/protocol-v0.md
+++ b/docs/protocol-v0.md
@@ -1005,6 +1005,33 @@ Emitted iff the connection opted in via `Workspace.Mount`'s `enable_telemetry: t
 }
 ```
 
+### 7.11b `Daemon.Telemetry` (RPC, v0.6+, capability `daemon_telemetry`)
+
+Pull-style snapshot of the daemon's raw telemetry collector inputs. Distinct from the §7.11 notification (which is push-style and per-event). The receiver-side bounded-enum filter still runs in `rts-mcp`; this RPC just hands the collectors their data without forcing the CLI to mount the workspace twice. HTTP-free — the telemetry POST lives behind a separate `--features telemetry` gate in the `rts` binary.
+
+**`params`**: `{}`
+**`result`**:
+
+```jsonc
+{
+  "uptime_secs":            12345,
+  "languages_indexed":      ["rust", "python"],
+  "method_counts":          { "Index.FindSymbol": 7, "Index.Grep": 23 },
+  "method_latency_p50_ms":  { "Index.FindSymbol": 2 },
+  "method_latency_p99_ms":  { "Index.FindSymbol": 8 },
+  "error_counts":           { "INVALID_PARAMS": 3 },
+  "cache_hit_rate":         0.84,
+  "cold_walk_ms_p50":       230,
+  "workspace_files":        47123,
+  "unresolved_refs_count":  117
+}
+```
+
+Field notes:
+
+- `unresolved_refs_count` (u64, capability `daemon_telemetry_unresolved_refs_count`) — size of the UNRESOLVED_REFS multimap at snapshot time. Each row is a reference the resolver couldn't bind to a defined symbol; forward references decrement the count when their callee finally lands in a later commit, while true externals (stdlib `Vec`, `println!`, etc.) accumulate permanently. Lower is better. A regression that breaks an extractor surfaces as the count jumping up — the real-repo CI bench gates on this.
+- Map keys are sourced from closed-enum strings (`CallCounters::snapshot`, `MethodLatencyHistograms::enumerated`, `ErrorCode::as_wire_str`, `writer::lang_tag_to_name`); no user-controlled identifiers reach the wire.
+
 ---
 
 ## 8. Cold-state semantics

--- a/schemas/v0/methods/Daemon.Telemetry.resp.schema.json
+++ b/schemas/v0/methods/Daemon.Telemetry.resp.schema.json
@@ -23,7 +23,12 @@
       "description": "p50 cold-walk duration in ms; `null` until at least one cold walk has completed.",
       "type": ["integer", "null"]
     },
-    "workspace_files":        { "type": "integer", "minimum": 0 }
+    "workspace_files":        { "type": "integer", "minimum": 0 },
+    "unresolved_refs_count": {
+      "description": "Capability `daemon_telemetry_unresolved_refs_count`. Number of entries in the UNRESOLVED_REFS multimap — references the indexer couldn't bind to a defined symbol (forward references awaiting a later commit, or true externals like stdlib `Vec`/`println!`). Point-in-time; lower is better. 0 pre-Mount.",
+      "type": "integer",
+      "minimum": 0
+    }
   },
   "required": [
     "uptime_secs",
@@ -34,6 +39,7 @@
     "error_counts",
     "cache_hit_rate",
     "cold_walk_ms_p50",
-    "workspace_files"
+    "workspace_files",
+    "unresolved_refs_count"
   ]
 }


### PR DESCRIPTION
## Summary

Adds a new `unresolved_refs_count: u64` field to the `Daemon.Telemetry` RPC response. The count is the size of the daemon's `UNRESOLVED_REFS` multimap at snapshot time — references the resolver couldn't bind to a defined symbol (forward references awaiting a later commit, or true externals like stdlib `Vec` / `println!`). Lower is better.

## Motivation

PR #123 wired the real-repo CI regression bench against `tokio` / `flask` / `gin` to catch performance / correctness regressions before they ship. The bench's diff policy already understood `unresolved_refs_count` as a one-sided gate (current may not exceed baseline by more than +10%), but it had to mark the field `Option<u64>` with a `TODO(post-G)` because the daemon's `Daemon.Telemetry` RPC didn't surface the counter yet. This PR is that follow-up.

This is the exact metric that would have caught **PR #118** (PHP `method_declaration` extractor gap) early: a regression that breaks an extractor surfaces as the count jumping up for that language's fixtures. The bench in #123 can now gate on it once `rts-bench` drops its `Option<u64>` wrapping (separate sweep — explicitly not in this PR).

## Cross-references

- **PR #118** — PHP `method_declaration` extractor gap. The kind of regression this metric would have caught early.
- **PR #123** — real-repo CI regression bench that surfaced the missing field and marked it `Option<u64>` pending this PR.
- **PR #122** — schema gate (`schemas/v0/`). The `response_matches_schema_for_each_method` drift test gates accidental field removal automatically.

## Sample response

```jsonc
// Daemon.Telemetry response after mounting a small workspace
{
  "uptime_secs":            12,
  "languages_indexed":      ["rust"],
  "method_counts":          { "Workspace.Mount": 1 },
  "method_latency_p50_ms":  { "Workspace.Mount": 4 },
  "method_latency_p99_ms":  { "Workspace.Mount": 4 },
  "error_counts":           {},
  "cache_hit_rate":         null,
  "cold_walk_ms_p50":       3,
  "workspace_files":        1,
  "unresolved_refs_count":  0
}
```

After a cross-batch commit where `caller.rs` references `target` before `target.rs` lands, `unresolved_refs_count` shows `1`; once `target.rs` lands and Pass-3 drains the deferred row, it returns to `0`.

## Capability advertisement

Exactly one new capability string is added to `DAEMON_CAPABILITIES` in `crates/rts-daemon/src/methods/daemon.rs`:

```
daemon_telemetry_unresolved_refs_count
```

Clients gate on this string (e.g. via `Daemon.Ping`'s `capabilities` array) to detect the field's presence without protocol version sniffing. Pattern matches every other capability-string entry in the array.

## Implementation notes

- `Store::unresolved_refs_count() -> Result<u64, redb::Error>` is a single-line wrapper around redb's `MultimapTable::len()`, which returns the `num_values` counter the table maintains across commits — O(1). Best-effort: returns 0 if the table is missing (pre-Mount).
- The telemetry handler reads the count under the same `state.store.lock()` acquisition that already covers `language_tag_counts()` — no extra mutex contention.
- The JSON Schema marks the new field as `required`. The schema-drift test (`response_matches_schema_for_each_method`, behind `#[ignore]`, opt-in via `--include-ignored`) catches accidental removal in either direction (schema-vs-code).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy -p rts-daemon -p rts-mcp -p rts-bench --all-targets` — no new warnings from this PR (pre-existing warnings only)
- [x] `cargo test --workspace` passes
- [x] `cargo test -p rts-daemon --test protocol_schemas -- --include-ignored` passes (5/5 incl. new test + schema drift)
- [x] New unit test: `unresolved_refs_count_reflects_table_size` — verifies 0 → 1 → 0 transition across a cross-batch unresolved-ref scenario
- [x] New live RPC test: `unresolved_refs_count_appears_in_telemetry_response` — spawns the daemon, mounts a fixture, asserts the field is present and well-typed
- [x] No `unsafe` blocks added

## Post-Deploy Monitoring & Validation

New telemetry field becomes immediately available to opt-in clients. The schema-drift test gates accidental field removal. No additional operational monitoring required.

---

🤖 Generated with Claude Opus 4.7 (1M context) via Claude Code + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>