### PR TITLE
chore: remove unused dependencies (cargo-shear)

### DIFF
--- a/changelog.d/139-chore-cargo-shear-unused-deps.md
+++ b/changelog.d/139-chore-cargo-shear-unused-deps.md
@@ -1,0 +1,22 @@
+### Removed unused dependencies (cargo-shear)
+
+Stripped 28 unused dependency declarations across the workspace, flagged
+by [`cargo-shear`](https://github.com/Boshen/cargo-shear). These were
+left orphaned by the v0.6 pre-pivot cleanup (deletion of
+`CodebaseAnalyzer` and the pre-pivot weight in `rts-core`); nothing in
+the surviving code paths referenced them.
+
+- **rts-core (`rust_tree_sitter`)**: `serde_json`, `serde_yaml`, `regex`,
+  `sha2`, `rayon`, `petgraph`, `ignore`, `walkdir`, `parking_lot`,
+  `crossbeam-channel`, `memmap2`, `dashmap`, `num_cpus`, `chrono`,
+  `uuid`, `dirs`, `tracing`, `tracing-subscriber`, and the `criterion`
+  dev-dependency.
+- **rts-daemon**: `tokio-stream`, `futures-util`.
+- **rts-mcp**: `thiserror`, `hex`, `unicode-normalization`, `nix`,
+  `libc`.
+- **rts-bench**: `thiserror`, `ignore`.
+
+No false positives: every removal was verified against
+`cargo build --workspace --all-targets`, `--all-features`, the
+per-crate `telemetry`/`experimental` feature builds, and
+`cargo test --workspace`. No cargo-shear ignore list was needed.

--- a/crates/rts-bench/Cargo.toml
+++ b/crates/rts-bench/Cargo.toml
@@ -26,7 +26,6 @@ serde_json = "1"
 
 # Errors
 anyhow = "1"
-thiserror = "1"
 
 # Logging
 tracing = "0.1"
@@ -46,9 +45,6 @@ clap = { version = "4", features = ["derive"] }
 # already a transitive dep via rts-daemon; promote to direct here so
 # the doctor surface doesn't depend on it indirectly.
 dirs = "5"
-
-# Filesystem walking (mirrors rts-core's filter).
-ignore = "0.4"
 
 # Pretty-printing the JSON report.
 indexmap = { version = "2", features = ["serde"] }

--- a/crates/rts-core/Cargo.toml
+++ b/crates/rts-core/Cargo.toml
@@ -36,30 +36,6 @@ anyhow = "1.0"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_yaml = "0.9"
-
-# Core analysis helpers
-regex = "1.10"
-sha2 = "0.10"
-rayon = "1.8"
-petgraph = "0.6"
-ignore = "0.4"
-walkdir = "2.4"
-parking_lot = "0.12"
-crossbeam-channel = "0.5"
-memmap2 = "0.9"
-dashmap = "5.5"
-num_cpus = "1.0"
-
-# Time / IDs / paths
-chrono = { version = "0.4", features = ["serde"] }
-uuid = { version = "1.0", features = ["v4", "serde"] }
-dirs = "5.0"
-
-# Logging
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # LRU cache (replaces prior random-eviction HashMap caches)
 lru = "0.12"
@@ -69,7 +45,6 @@ toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3.0"
-criterion = "0.5"
 
 # Public-API drift gate (see docs/public-api-gate.md + crates/rts-core/tests/public_api.rs).
 # These deps power a `cargo test`-time check that fails when the crate's

--- a/crates/rts-daemon/Cargo.toml
+++ b/crates/rts-daemon/Cargo.toml
@@ -31,8 +31,6 @@ rust_tree_sitter = { path = "../rts-core" }
 # Async runtime + Unix-socket plumbing
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "signal", "fs", "sync", "time", "process"] }
 tokio-util = { version = "0.7", features = ["codec"] }
-tokio-stream = "0.1"
-futures-util = "0.3"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/rts-mcp/Cargo.toml
+++ b/crates/rts-mcp/Cargo.toml
@@ -57,7 +57,6 @@ serde_json = "1"
 
 # Errors
 anyhow = "1"
-thiserror = "1"
 
 # Logging — stderr-only per stdio MCP discipline.
 tracing = "0.1"
@@ -65,17 +64,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 # Workspace fingerprint → socket path discovery.
 blake3 = "1"
-hex = "0.4"
 
 # XDG / runtime-dir lookup mirrors rts-daemon's `socket::socket_path_for_default`.
 dirs = "5"
-
-# Path canonicalisation parity with rts-daemon's `workspace.rs`.
-unicode-normalization = "0.1"
-
-# Unix peer-cred / metadata probes parity with the daemon.
-nix = { version = "0.29", features = ["user", "fs"] }
-libc = "0.2"
 
 # v0.6 anonymous opt-in telemetry: TOML for the local opt-in flag.
 # Pure-Rust, already in the workspace via rts-bench/rts-core; no new


### PR DESCRIPTION
## Summary

Strips **28 unused dependency declarations** across the workspace, flagged by [`cargo-shear`](https://github.com/Boshen/cargo-shear). These deps were left orphaned by the v0.6 pre-pivot cleanup (deletion of `CodebaseAnalyzer` and the pre-pivot weight in `rts-core`, commits e4169ae / 58cc294) — no surviving code path referenced them. `cargo shear` now reports **clean** with no ignore list required.

### Deps removed

| Crate | Removed |
|-------|---------|
| `rts-core` (`rust_tree_sitter`) | `serde_json`, `serde_yaml`, `regex`, `sha2`, `rayon`, `petgraph`, `ignore`, `walkdir`, `parking_lot`, `crossbeam-channel`, `memmap2`, `dashmap`, `num_cpus`, `chrono`, `uuid`, `dirs`, `tracing`, `tracing-subscriber`, `criterion` (dev) |
| `rts-daemon` | `tokio-stream`, `futures-util` |
| `rts-mcp` | `thiserror`, `hex`, `unicode-normalization`, `nix`, `libc` |
| `rts-bench` | `thiserror`, `ignore` |

### False positives kept

**None.** Every flagged dep was confirmed genuinely unused. The rts-mcp deps (`nix`, `libc`, `unicode-normalization`, `hex`) had comments claiming "parity with daemon" peer-cred/path-normalisation, but the code that would use them lives only in `rts-daemon`, not `rts-mcp` — no `#[cfg]`-gated, feature-gated, build-script, or macro usage exists in the rts-mcp source. No `[workspace.metadata.cargo-shear] ignored` / per-crate ignore list was needed.

No source files were touched — the only `.rs`-adjacent risk (orphan files) was not flagged, and no orphan modules were found.

## Post-Deploy Monitoring & Validation

**No runtime impact.** This is a manifest-only change (4 `Cargo.toml` files + 1 changelog fragment); no source code, public API, wire protocol, or behavior changes. The compiled artifacts are byte-equivalent modulo unused-crate linkage. CI build/test is the gate.

Verification run locally, all green:

- `cargo build --workspace --all-targets` ✅
- `cargo build --workspace --all-features` ✅
- `cargo build -p rts-mcp --features telemetry` ✅
- `cargo build -p rts-mcp --features experimental` ✅
- `cargo build -p rts-daemon --features telemetry` ✅
- `cargo test --workspace` ✅ (all suites pass, incl. the rts-core `metadata.rs` Cargo.toml-introspection gate and both public-API drift gates)
- `cargo clippy --workspace --all-targets` ✅
- `cargo fmt --all --check` ✅
- `cargo shear` ✅ clean, no ignores

Nothing to monitor post-merge beyond a green CI run. If a future feature reintroduces a need for any removed crate, re-add it as a direct dependency in the consuming crate's `Cargo.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)