### PR TITLE
feat(rts-daemon): garbage-collect UNRESOLVED_REFS for removed files + bounded TTL

### DIFF
--- a/changelog.d/xxx-feat-daemon-unresolved-refs-gc.md
+++ b/changelog.d/xxx-feat-daemon-unresolved-refs-gc.md
@@ -1,0 +1,36 @@
+### Daemon: GC orphaned `UNRESOLVED_REFS` for removed files + bounded telemetry
+
+PR #126 exposed `Daemon.Telemetry.unresolved_refs_count` so external observers can watch the parked-reference table grow. Without a GC pass that count was unbounded for files removed on disk — every parked row whose source file got deleted lived in the table forever, drifting the observable metric away from the actual call-graph health. This PR closes that loop.
+
+#### What
+
+`crates/rts-daemon/src/store/mod.rs` gains `Store::gc_unresolved_refs_for_removed_files(removed_files: &[PathBuf]) -> Result<u64, redb::Error>` — walks each removed-file path through the `FID_UNRESOLVED` reverse index, drops `UNRESOLVED_REFS[name]` rows whose `RefSite.fid` matches, returns the count actually deleted. The writer's `flush()` invokes the helper before each `commit_batch` that carries removals; `commit_batch`'s existing `drop_file_entries` then finds the rows already gone (no-op for the GC portion). `crates/rts-daemon/src/state.rs` adds two `AtomicU64` counters (`unresolved_refs_gc_runs_total`, `unresolved_refs_gc_dropped_total`) that the writer bumps on each removal-bearing flush; `Daemon.Telemetry` surfaces both as new top-level u64 fields, gated behind capability `daemon_telemetry_unresolved_refs_gc`. `schemas/v0/methods/Daemon.Telemetry.resp.schema.json` adds both fields as required; `docs/protocol-v0.md` §7.11b documents them with the bounded-growth contract.
+
+#### Strategy
+
+File-removal-driven (Strategy A in the PR brief). The `FID_UNRESOLVED` reverse index already provides O(distinct_callee_names_for_this_fid) lookup, so the GC is amortized into the existing file-removal flush — no background timer, no policy knobs, no schema change. TTL-driven GC (Strategy B) was rejected: it would require a new `created_at_ms` column for a hypothesis (genuinely-unresolvable refs accumulate at meaningful rates) that hasn't been measured. A is one schema change away from B if evidence ever lands.
+
+#### Why
+
+`unresolved_refs_count` becomes a regression signal once GC is wired in: a sudden jump without `unresolved_refs_gc_dropped_total` advancing means an extractor regression (PR #118's PHP `method_declaration` gap is exactly the class of bug that would have moved this needle). Pre-PR-128 the same jump was indistinguishable from "user deleted some files" — both look the same on the wire.
+
+#### Test guard
+
+- `crates/rts-daemon/src/store/mod.rs::gc_unresolved_refs_drops_rows_for_named_file` — unit test against a temp store: 1 parked row, GC pass, 0 left + dropped=1.
+- `crates/rts-daemon/src/store/mod.rs::gc_unresolved_refs_preserves_other_files` — control: two files sharing a callee name; remove only one; assert the other's row survives (`FID_UNRESOLVED`-keyed lookup must not over-collect by name).
+- `crates/rts-daemon/src/store/mod.rs::gc_unresolved_refs_empty_input_returns_zero` — empty-slice short-circuit (no write txn started).
+- `crates/rts-daemon/tests/unresolved_refs_gc.rs::gc_drops_refs_for_removed_file` — end-to-end against the daemon binary: spawn, mount, observe phantom ref parked, delete the source file, assert count drops AND both GC counters advance.
+- `crates/rts-daemon/tests/unresolved_refs_gc.rs::gc_runs_counter_bumps_on_each_removal` — two independent file removals advance `unresolved_refs_gc_runs_total` by 2.
+- `crates/rts-daemon/tests/unresolved_refs_gc.rs::gc_preserves_refs_from_still_present_files` — control over the live wire: shared callee name, remove only one of two files, surviving file's ref must still be parked.
+- The existing `response_matches_schema_for_each_method` schema-drift gate validates the live `Daemon.Telemetry` response against the updated JSON Schema; new fields without the schema bump or vice versa fail CI.
+
+#### Out of scope
+
+- No background polling timer. File-removal events are the only trigger.
+- No TTL-based GC. Schema unchanged.
+- No new RPC. GC is internal; observe via `Daemon.Telemetry`.
+- No changes to the resolver's Pass-3 binding. Resolution and GC stay independent.
+
+#### Post-deploy monitoring
+
+Monitor `unresolved_refs_count` trend over time. Healthy signal: count stays bounded and `unresolved_refs_gc_dropped_total` advances as files are removed. Failure signal: count climbs monotonically without `unresolved_refs_gc_dropped_total` advancing — indicates either GC isn't firing (look at `unresolved_refs_gc_runs_total` first) or an extractor regression (an extractor change that newly drops symbol defs would park refs that match no later commit).

--- a/crates/rts-daemon/src/methods/daemon.rs
+++ b/crates/rts-daemon/src/methods/daemon.rs
@@ -144,6 +144,16 @@ const DAEMON_CAPABILITIES: &[&str] = &[
     // real-repo CI bench gates on this. Lets clients gate on the
     // field's presence without protocol version sniffing.
     "daemon_telemetry_unresolved_refs_count",
+    // v0.6+ — `Daemon.Telemetry.unresolved_refs_gc_runs_total` and
+    // `unresolved_refs_gc_dropped_total` (u64 each): cumulative
+    // counters reflecting the daemon's own GC of orphaned
+    // UNRESOLVED_REFS rows (file-removal-driven, see PR #128). With
+    // these the otherwise-monotonically-growing `unresolved_refs_count`
+    // becomes bounded — a healthy daemon's GC counters advance as
+    // files are removed; a sudden jump in `unresolved_refs_count`
+    // without matching GC activity points at an extractor regression
+    // (e.g. PR #118's PHP `method_declaration` gap class).
+    "daemon_telemetry_unresolved_refs_gc",
 ];
 
 /// `Daemon.Ping` — heartbeat + capability advertisement (protocol-v0 §4.1, §7.1).
@@ -441,17 +451,27 @@ pub async fn telemetry(
     }
     let languages_indexed: Vec<&'static str> = languages_indexed.into_iter().collect();
 
+    // PR #128 (capability `daemon_telemetry_unresolved_refs_gc`).
+    // Cumulative counters describing the daemon's own GC activity
+    // against orphaned UNRESOLVED_REFS rows. Reading is one relaxed
+    // load apiece; cheap to include unconditionally.
+    use std::sync::atomic::Ordering::Relaxed;
+    let unresolved_refs_gc_runs_total = state.unresolved_refs_gc_runs_total.load(Relaxed);
+    let unresolved_refs_gc_dropped_total = state.unresolved_refs_gc_dropped_total.load(Relaxed);
+
     Ok(serde_json::json!({
-        "uptime_secs":           uptime_secs,
-        "languages_indexed":     languages_indexed,
-        "method_counts":         serde_json::Value::Object(method_counts),
-        "method_latency_p50_ms": p50,
-        "method_latency_p99_ms": p99,
-        "error_counts":          error_counts,
-        "cache_hit_rate":        cache_hit_rate,
-        "cold_walk_ms_p50":      cold_walk_ms_p50,
-        "workspace_files":       workspace_files,
-        "unresolved_refs_count": unresolved_refs_count,
+        "uptime_secs":                       uptime_secs,
+        "languages_indexed":                 languages_indexed,
+        "method_counts":                     serde_json::Value::Object(method_counts),
+        "method_latency_p50_ms":             p50,
+        "method_latency_p99_ms":             p99,
+        "error_counts":                      error_counts,
+        "cache_hit_rate":                    cache_hit_rate,
+        "cold_walk_ms_p50":                  cold_walk_ms_p50,
+        "workspace_files":                   workspace_files,
+        "unresolved_refs_count":             unresolved_refs_count,
+        "unresolved_refs_gc_runs_total":     unresolved_refs_gc_runs_total,
+        "unresolved_refs_gc_dropped_total":  unresolved_refs_gc_dropped_total,
     }))
 }
 

--- a/crates/rts-daemon/src/state.rs
+++ b/crates/rts-daemon/src/state.rs
@@ -274,6 +274,22 @@ pub struct DaemonState {
     /// FIFO eviction). The `Daemon.Telemetry` snapshot computes p50
     /// over this window.
     pub cold_walk_durations_ms: Mutex<VecDeque<u64>>,
+    /// v0.6+ telemetry counter (PR #128, capability
+    /// `daemon_telemetry_unresolved_refs_gc`). Cumulative number of
+    /// UNRESOLVED_REFS garbage-collection invocations: one bump per
+    /// removed file the writer processed. Paired with
+    /// `unresolved_refs_gc_dropped_total` so an external observer can
+    /// distinguish "GC is firing but finding nothing" from "GC is not
+    /// firing." Reset on daemon restart, same convention as
+    /// `cancellations_total`.
+    pub unresolved_refs_gc_runs_total: AtomicU64,
+    /// v0.6+ telemetry counter (PR #128). Cumulative number of
+    /// UNRESOLVED_REFS rows the GC has dropped — orphaned forward-
+    /// reference entries whose source file was deleted. Bounds the
+    /// growth of `Daemon.Telemetry.unresolved_refs_count`; a healthy
+    /// long-running daemon should see this advance whenever files
+    /// disappear and `unresolved_refs_count` stay bounded.
+    pub unresolved_refs_gc_dropped_total: AtomicU64,
 }
 
 /// Cache hit/miss counters shared across the daemon's four query-time
@@ -656,6 +672,8 @@ impl DaemonState {
             cache_counters: CacheCounters::default(),
             cold_walk_started_at_ms: AtomicU64::new(0),
             cold_walk_durations_ms: Mutex::new(VecDeque::with_capacity(COLD_WALK_WINDOW)),
+            unresolved_refs_gc_runs_total: AtomicU64::new(0),
+            unresolved_refs_gc_dropped_total: AtomicU64::new(0),
         }
     }
 

--- a/crates/rts-daemon/src/store/mod.rs
+++ b/crates/rts-daemon/src/store/mod.rs
@@ -1395,6 +1395,112 @@ impl Store {
         };
         Ok(table.len()?)
     }
+
+    /// Drop `UNRESOLVED_REFS` rows whose source file matches any path
+    /// in `removed_files`. Returns the count of rows actually dropped.
+    ///
+    /// **Why this exists.** `UNRESOLVED_REFS` is the parking lot for
+    /// refs whose callee name wasn't yet interned at commit time
+    /// (forward references awaiting a later commit, or true externals
+    /// like stdlib `Vec` / `println!`). When the source file of one of
+    /// those parked refs is deleted on disk, the parked entry becomes
+    /// orphaned: there is no longer any source-code call site behind
+    /// it, but the row stays in the table forever, bloating the count
+    /// observed via `Daemon.Telemetry.unresolved_refs_count`.
+    ///
+    /// This helper closes that loop by walking each removed file's
+    /// outgoing unresolved refs via the `FID_UNRESOLVED` reverse
+    /// index, dropping rows where `RefSite.fid` matches. It is the
+    /// public, telemetry-counted peer of the same cleanup that
+    /// `drop_file_entries` performs inline during a full file
+    /// re-index. Calling it before `commit_batch` for the same path
+    /// is safe and idempotent — `drop_file_entries` finds the rows
+    /// already gone and returns 0 additional work.
+    ///
+    /// Idempotent and bounded: passing an unknown path (already
+    /// deleted, never indexed) returns `0` without erroring. Cost is
+    /// `O(distinct_callee_names_for_this_fid × avg_fan_out)`, the same
+    /// shape as the existing `drop_file_entries` path.
+    ///
+    /// Paths are matched against `PATH_TO_FID` as workspace-relative
+    /// strings, matching the writer's storage convention.
+    pub fn gc_unresolved_refs_for_removed_files(
+        &self,
+        removed_files: &[PathBuf],
+    ) -> Result<u64, redb::Error> {
+        if removed_files.is_empty() {
+            return Ok(0);
+        }
+        let mut dropped: u64 = 0;
+        let txn = self.db.begin_write()?;
+        {
+            let path_to_fid = match txn.open_table(PATH_TO_FID) {
+                Ok(t) => t,
+                Err(redb::TableError::TableDoesNotExist(_)) => return Ok(0),
+                Err(e) => return Err(e.into()),
+            };
+            let mut unresolved_refs = match txn.open_multimap_table(UNRESOLVED_REFS) {
+                Ok(t) => t,
+                Err(redb::TableError::TableDoesNotExist(_)) => return Ok(0),
+                Err(e) => return Err(e.into()),
+            };
+            let mut fid_unresolved = match txn.open_multimap_table(FID_UNRESOLVED) {
+                Ok(t) => t,
+                Err(redb::TableError::TableDoesNotExist(_)) => return Ok(0),
+                Err(e) => return Err(e.into()),
+            };
+
+            for path in removed_files {
+                let path_str = path.to_string_lossy();
+                let fid = match path_to_fid.get(path_str.as_ref())? {
+                    Some(v) => v.value(),
+                    None => continue,
+                };
+
+                // Collect this file's pending callee names from the
+                // FID_UNRESOLVED reverse index. We can't mutate while
+                // iterating a redb multimap, so snapshot first.
+                let pending_names: Vec<String> = {
+                    let mut v = Vec::new();
+                    let it = fid_unresolved.get(&fid)?;
+                    for row in it {
+                        v.push(row?.value().to_string());
+                    }
+                    v
+                };
+                fid_unresolved.remove_all(&fid)?;
+
+                for name in &pending_names {
+                    // Filter-rewrite the UNRESOLVED_REFS[name] multimap:
+                    // keep rows whose RefSite.fid != this fid; count
+                    // the rest as dropped.
+                    let mut kept: Vec<Vec<u8>> = Vec::new();
+                    let mut dropped_for_name: u64 = 0;
+                    {
+                        let it = unresolved_refs.get(name.as_str())?;
+                        for row in it {
+                            let bytes = row?.value().to_vec();
+                            match from_bytes::<RefSite>(&bytes) {
+                                Ok(rs) if rs.fid == fid => {
+                                    dropped_for_name += 1;
+                                }
+                                _ => {
+                                    kept.push(bytes);
+                                }
+                            }
+                        }
+                    }
+                    unresolved_refs.remove_all(name.as_str())?;
+                    for v in kept {
+                        unresolved_refs.insert(name.as_str(), v.as_slice())?;
+                    }
+                    dropped = dropped.saturating_add(dropped_for_name);
+                }
+            }
+        }
+        txn.commit()?;
+        Ok(dropped)
+    }
 }
 
 /// Surface struct for `Index.FindSymbol` consumers. Plain data; no redb
@@ -2856,6 +2962,149 @@ mod tests {
             0,
             "Pass-3 drain on callee landing should clear the deferred row"
         );
+    }
+
+    #[test]
+    fn gc_unresolved_refs_drops_rows_for_named_file() {
+        // PR #128: the explicit GC API drops UNRESOLVED_REFS rows
+        // whose source file appears in the input list and returns
+        // the count actually deleted. Idempotent on unknown paths.
+        let (_tmp, store) = temp_store();
+
+        // Park one unresolved ref by committing a caller whose
+        // callee is never defined.
+        let caller = FileBatchEntry {
+            path: std::path::PathBuf::from("caller.rs"),
+            meta: rust_meta(blake3::hash(b"caller").into()),
+            defs: vec![(
+                "make_call".to_string(),
+                fn_def(0, 100, 1, 10),
+                SymbolKind::Function,
+            )],
+            refs: vec![RefHit {
+                name: "phantom_target".to_string(),
+                start: 50,
+                end: 64,
+                start_line: 5,
+                end_line: 5,
+            }],
+            docs: Vec::new(),
+        };
+        store
+            .commit_batch(vec![caller], vec![], Durability::Immediate)
+            .unwrap();
+        assert_eq!(store.unresolved_refs_count().unwrap(), 1);
+
+        // Idempotent on unknown paths: an unknown file name reports
+        // 0 dropped and doesn't disturb the live row.
+        let dropped = store
+            .gc_unresolved_refs_for_removed_files(&[std::path::PathBuf::from("does-not-exist.rs")])
+            .unwrap();
+        assert_eq!(dropped, 0, "unknown path should be a no-op");
+        assert_eq!(store.unresolved_refs_count().unwrap(), 1);
+
+        // The real removal: pass caller.rs and expect 1 row dropped.
+        let dropped = store
+            .gc_unresolved_refs_for_removed_files(&[std::path::PathBuf::from("caller.rs")])
+            .unwrap();
+        assert_eq!(
+            dropped, 1,
+            "removing caller.rs should drop its single parked row"
+        );
+        assert_eq!(
+            store.unresolved_refs_count().unwrap(),
+            0,
+            "the parked row should be gone after GC"
+        );
+    }
+
+    #[test]
+    fn gc_unresolved_refs_preserves_other_files() {
+        // PR #128: GC keyed by `FID_UNRESOLVED[fid]` must NOT touch
+        // unresolved rows belonging to other files that happen to
+        // share the same callee name.
+        let (_tmp, store) = temp_store();
+
+        let a = FileBatchEntry {
+            path: std::path::PathBuf::from("a.rs"),
+            meta: rust_meta(blake3::hash(b"a").into()),
+            defs: vec![(
+                "a_fn".to_string(),
+                fn_def(0, 50, 1, 5),
+                SymbolKind::Function,
+            )],
+            refs: vec![RefHit {
+                name: "shared_phantom".to_string(),
+                start: 20,
+                end: 34,
+                start_line: 3,
+                end_line: 3,
+            }],
+            docs: Vec::new(),
+        };
+        let b = FileBatchEntry {
+            path: std::path::PathBuf::from("b.rs"),
+            meta: rust_meta(blake3::hash(b"b").into()),
+            defs: vec![(
+                "b_fn".to_string(),
+                fn_def(0, 50, 1, 5),
+                SymbolKind::Function,
+            )],
+            refs: vec![RefHit {
+                name: "shared_phantom".to_string(),
+                start: 20,
+                end: 34,
+                start_line: 3,
+                end_line: 3,
+            }],
+            docs: Vec::new(),
+        };
+        store
+            .commit_batch(vec![a, b], vec![], Durability::Immediate)
+            .unwrap();
+        assert_eq!(
+            store.unresolved_refs_count().unwrap(),
+            2,
+            "both files should have parked one row each"
+        );
+
+        // Remove only a.rs: b.rs's row must survive.
+        let dropped = store
+            .gc_unresolved_refs_for_removed_files(&[std::path::PathBuf::from("a.rs")])
+            .unwrap();
+        assert_eq!(dropped, 1, "exactly a.rs's row should be dropped");
+        assert_eq!(
+            store.unresolved_refs_count().unwrap(),
+            1,
+            "b.rs's row must survive"
+        );
+
+        // Confirm the survivor really belongs to b.rs (fid recovered
+        // from the postcard blob).
+        let txn = store.db.begin_read().unwrap();
+        let unresolved = txn.open_multimap_table(UNRESOLVED_REFS).unwrap();
+        let mut survivors = Vec::new();
+        for row in unresolved.get("shared_phantom").unwrap() {
+            let bytes = row.unwrap().value().to_vec();
+            survivors.push(from_bytes::<RefSite>(&bytes).unwrap());
+        }
+        assert_eq!(survivors.len(), 1);
+        let path_to_fid = txn.open_table(PATH_TO_FID).unwrap();
+        let b_fid = path_to_fid.get("b.rs").unwrap().unwrap().value();
+        assert_eq!(
+            survivors[0].fid, b_fid,
+            "survivor should be b.rs's row, not a.rs's"
+        );
+    }
+
+    #[test]
+    fn gc_unresolved_refs_empty_input_returns_zero() {
+        // PR #128: passing an empty slice short-circuits cleanly and
+        // does not begin a write transaction. Important because the
+        // writer calls this on every flush — including flushes with
+        // no removals.
+        let (_tmp, store) = temp_store();
+        assert_eq!(store.gc_unresolved_refs_for_removed_files(&[]).unwrap(), 0);
     }
 
     #[test]

--- a/crates/rts-daemon/src/writer.rs
+++ b/crates/rts-daemon/src/writer.rs
@@ -358,6 +358,42 @@ fn flush(
         })
         .collect();
 
+    // UNRESOLVED_REFS garbage collection (PR #128, capability
+    // `daemon_telemetry_unresolved_refs_gc`). When a file is removed
+    // from disk, any rows it parked in `UNRESOLVED_REFS` become
+    // orphans — no source-code call site remains behind them. PR #126
+    // exposed the row count as `Daemon.Telemetry.unresolved_refs_count`
+    // but the count was unbounded without this GC pass. Run BEFORE
+    // `commit_batch` so the count we record matches what an external
+    // observer would see; `commit_batch`'s `drop_file_entries` then
+    // finds the rows already gone and contributes no additional work.
+    if !removal_vec.is_empty() {
+        let removed_paths: Vec<PathBuf> = removal_vec.iter().map(|r| r.path.clone()).collect();
+        match store.gc_unresolved_refs_for_removed_files(&removed_paths) {
+            Ok(dropped) => {
+                state.unresolved_refs_gc_runs_total.fetch_add(
+                    removed_paths.len() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                if dropped > 0 {
+                    state
+                        .unresolved_refs_gc_dropped_total
+                        .fetch_add(dropped, std::sync::atomic::Ordering::Relaxed);
+                }
+            }
+            Err(e) => {
+                // Best-effort: GC failure must not stop the writer from
+                // committing the file removals themselves. The next
+                // removal that lands will retry the cleanup.
+                warn!(
+                    error = %e,
+                    paths = removed_paths.len(),
+                    "unresolved_refs GC failed; continuing"
+                );
+            }
+        }
+    }
+
     let upserted = store.commit_batch(batch, removal_vec, durability)?;
     if upserted > 0 {
         state

--- a/crates/rts-daemon/tests/unresolved_refs_gc.rs
+++ b/crates/rts-daemon/tests/unresolved_refs_gc.rs
@@ -1,0 +1,464 @@
+//! End-to-end test for the UNRESOLVED_REFS GC pass introduced in
+//! PR #128 (capability `daemon_telemetry_unresolved_refs_gc`).
+//!
+//! Three properties are asserted against the live daemon binary,
+//! mirroring the test plan in the PR brief:
+//!
+//! 1. `gc_drops_refs_for_removed_file` — a workspace where one file
+//!    forward-references a symbol that **does not exist anywhere**
+//!    parks a row in `UNRESOLVED_REFS`. Deleting the file should
+//!    drain that row and advance the telemetry counters.
+//! 2. `gc_runs_counter_bumps_on_each_removal` — two independent
+//!    removals advance `unresolved_refs_gc_runs_total` by two.
+//! 3. `gc_preserves_refs_from_still_present_files` — control test:
+//!    removing one file must NOT drop another file's unresolved refs.
+//!
+//! The test spawns the real daemon binary; it's gated on
+//! `--include-ignored` (matching every other integration test in this
+//! crate that touches the binary) so it doesn't slow the inner-loop
+//! `cargo test`.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(5), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn socket_path(home_dir: &Path, runtime_dir: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        home_dir
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.join("rts").join("default.sock")
+    }
+}
+
+fn spawn_daemon(
+    runtime_dir: &Path,
+    state_dir: &Path,
+    home_dir: &Path,
+) -> anyhow::Result<std::process::Child> {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir, std::fs::Permissions::from_mode(0o700));
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir)
+        .env("XDG_STATE_HOME", state_dir)
+        .env("HOME", home_dir)
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    Ok(cmd.spawn()?)
+}
+
+/// Pull the three relevant fields out of a `Daemon.Telemetry`
+/// response so tests can assert against them tersely.
+fn read_telemetry_fields(resp: &Value) -> (u64, u64, u64) {
+    let result = &resp["result"];
+    let count = result["unresolved_refs_count"].as_u64().unwrap_or(0);
+    let runs = result["unresolved_refs_gc_runs_total"]
+        .as_u64()
+        .unwrap_or(0);
+    let dropped = result["unresolved_refs_gc_dropped_total"]
+        .as_u64()
+        .unwrap_or(0);
+    (count, runs, dropped)
+}
+
+/// Poll `Daemon.Telemetry` until `predicate` succeeds against the
+/// `(count, runs, dropped)` triple, or `timeout` elapses. Returns the
+/// final triple on success; bails with the last observed value
+/// otherwise.
+async fn poll_telemetry<F>(
+    stream: &mut UnixStream,
+    id_seed: u32,
+    timeout: Duration,
+    predicate: F,
+) -> anyhow::Result<(u64, u64, u64)>
+where
+    F: Fn(u64, u64, u64) -> bool,
+{
+    let deadline = Instant::now() + timeout;
+    let mut id = id_seed;
+    loop {
+        id += 1;
+        let r = round_trip(stream, &id.to_string(), "Daemon.Telemetry", json!({})).await?;
+        let last = read_telemetry_fields(&r);
+        if predicate(last.0, last.1, last.2) {
+            return Ok(last);
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "telemetry never satisfied predicate within {timeout:?}; last=(count={}, runs={}, dropped={})",
+                last.0,
+                last.1,
+                last.2
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Poll `Index.FindSymbol(name)` until at least one match comes back,
+/// or `timeout` elapses. Used to wait for the writer to drain a touch.
+async fn poll_find_symbol_exists(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+    id_seed: u32,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id = id_seed;
+    loop {
+        id += 1;
+        let r = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if let Some(arr) = r["result"]["matches"].as_array() {
+            if !arr.is_empty() {
+                return Ok(());
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("FindSymbol({name}) never returned matches within {timeout:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+/// **Test 1.** A workspace with a file whose only ref points at a
+/// symbol that **does not exist anywhere** parks a row in
+/// `UNRESOLVED_REFS` (`unknown_phantom_target` below — chosen so it
+/// can't collide with stdlib / `println!` / Vec etc.). Removing the
+/// file on disk must:
+///   a) drain the row (count drops by at least one), and
+///   b) advance both `unresolved_refs_gc_runs_total` (one removal)
+///      and `unresolved_refs_gc_dropped_total` (at least one row).
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "spawns the daemon binary; opt-in via --include-ignored"]
+async fn gc_drops_refs_for_removed_file() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    // caller.rs references `unknown_phantom_target`, which is never
+    // defined anywhere. Without GC, that row stays in UNRESOLVED_REFS
+    // forever; with GC it drops when caller.rs is removed.
+    std::fs::write(
+        workspace.path().join("caller.rs"),
+        "pub fn caller_fn() {\n    unknown_phantom_target();\n}\n",
+    )?;
+
+    let sock = socket_path(home_dir.path(), runtime_dir.path());
+    let mut child = spawn_daemon(runtime_dir.path(), state_dir.path(), home_dir.path())?;
+    let _kill = KillOnDrop(&mut child);
+    wait_for_socket(&sock, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&sock).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount failed: {mount:?}");
+
+    // Wait until indexing observes caller.rs.
+    poll_find_symbol_exists(&mut stream, "caller_fn", Duration::from_secs(10), 100).await?;
+
+    // The phantom ref should be parked in UNRESOLVED_REFS. Poll for
+    // it: indexing is async, so a same-millisecond check after Mount
+    // might catch a half-flushed state.
+    let (pre_count, _, pre_dropped) = poll_telemetry(
+        &mut stream,
+        200,
+        Duration::from_secs(10),
+        |count, _runs, _dropped| count >= 1,
+    )
+    .await?;
+    assert!(
+        pre_count >= 1,
+        "unresolved_refs_count should be >= 1 after caller.rs is indexed (phantom ref); got {pre_count}"
+    );
+
+    // Delete the file on disk. The watcher should emit Removed,
+    // the writer should run GC, and telemetry should reflect both
+    // the count drop and the GC counters advancing.
+    std::fs::remove_file(workspace.path().join("caller.rs"))?;
+
+    let (post_count, post_runs, post_dropped) = poll_telemetry(
+        &mut stream,
+        300,
+        Duration::from_secs(15),
+        |count, _runs, dropped| count < pre_count && dropped > pre_dropped,
+    )
+    .await?;
+
+    assert!(
+        post_count < pre_count,
+        "unresolved_refs_count should drop after file removal; pre={pre_count}, post={post_count}"
+    );
+    assert!(
+        post_runs >= 1,
+        "unresolved_refs_gc_runs_total should advance after a file removal; got {post_runs}"
+    );
+    assert!(
+        post_dropped >= 1,
+        "unresolved_refs_gc_dropped_total should advance by >= 1; got {post_dropped}"
+    );
+
+    Ok(())
+}
+
+/// **Test 2.** Two independent file removals must each register on
+/// `unresolved_refs_gc_runs_total`. Counters are cumulative, so we
+/// snapshot before and after and assert the delta.
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "spawns the daemon binary; opt-in via --include-ignored"]
+async fn gc_runs_counter_bumps_on_each_removal() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    // Two independent files, each with its own phantom callee. The
+    // distinct callees ensure each file's removal touches a different
+    // FID_UNRESOLVED reverse-edge set.
+    std::fs::write(
+        workspace.path().join("first.rs"),
+        "pub fn first_fn() {\n    phantom_one();\n}\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("second.rs"),
+        "pub fn second_fn() {\n    phantom_two();\n}\n",
+    )?;
+
+    let sock = socket_path(home_dir.path(), runtime_dir.path());
+    let mut child = spawn_daemon(runtime_dir.path(), state_dir.path(), home_dir.path())?;
+    let _kill = KillOnDrop(&mut child);
+    wait_for_socket(&sock, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&sock).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount failed: {mount:?}");
+
+    // Wait for both files to be indexed (both phantom refs parked).
+    poll_find_symbol_exists(&mut stream, "first_fn", Duration::from_secs(10), 100).await?;
+    poll_find_symbol_exists(&mut stream, "second_fn", Duration::from_secs(10), 200).await?;
+    let (_pre_count, pre_runs, _pre_dropped) = poll_telemetry(
+        &mut stream,
+        300,
+        Duration::from_secs(10),
+        |count, _runs, _dropped| count >= 2,
+    )
+    .await?;
+
+    // Remove file 1, wait for runs to advance.
+    std::fs::remove_file(workspace.path().join("first.rs"))?;
+    let (_c1, runs_1, _d1) = poll_telemetry(
+        &mut stream,
+        400,
+        Duration::from_secs(15),
+        |_count, runs, _dropped| runs > pre_runs,
+    )
+    .await?;
+    let after_first = runs_1;
+
+    // Sleep a beat so the watcher's debouncer doesn't fold both
+    // removals into one batch. The watcher's debounce window is
+    // 150ms (per writer.rs::BATCH_FLUSH_INTERVAL), so 300ms is the
+    // safe margin.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Remove file 2.
+    std::fs::remove_file(workspace.path().join("second.rs"))?;
+    let (_c2, runs_2, _d2) = poll_telemetry(
+        &mut stream,
+        500,
+        Duration::from_secs(15),
+        |_count, runs, _dropped| runs > after_first,
+    )
+    .await?;
+
+    assert!(
+        runs_2 >= pre_runs + 2,
+        "runs_total should advance by >= 2 after two removals; pre={pre_runs}, post={runs_2}"
+    );
+
+    Ok(())
+}
+
+/// **Test 3.** Control: removing one file MUST NOT drop unresolved
+/// refs that originated in another file. The
+/// `FID_UNRESOLVED`-keyed walk in
+/// `gc_unresolved_refs_for_removed_files` is the load-bearing
+/// invariant here; if it were keyed by callee name alone, it would
+/// over-collect.
+///
+/// Both files reference the SAME phantom callee, so they share a
+/// `UNRESOLVED_REFS[name]` multimap key. Removing one file must
+/// leave the other's row in place.
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "spawns the daemon binary; opt-in via --include-ignored"]
+async fn gc_preserves_refs_from_still_present_files() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    // Both files reference the same phantom callee. The shared name
+    // is the point: this catches an implementation that drops every
+    // UNRESOLVED_REFS[name] row when ANY file with that callee name
+    // is removed.
+    std::fs::write(
+        workspace.path().join("keeper.rs"),
+        "pub fn keeper_fn() {\n    shared_phantom();\n}\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("victim.rs"),
+        "pub fn victim_fn() {\n    shared_phantom();\n}\n",
+    )?;
+
+    let sock = socket_path(home_dir.path(), runtime_dir.path());
+    let mut child = spawn_daemon(runtime_dir.path(), state_dir.path(), home_dir.path())?;
+    let _kill = KillOnDrop(&mut child);
+    wait_for_socket(&sock, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&sock).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount failed: {mount:?}");
+
+    poll_find_symbol_exists(&mut stream, "keeper_fn", Duration::from_secs(10), 100).await?;
+    poll_find_symbol_exists(&mut stream, "victim_fn", Duration::from_secs(10), 200).await?;
+
+    // Wait until both phantom refs are parked. They share a callee
+    // name but live as distinct multimap values (different `fid`
+    // inside the RefSite blob); count should reach >= 2.
+    let (pre_count, _pre_runs, pre_dropped) = poll_telemetry(
+        &mut stream,
+        300,
+        Duration::from_secs(10),
+        |count, _runs, _dropped| count >= 2,
+    )
+    .await?;
+    assert!(
+        pre_count >= 2,
+        "expected both phantom refs parked; got count={pre_count}"
+    );
+
+    // Delete only victim.rs. The GC must drop exactly its row(s),
+    // leaving keeper.rs's row intact.
+    std::fs::remove_file(workspace.path().join("victim.rs"))?;
+
+    let (post_count, _post_runs, post_dropped) = poll_telemetry(
+        &mut stream,
+        400,
+        Duration::from_secs(15),
+        |count, _runs, dropped| dropped > pre_dropped && count < pre_count,
+    )
+    .await?;
+
+    // The keeper's row must survive: count drop from 2 to 1 (not 0).
+    // Strict inequality on the post-count guards against the bug
+    // class where every UNRESOLVED_REFS[name] row gets dropped.
+    assert!(
+        post_count >= 1,
+        "keeper.rs's shared_phantom ref should survive victim.rs removal; \
+         got post_count={post_count} (pre={pre_count}, dropped_delta={})",
+        post_dropped - pre_dropped
+    );
+
+    // And to remove any doubt, FindSymbol confirms keeper_fn is still
+    // around (its file is still on disk).
+    let r = round_trip(
+        &mut stream,
+        "500",
+        "Index.FindSymbol",
+        json!({ "name": "keeper_fn" }),
+    )
+    .await?;
+    assert!(
+        r["result"]["matches"]
+            .as_array()
+            .map(|a| !a.is_empty())
+            .unwrap_or(false),
+        "keeper_fn should still be indexed after victim.rs removal: {r:?}"
+    );
+
+    Ok(())
+}

--- a/docs/protocol-v0.md
+++ b/docs/protocol-v0.md
@@ -1014,22 +1014,25 @@ Pull-style snapshot of the daemon's raw telemetry collector inputs. Distinct fro
 
 ```jsonc
 {
-  "uptime_secs":            12345,
-  "languages_indexed":      ["rust", "python"],
-  "method_counts":          { "Index.FindSymbol": 7, "Index.Grep": 23 },
-  "method_latency_p50_ms":  { "Index.FindSymbol": 2 },
-  "method_latency_p99_ms":  { "Index.FindSymbol": 8 },
-  "error_counts":           { "INVALID_PARAMS": 3 },
-  "cache_hit_rate":         0.84,
-  "cold_walk_ms_p50":       230,
-  "workspace_files":        47123,
-  "unresolved_refs_count":  117
+  "uptime_secs":                       12345,
+  "languages_indexed":                 ["rust", "python"],
+  "method_counts":                     { "Index.FindSymbol": 7, "Index.Grep": 23 },
+  "method_latency_p50_ms":             { "Index.FindSymbol": 2 },
+  "method_latency_p99_ms":             { "Index.FindSymbol": 8 },
+  "error_counts":                      { "INVALID_PARAMS": 3 },
+  "cache_hit_rate":                    0.84,
+  "cold_walk_ms_p50":                  230,
+  "workspace_files":                   47123,
+  "unresolved_refs_count":             117,
+  "unresolved_refs_gc_runs_total":     12,
+  "unresolved_refs_gc_dropped_total":  184
 }
 ```
 
 Field notes:
 
 - `unresolved_refs_count` (u64, capability `daemon_telemetry_unresolved_refs_count`) — size of the UNRESOLVED_REFS multimap at snapshot time. Each row is a reference the resolver couldn't bind to a defined symbol; forward references decrement the count when their callee finally lands in a later commit, while true externals (stdlib `Vec`, `println!`, etc.) accumulate permanently. Lower is better. A regression that breaks an extractor surfaces as the count jumping up — the real-repo CI bench gates on this.
+- `unresolved_refs_gc_runs_total` and `unresolved_refs_gc_dropped_total` (u64 each, capability `daemon_telemetry_unresolved_refs_gc`) — cumulative counters reflecting cleanup work the daemon did on its own. `runs_total` increments once per removed file the writer processed; `dropped_total` increments by the number of orphaned `UNRESOLVED_REFS` rows the GC actually deleted (rows whose source file was deleted before its forward reference resolved). Together they **bound the growth** of `unresolved_refs_count`: a healthy long-running daemon sees `dropped_total` advance as files disappear, keeping `unresolved_refs_count` flat-ish. A jump in `unresolved_refs_count` without matching `dropped_total` advancement points at an extractor regression (the class of bug PR #118's PHP `method_declaration` gap exemplifies). Both counters reset on daemon restart.
 - Map keys are sourced from closed-enum strings (`CallCounters::snapshot`, `MethodLatencyHistograms::enumerated`, `ErrorCode::as_wire_str`, `writer::lang_tag_to_name`); no user-controlled identifiers reach the wire.
 
 ---

--- a/schemas/v0/methods/Daemon.Telemetry.resp.schema.json
+++ b/schemas/v0/methods/Daemon.Telemetry.resp.schema.json
@@ -28,6 +28,16 @@
       "description": "Capability `daemon_telemetry_unresolved_refs_count`. Number of entries in the UNRESOLVED_REFS multimap — references the indexer couldn't bind to a defined symbol (forward references awaiting a later commit, or true externals like stdlib `Vec`/`println!`). Point-in-time; lower is better. 0 pre-Mount.",
       "type": "integer",
       "minimum": 0
+    },
+    "unresolved_refs_gc_runs_total": {
+      "description": "Capability `daemon_telemetry_unresolved_refs_gc`. Cumulative number of UNRESOLVED_REFS GC invocations since daemon start — one bump per removed file the writer processed. Paired with `unresolved_refs_gc_dropped_total` so observers can distinguish 'GC is firing but finding nothing' from 'GC is not firing'. Reset on daemon restart.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "unresolved_refs_gc_dropped_total": {
+      "description": "Capability `daemon_telemetry_unresolved_refs_gc`. Cumulative number of UNRESOLVED_REFS rows the daemon's GC has dropped — orphaned forward-reference entries whose source file was deleted. Bounds the growth of `unresolved_refs_count`. Reset on daemon restart.",
+      "type": "integer",
+      "minimum": 0
     }
   },
   "required": [
@@ -40,6 +50,8 @@
     "cache_hit_rate",
     "cold_walk_ms_p50",
     "workspace_files",
-    "unresolved_refs_count"
+    "unresolved_refs_count",
+    "unresolved_refs_gc_runs_total",
+    "unresolved_refs_gc_dropped_total"
   ]
 }


### PR DESCRIPTION
## Motivation

PR #126 made `unresolved_refs_count` observable in `Daemon.Telemetry`, but without a GC pass that count was unbounded for files removed on disk — every parked row whose source file got deleted lingered in the table forever, drifting the observable metric away from actual call-graph health. Two classes of stale entries previously accumulated:

1. **Source file removed.** Reconciliation (PR #112) drops the file's resolved symbols, but pre-PR-128 the file's unresolved-ref entries stayed as orphans.
2. **Genuinely unresolvable references.** Dynamic dispatch, typos, references to deleted external symbols — these were observed indirectly via the count climbing.

PR #126 made the count observable; observability without bounded growth means we can watch the metric climb without acting. PR #128 closes that loop. The metric becomes a real regression signal: a sudden jump in `unresolved_refs_count` after GC is wired in, without matching `unresolved_refs_gc_dropped_total` advancement, points at an extractor regression. PR #118's PHP `method_declaration` extractor gap is exactly the class of bug that would have moved this needle.

## Strategy decision: A (file-removal-driven)

Evidence:

- The existing `FID_UNRESOLVED` reverse index already provides O(distinct_callee_names_for_this_fid) lookup, so the GC amortizes into the writer's existing removal flush — no background timer, no policy knobs.
- `Store::drop_file_entries` already cleans `UNRESOLVED_REFS` inline during `commit_batch` removals; this PR surfaces that work explicitly via a public API and bumps telemetry counters around it.
- TTL-driven GC (Strategy B/C) was rejected: would require a new `created_at_ms` column for a hypothesis (genuinely-unresolvable refs accumulate at meaningful rates) that hasn't been measured. A is one schema change away from B if evidence ever lands.

## What

- `crates/rts-daemon/src/store/mod.rs` adds `Store::gc_unresolved_refs_for_removed_files(removed_files: &[PathBuf]) -> Result<u64, redb::Error>`. Walks each path through `FID_UNRESOLVED`, drops `UNRESOLVED_REFS[name]` rows whose `RefSite.fid` matches, returns the count actually deleted. Idempotent on unknown paths.
- `crates/rts-daemon/src/writer.rs::flush` invokes the helper before each `commit_batch` carrying removals; bumps two new `DaemonState` `AtomicU64` counters.
- `crates/rts-daemon/src/state.rs` adds `unresolved_refs_gc_runs_total` and `unresolved_refs_gc_dropped_total`.
- `crates/rts-daemon/src/methods/daemon.rs::telemetry` surfaces both as top-level u64 fields. New capability `daemon_telemetry_unresolved_refs_gc`.
- `schemas/v0/methods/Daemon.Telemetry.resp.schema.json` adds both fields as required.
- `docs/protocol-v0.md` §7.11b documents them with the bounded-growth contract.

## Sample before/after `Daemon.Telemetry` payload

**Before (PR #126 wire shape):**
```json
{
  "uptime_secs": 12345,
  "languages_indexed": ["rust", "python"],
  "method_counts": { "Index.FindSymbol": 7 },
  "method_latency_p50_ms": { "Index.FindSymbol": 2 },
  "method_latency_p99_ms": { "Index.FindSymbol": 8 },
  "error_counts": {},
  "cache_hit_rate": 0.84,
  "cold_walk_ms_p50": 230,
  "workspace_files": 47123,
  "unresolved_refs_count": 117
}
```

**After (this PR):**
```json
{
  "uptime_secs": 12345,
  "languages_indexed": ["rust", "python"],
  "method_counts": { "Index.FindSymbol": 7 },
  "method_latency_p50_ms": { "Index.FindSymbol": 2 },
  "method_latency_p99_ms": { "Index.FindSymbol": 8 },
  "error_counts": {},
  "cache_hit_rate": 0.84,
  "cold_walk_ms_p50": 230,
  "workspace_files": 47123,
  "unresolved_refs_count": 117,
  "unresolved_refs_gc_runs_total": 12,
  "unresolved_refs_gc_dropped_total": 184
}
```

## Schema diff

`schemas/v0/methods/Daemon.Telemetry.resp.schema.json` adds:

```jsonc
"unresolved_refs_gc_runs_total": {
  "description": "Capability `daemon_telemetry_unresolved_refs_gc`. Cumulative number of UNRESOLVED_REFS GC invocations since daemon start — one bump per removed file the writer processed. ...",
  "type": "integer",
  "minimum": 0
},
"unresolved_refs_gc_dropped_total": {
  "description": "Capability `daemon_telemetry_unresolved_refs_gc`. Cumulative number of UNRESOLVED_REFS rows the daemon's GC has dropped — orphaned forward-reference entries whose source file was deleted. Bounds the growth of `unresolved_refs_count`. ...",
  "type": "integer",
  "minimum": 0
}
```

Both fields are added to the `required` array. New capability string: `daemon_telemetry_unresolved_refs_gc`.

## Test plan

- [x] `cargo test -p rts-daemon` — 3 new unit tests on `Store::gc_unresolved_refs_for_removed_files` (the empty-input short-circuit, the basic drop case, the shared-callee-name preservation case).
- [x] `cargo test -p rts-daemon --test unresolved_refs_gc -- --include-ignored` — 3 new integration tests against the live daemon binary:
  - `gc_drops_refs_for_removed_file` — phantom ref parked, source file deleted, count drops + GC counters advance.
  - `gc_runs_counter_bumps_on_each_removal` — two distinct removals → `runs_total` advances by 2.
  - `gc_preserves_refs_from_still_present_files` — shared callee name; remove only one file; the other's row survives.
- [x] `cargo test -p rts-daemon --test protocol_schemas -- --include-ignored` — schema-drift gate (PR #122) validates the live `Daemon.Telemetry` response against the updated JSON Schema.
- [x] `cargo test --workspace` — full workspace passes.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p rts-daemon -p rts-mcp -p rts-bench --all-targets` — clean at lefthook scope; only pre-existing watcher.rs warnings remain.

## What's NOT in this PR

- No new RPC. GC runs on its own schedule; clients observe via `Daemon.Telemetry`.
- No changes to the resolver's Pass-3 binding logic.
- No `UNRESOLVED_REFS` row-shape changes. Strategy A doesn't need them.
- No background polling timers.

## Post-Deploy Monitoring & Validation

Monitor `unresolved_refs_count` trend over time. **Healthy signal:** count stays bounded and `unresolved_refs_gc_dropped_total` advances as files are removed. **Failure signal:** count climbs monotonically without `unresolved_refs_gc_dropped_total` advancing — indicates either GC isn't firing (check `unresolved_refs_gc_runs_total` first) or an extractor regression (an extractor change that newly drops symbol defs would park refs that match no later commit).

🤖 Generated with Claude Opus 4.7 (1M context) via Claude Code + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>