### PR TITLE
chore(rts-core): clear clippy advisory baseline

### DIFF
--- a/changelog.d/140-chore-rts-core-clippy.md
+++ b/changelog.d/140-chore-rts-core-clippy.md
@@ -1,0 +1,23 @@
+### rts-core — cleared the clippy advisory baseline
+
+`cargo clippy -p rust_tree_sitter --all-targets` is now warning-free. The
+crate carried ~88 advisory clippy warnings (CI does not run `-D` for
+rts-core, so they never failed a build). All are resolved with no runtime
+behavior change:
+
+- `assertions_on_constants` (35×, `constants.rs` tests) — compile-time
+  invariant `assert!`s moved into `const { … }` blocks, so they now fail the
+  build (not just the test) if a constant drifts out of range.
+- `type_complexity` (2×) — the tuple return types of `RustSyntax::find_impl_blocks`
+  and `PythonSyntax::find_typed_functions` are named via private (transparent)
+  type aliases; the public API surface is unchanged.
+- `only_used_in_recursion` (2×) — `SyntaxTree`'s private `collect_*` helpers
+  no longer take an unused `&self`.
+- `if_same_then_else` (2×) — merged identical C/Python declarator branches.
+- `let_unit_value` + the no-op `streaming_iterator_present_check` shim and its
+  dead `as _` import (`signature.rs`) removed; the dependency stays live via
+  `query.rs`.
+- dead `descend_for_body` (`signature.rs`) removed.
+- `too_many_arguments` on the public `create_edit` constructor — site-specific
+  `#[allow]` with justification; its 9 args mirror `InputEdit`'s three flattened
+  `Point` fields and collapsing them would change a public signature.

--- a/crates/rts-core/src/constants.rs
+++ b/crates/rts-core/src/constants.rs
@@ -256,30 +256,40 @@ mod tests {
 
     #[test]
     fn test_security_constants() {
-        assert!(security::DEFAULT_MIN_CONFIDENCE > 0.0);
-        assert!(security::DEFAULT_MIN_CONFIDENCE <= 1.0);
+        // These invariants hold over compile-time constants, so assert them in
+        // `const {}` blocks: they fail the build (not just the test) if a
+        // constant is ever set out of range, and clippy doesn't flag them as
+        // constant-folded runtime asserts.
+        const {
+            assert!(security::DEFAULT_MIN_CONFIDENCE > 0.0);
+            assert!(security::DEFAULT_MIN_CONFIDENCE <= 1.0);
+        }
         assert_eq!(security::MAX_SECURITY_SCORE, 100);
         assert_eq!(security::PERFECT_SECURITY_SCORE, 100);
         assert_eq!(security::BASE_SECURITY_SCORE, 100);
-        assert!(security::COVERAGE_CALCULATION_DIVISOR > 0.0);
+        const { assert!(security::COVERAGE_CALCULATION_DIVISOR > 0.0) };
         assert_eq!(security::HIGH_SECRETS_COMPLIANCE, 100);
         assert_eq!(security::MEDIUM_SECRETS_COMPLIANCE, 80);
-        assert!(security::HIGH_SEVERITY_EFFORT > security::MEDIUM_SEVERITY_EFFORT);
-        assert!(security::MEDIUM_SEVERITY_EFFORT > security::LOW_SEVERITY_EFFORT);
+        const {
+            assert!(security::HIGH_SEVERITY_EFFORT > security::MEDIUM_SEVERITY_EFFORT);
+            assert!(security::MEDIUM_SEVERITY_EFFORT > security::LOW_SEVERITY_EFFORT);
+        }
     }
 
     #[test]
     fn test_intent_mapping_constants() {
-        assert!(intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD > 0.0);
-        assert!(intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD <= 1.0);
-        assert!(
-            intent_mapping::DEFAULT_AUTO_VALIDATION_THRESHOLD
-                > intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD
-        );
-        assert!(
-            intent_mapping::DEFAULT_MAX_MAPPING_DISTANCE
-                > intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD
-        );
+        const {
+            assert!(intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD > 0.0);
+            assert!(intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD <= 1.0);
+            assert!(
+                intent_mapping::DEFAULT_AUTO_VALIDATION_THRESHOLD
+                    > intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD
+            );
+            assert!(
+                intent_mapping::DEFAULT_MAX_MAPPING_DISTANCE
+                    > intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD
+            );
+        }
 
         // Test validation weights sum to 1.0
         let total_weight = intent_mapping::VALIDATION_CONFIDENCE_WEIGHT
@@ -288,30 +298,40 @@ mod tests {
             + intent_mapping::VALIDATION_QUALITY_WEIGHT;
         assert!((total_weight - 1.0).abs() < 0.001);
 
-        // Test thresholds are in logical order
-        assert!(
-            intent_mapping::VALIDATION_VALID_THRESHOLD
-                > intent_mapping::VALIDATION_REVIEW_THRESHOLD
-        );
-        assert!(intent_mapping::COVERAGE_THRESHOLD > intent_mapping::QUALITY_COVERAGE_THRESHOLD);
+        const {
+            // Test thresholds are in logical order
+            assert!(
+                intent_mapping::VALIDATION_VALID_THRESHOLD
+                    > intent_mapping::VALIDATION_REVIEW_THRESHOLD
+            );
+            assert!(
+                intent_mapping::COVERAGE_THRESHOLD > intent_mapping::QUALITY_COVERAGE_THRESHOLD
+            );
+        }
 
         // Test default values are reasonable
         assert_eq!(intent_mapping::DEFAULT_COVERAGE, 0.0);
         assert_eq!(intent_mapping::DEFAULT_COMPLEXITY, 1.0);
-        assert!(intent_mapping::DEFAULT_MAINTAINABILITY > 0.0);
-        assert!(intent_mapping::DEFAULT_PERFORMANCE > 0.0);
-        assert!(intent_mapping::DEFAULT_SECURITY > 0.0);
+        const {
+            assert!(intent_mapping::DEFAULT_MAINTAINABILITY > 0.0);
+            assert!(intent_mapping::DEFAULT_PERFORMANCE > 0.0);
+            assert!(intent_mapping::DEFAULT_SECURITY > 0.0);
+        }
     }
 
     #[test]
     fn test_performance_constants() {
         assert_eq!(performance::MAX_PERFORMANCE_SCORE, 100);
-        assert!(performance::FUNCTION_LENGTH_HIGH_THRESHOLD > 0);
-        assert!(performance::LARGE_CODEBASE_THRESHOLD > 0);
-        assert!(performance::LINES_PER_COMPLEXITY_UNIT > 0.0);
+        const {
+            assert!(performance::FUNCTION_LENGTH_HIGH_THRESHOLD > 0);
+            assert!(performance::LARGE_CODEBASE_THRESHOLD > 0);
+            assert!(performance::LINES_PER_COMPLEXITY_UNIT > 0.0);
+        }
         assert_eq!(performance::BASE_PERFORMANCE_SCORE, 100.0);
-        assert!(performance::COMPLEXITY_CPU_MULTIPLIER > 0.0);
-        assert!(performance::COMPLEXITY_OVERALL_MULTIPLIER > 0.0);
+        const {
+            assert!(performance::COMPLEXITY_CPU_MULTIPLIER > 0.0);
+            assert!(performance::COMPLEXITY_OVERALL_MULTIPLIER > 0.0);
+        }
         assert_eq!(performance::MAX_CPU_IMPACT, 100.0);
         assert_eq!(performance::MAX_OVERALL_IMPACT, 100.0);
     }
@@ -325,7 +345,7 @@ mod tests {
 
     #[test]
     fn test_refactoring_constants() {
-        assert!(refactoring::LARGE_FILE_THRESHOLD > 0);
+        const { assert!(refactoring::LARGE_FILE_THRESHOLD > 0) };
         assert_eq!(refactoring::BASE_REFACTORING_SCORE, 100);
     }
 
@@ -334,7 +354,7 @@ mod tests {
         assert_eq!(file_processing::DEFAULT_MAX_FILE_SIZE, 1024 * 1024);
         assert_eq!(file_processing::MEGABYTE, 1024 * 1024);
         assert_eq!(file_processing::KILOBYTE, 1024);
-        assert!(file_processing::MEGABYTE > file_processing::KILOBYTE);
+        const { assert!(file_processing::MEGABYTE > file_processing::KILOBYTE) };
     }
 
     #[test]
@@ -343,7 +363,7 @@ mod tests {
         assert_eq!(scoring::MAX_SCORE, 100.0);
         assert_eq!(scoring::PERFECT_SCORE, 100.0);
         assert_eq!(scoring::PERCENTAGE_FACTOR, 100.0);
-        assert!(scoring::MAX_SCORE > scoring::MIN_SCORE);
+        const { assert!(scoring::MAX_SCORE > scoring::MIN_SCORE) };
     }
 
     #[test]
@@ -374,56 +394,62 @@ mod tests {
 
     #[test]
     fn test_constants_ranges() {
-        // Test that confidence thresholds are in valid range [0.0, 1.0]
-        assert!(security::DEFAULT_MIN_CONFIDENCE >= 0.0 && security::DEFAULT_MIN_CONFIDENCE <= 1.0);
-        assert!(
-            intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD >= 0.0
-                && intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD <= 1.0
-        );
-        assert!(
-            intent_mapping::DEFAULT_MAX_MAPPING_DISTANCE >= 0.0
-                && intent_mapping::DEFAULT_MAX_MAPPING_DISTANCE <= 1.0
-        );
-        assert!(
-            intent_mapping::DEFAULT_AUTO_VALIDATION_THRESHOLD >= 0.0
-                && intent_mapping::DEFAULT_AUTO_VALIDATION_THRESHOLD <= 1.0
-        );
+        const {
+            // Test that confidence thresholds are in valid range [0.0, 1.0]
+            assert!(
+                security::DEFAULT_MIN_CONFIDENCE >= 0.0 && security::DEFAULT_MIN_CONFIDENCE <= 1.0
+            );
+            assert!(
+                intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD >= 0.0
+                    && intent_mapping::DEFAULT_CONFIDENCE_THRESHOLD <= 1.0
+            );
+            assert!(
+                intent_mapping::DEFAULT_MAX_MAPPING_DISTANCE >= 0.0
+                    && intent_mapping::DEFAULT_MAX_MAPPING_DISTANCE <= 1.0
+            );
+            assert!(
+                intent_mapping::DEFAULT_AUTO_VALIDATION_THRESHOLD >= 0.0
+                    && intent_mapping::DEFAULT_AUTO_VALIDATION_THRESHOLD <= 1.0
+            );
 
-        // Test that validation weights are in valid range [0.0, 1.0]
-        assert!(
-            intent_mapping::VALIDATION_CONFIDENCE_WEIGHT >= 0.0
-                && intent_mapping::VALIDATION_CONFIDENCE_WEIGHT <= 1.0
-        );
-        assert!(
-            intent_mapping::VALIDATION_REQUIREMENT_WEIGHT >= 0.0
-                && intent_mapping::VALIDATION_REQUIREMENT_WEIGHT <= 1.0
-        );
-        assert!(
-            intent_mapping::VALIDATION_IMPLEMENTATION_WEIGHT >= 0.0
-                && intent_mapping::VALIDATION_IMPLEMENTATION_WEIGHT <= 1.0
-        );
-        assert!(
-            intent_mapping::VALIDATION_QUALITY_WEIGHT >= 0.0
-                && intent_mapping::VALIDATION_QUALITY_WEIGHT <= 1.0
-        );
+            // Test that validation weights are in valid range [0.0, 1.0]
+            assert!(
+                intent_mapping::VALIDATION_CONFIDENCE_WEIGHT >= 0.0
+                    && intent_mapping::VALIDATION_CONFIDENCE_WEIGHT <= 1.0
+            );
+            assert!(
+                intent_mapping::VALIDATION_REQUIREMENT_WEIGHT >= 0.0
+                    && intent_mapping::VALIDATION_REQUIREMENT_WEIGHT <= 1.0
+            );
+            assert!(
+                intent_mapping::VALIDATION_IMPLEMENTATION_WEIGHT >= 0.0
+                    && intent_mapping::VALIDATION_IMPLEMENTATION_WEIGHT <= 1.0
+            );
+            assert!(
+                intent_mapping::VALIDATION_QUALITY_WEIGHT >= 0.0
+                    && intent_mapping::VALIDATION_QUALITY_WEIGHT <= 1.0
+            );
 
-        // Test that pattern matching weights are reasonable
-        assert!(
-            intent_mapping::USER_STORY_API_WEIGHT >= 0.0
-                && intent_mapping::USER_STORY_API_WEIGHT <= 1.0
-        );
-        assert!(
-            intent_mapping::FUNCTIONAL_FUNCTION_WEIGHT >= 0.0
-                && intent_mapping::FUNCTIONAL_FUNCTION_WEIGHT <= 1.0
-        );
-        assert!(
-            intent_mapping::TECHNICAL_MODULE_WEIGHT >= 0.0
-                && intent_mapping::TECHNICAL_MODULE_WEIGHT <= 1.0
-        );
-        assert!(intent_mapping::SECURITY_WEIGHT >= 0.0 && intent_mapping::SECURITY_WEIGHT <= 1.0);
-        assert!(
-            intent_mapping::KEYWORD_SIMILARITY_WEIGHT >= 0.0
-                && intent_mapping::KEYWORD_SIMILARITY_WEIGHT <= 1.0
-        );
+            // Test that pattern matching weights are reasonable
+            assert!(
+                intent_mapping::USER_STORY_API_WEIGHT >= 0.0
+                    && intent_mapping::USER_STORY_API_WEIGHT <= 1.0
+            );
+            assert!(
+                intent_mapping::FUNCTIONAL_FUNCTION_WEIGHT >= 0.0
+                    && intent_mapping::FUNCTIONAL_FUNCTION_WEIGHT <= 1.0
+            );
+            assert!(
+                intent_mapping::TECHNICAL_MODULE_WEIGHT >= 0.0
+                    && intent_mapping::TECHNICAL_MODULE_WEIGHT <= 1.0
+            );
+            assert!(
+                intent_mapping::SECURITY_WEIGHT >= 0.0 && intent_mapping::SECURITY_WEIGHT <= 1.0
+            );
+            assert!(
+                intent_mapping::KEYWORD_SIMILARITY_WEIGHT >= 0.0
+                    && intent_mapping::KEYWORD_SIMILARITY_WEIGHT <= 1.0
+            );
+        }
     }
 }

--- a/crates/rts-core/src/languages/c.rs
+++ b/crates/rts-core/src/languages/c.rs
@@ -247,21 +247,12 @@ impl CSyntax {
                     return Some(param_name.to_string());
                 }
             }
-            // Look for identifier in pointer_declarator
-            else if child.kind() == "pointer_declarator" {
-                for pointer_child in child.children() {
-                    if pointer_child.kind() == "identifier" {
-                        if let Ok(param_name) = pointer_child.text() {
-                            return Some(param_name.to_string());
-                        }
-                    }
-                }
-            }
-            // Look for identifier in array_declarator
-            else if child.kind() == "array_declarator" {
-                for array_child in child.children() {
-                    if array_child.kind() == "identifier" {
-                        if let Ok(param_name) = array_child.text() {
+            // Look for identifier nested in a pointer_declarator or
+            // array_declarator (both wrap the identifier the same way).
+            else if child.kind() == "pointer_declarator" || child.kind() == "array_declarator" {
+                for nested_child in child.children() {
+                    if nested_child.kind() == "identifier" {
+                        if let Ok(param_name) = nested_child.text() {
                             return Some(param_name.to_string());
                         }
                     }

--- a/crates/rts-core/src/languages/python.rs
+++ b/crates/rts-core/src/languages/python.rs
@@ -8,6 +8,10 @@ use crate::query::Query;
 use crate::tree::{Node, SyntaxTree};
 use tree_sitter::Point;
 
+/// One type-hinted function discovered by [`PythonSyntax::find_typed_functions`]:
+/// `(name, parameter_types, return_type, start_point, end_point)`.
+type TypedFunction = (String, Vec<String>, Option<String>, Point, Point);
+
 /// Python-specific syntax utilities
 pub struct PythonSyntax;
 
@@ -155,11 +159,10 @@ impl PythonSyntax {
 
         if let Some(superclasses_node) = node.child_by_field_name("superclasses") {
             for child in superclasses_node.children() {
-                if child.kind() == "identifier" {
-                    if let Ok(base) = child.text() {
-                        bases.push(base.to_string());
-                    }
-                } else if child.kind() == "attribute" {
+                // A base class is either a bare name (`identifier`) or a
+                // dotted path (`attribute`, e.g. `abc.ABC`); both are recorded
+                // verbatim from their source text.
+                if child.kind() == "identifier" || child.kind() == "attribute" {
                     if let Ok(base) = child.text() {
                         bases.push(base.to_string());
                     }
@@ -845,16 +848,7 @@ impl PythonSyntax {
     }
 
     /// Find functions with comprehensive type hints
-    pub fn find_typed_functions(
-        tree: &SyntaxTree,
-        source: &str,
-    ) -> Vec<(
-        String,
-        Vec<String>,
-        Option<String>,
-        tree_sitter::Point,
-        tree_sitter::Point,
-    )> {
+    pub fn find_typed_functions(tree: &SyntaxTree, source: &str) -> Vec<TypedFunction> {
         let mut typed_functions = Vec::new();
         let function_nodes = tree.find_nodes_by_kind("function_definition");
 

--- a/crates/rts-core/src/languages/rust.rs
+++ b/crates/rts-core/src/languages/rust.rs
@@ -5,6 +5,16 @@ use crate::query::Query;
 use crate::tree::SyntaxTree;
 use tree_sitter::Node;
 
+/// One impl block discovered by [`RustSyntax::find_impl_blocks`]:
+/// `(type_name, trait_name, method_names, start_point, end_point)`.
+type ImplBlock = (
+    String,
+    Option<String>,
+    Vec<String>,
+    tree_sitter::Point,
+    tree_sitter::Point,
+);
+
 /// Rust-specific syntax tree utilities
 pub struct RustSyntax;
 
@@ -280,16 +290,7 @@ impl RustSyntax {
     }
 
     /// Find impl blocks in a syntax tree
-    pub fn find_impl_blocks(
-        tree: &SyntaxTree,
-        source: &str,
-    ) -> Vec<(
-        String,
-        Option<String>,
-        Vec<String>,
-        tree_sitter::Point,
-        tree_sitter::Point,
-    )> {
+    pub fn find_impl_blocks(tree: &SyntaxTree, source: &str) -> Vec<ImplBlock> {
         let mut impl_blocks = Vec::new();
         let impl_nodes = tree.find_nodes_by_kind("impl_item");
 

--- a/crates/rts-core/src/parser.rs
+++ b/crates/rts-core/src/parser.rs
@@ -274,6 +274,10 @@ impl Clone for Parser {
 }
 
 /// Helper function to create an InputEdit from simple parameters
+// The 9 parameters mirror `tree_sitter::InputEdit`'s three `Point` fields
+// flattened to scalars; collapsing them would change this public constructor's
+// signature, so the arg count is intrinsic rather than a code smell.
+#[allow(clippy::too_many_arguments)]
 pub fn create_edit(
     start_byte: usize,
     old_end_byte: usize,

--- a/crates/rts-core/src/signature.rs
+++ b/crates/rts-core/src/signature.rs
@@ -19,8 +19,6 @@
 //! `0.2.0-alpha.17`. Callers fall through to body returns when this
 //! module returns `None`.
 
-use streaming_iterator::StreamingIterator as _;
-
 /// Render the signature of a Rust top-level item. Returns `None` when the
 /// input doesn't parse as a single top-level item or the item kind has no
 /// meaningful signature distinction (the caller should fall back to the
@@ -33,8 +31,6 @@ use streaming_iterator::StreamingIterator as _;
 /// whitespace is trimmed; doc comments at the front of the item are
 /// retained (they're useful to the agent and cheap to carry).
 pub fn render_rust(bytes: &[u8]) -> Option<String> {
-    let _ = streaming_iterator_present_check();
-
     let mut parser = tree_sitter::Parser::new();
     let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
     parser.set_language(&language).ok()?;
@@ -169,14 +165,6 @@ fn body_start(item: &tree_sitter::Node<'_>, _bytes: &[u8]) -> Option<usize> {
     }
     None
 }
-
-/// Tiny no-op that pulls `streaming_iterator::StreamingIterator` into scope
-/// so the import is preserved even though this file doesn't iterate
-/// `QueryMatches` directly. Keeps the `use streaming_iterator` line
-/// visible at the top so future query-based renderers don't have to
-/// rediscover that rts-core uses it.
-#[inline]
-fn streaming_iterator_present_check() {}
 
 /// Render the signature of a Python top-level item.
 ///
@@ -520,23 +508,6 @@ fn render_strip_body_with_recursive_body(
         return None;
     }
     Some(signature)
-}
-
-fn descend_for_body(node: &tree_sitter::Node<'_>, kinds: &[&str], out: &mut Option<usize>) {
-    if out.is_some() {
-        return;
-    }
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if kinds.contains(&child.kind()) {
-            *out = Some(child.start_byte());
-            return;
-        }
-        descend_for_body(&child, kinds, out);
-        if out.is_some() {
-            return;
-        }
-    }
 }
 
 fn trim_trailing_open_brace(s: &str) -> String {

--- a/crates/rts-core/src/tree.rs
+++ b/crates/rts-core/src/tree.rs
@@ -57,35 +57,35 @@ impl SyntaxTree {
     /// Get all nodes with errors
     pub fn error_nodes(&self) -> Vec<Node<'_>> {
         let mut errors = Vec::new();
-        self.collect_error_nodes(self.root_node(), &mut errors);
+        Self::collect_error_nodes(self.root_node(), &mut errors);
         errors
     }
 
-    fn collect_error_nodes<'a>(&self, node: Node<'a>, errors: &mut Vec<Node<'a>>) {
+    fn collect_error_nodes<'a>(node: Node<'a>, errors: &mut Vec<Node<'a>>) {
         if node.is_error() || node.is_missing() {
             errors.push(node);
         }
 
         for child in node.children() {
-            self.collect_error_nodes(child, errors);
+            Self::collect_error_nodes(child, errors);
         }
     }
 
     /// Find all nodes of a specific kind (optimized with pre-allocation)
     pub fn find_nodes_by_kind(&self, kind: &str) -> Vec<Node<'_>> {
         let mut nodes = Vec::with_capacity(32); // Pre-allocate for common case
-        self.collect_nodes_by_kind(self.root_node(), kind, &mut nodes);
+        Self::collect_nodes_by_kind(self.root_node(), kind, &mut nodes);
         nodes.shrink_to_fit(); // Reclaim unused memory
         nodes
     }
 
-    fn collect_nodes_by_kind<'a>(&self, node: Node<'a>, kind: &str, nodes: &mut Vec<Node<'a>>) {
+    fn collect_nodes_by_kind<'a>(node: Node<'a>, kind: &str, nodes: &mut Vec<Node<'a>>) {
         if node.kind() == kind {
             nodes.push(node);
         }
 
         for child in node.children() {
-            self.collect_nodes_by_kind(child, kind, nodes);
+            Self::collect_nodes_by_kind(child, kind, nodes);
         }
     }
 


### PR DESCRIPTION
## Summary

Makes `cargo clippy -p rust_tree_sitter --all-targets` **warning-free**. The rts-core crate (`rust_tree_sitter`) carried ~88 advisory clippy warnings — CI clippy runs in advisory mode (no `-D warnings`) for rts-core, so these never failed a build. The CI workflow comment notes `-D warnings` will be reintroduced "once the pre-pivot `rts-core` legacy lints are cleaned up incrementally per crate"; this PR is that cleanup for rts-core.

All fixes are style/correctness lints with **no runtime behavior change**.

## What changed

| Lint | Count | Fix |
|------|-------|-----|
| `assertions_on_constants` | 35 | Compile-time invariant `assert!`s in `constants.rs` tests moved into `const { … }` blocks — now fail the build (not just the test) if a constant drifts out of range. |
| `type_complexity` | 2 | Tuple returns of `RustSyntax::find_impl_blocks` / `PythonSyntax::find_typed_functions` named via **private transparent type aliases**. Public API surface unchanged (the snapshot resolves aliases). |
| `only_used_in_recursion` | 2 | `SyntaxTree`'s private `collect_error_nodes` / `collect_nodes_by_kind` helpers drop their unused `&self` (now `Self::`-called). |
| `if_same_then_else` | 2 | Merged identical C (`pointer_declarator`/`array_declarator`) and Python (`identifier`/`attribute`) declarator branches with `||`. |
| `let_unit_value` + `unused_imports` + `dead_code` | 3 | Removed the no-op `streaming_iterator_present_check` shim, its dead `use … as _` import, and the dead `descend_for_body` fn in `signature.rs`. The `streaming-iterator` dep stays live via `query.rs`. |
| `too_many_arguments` | 1 | Site-specific `#[allow]` with a justifying comment on the public `create_edit` constructor: its 9 args mirror `tree_sitter::InputEdit`'s three flattened `Point` fields; collapsing them would change a public signature. (Genuine "constructor mirroring struct fields" case, per the no-blanket-allow exception.) |

`#![forbid(unsafe_code)]` / workspace `unsafe_code = "deny"` is untouched. No public signatures changed — the `public_api` snapshot gate passes **without regen**.

## Verification

- `cargo clippy -p rust_tree_sitter --all-targets` → **0 warnings** (verified on a clean `cargo clean -p` build).
- `cargo test -p rust_tree_sitter` → **green** (266 passed, 0 failed, incl. the `public_api` snapshot test — unchanged).
- `cargo build --workspace` → **green** (no downstream break in rts-daemon/rts-mcp/rts-bench).
- `cargo fmt --all --check` → clean.

## Post-Deploy Monitoring & Validation

**No runtime behavior change.** This PR only adjusts source style/structure (test-time `const` asserts, transparent type aliases, removed dead code, branch merges, one justified `#[allow]`) — no logic, no public API, no on-disk or wire format changes. There is nothing to monitor at runtime.

The validation gate is CI itself:
- CI's advisory `cargo clippy --workspace --all-targets` step will now emit zero warnings for rts-core (previously ~88).
- CI's `cargo test --workspace` exercises the rts-core suite + the `public_api` drift gate; both stay green.
- This unblocks a future flip of rts-core clippy from advisory to `-D warnings` (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)