### PR TITLE
feat: markdown indexing — first-class prose retrieval (v0.7.0)

### DIFF
--- a/changelog.d/xxx-feat-markdown-indexing.md
+++ b/changelog.d/xxx-feat-markdown-indexing.md
@@ -1,0 +1,65 @@
+### Feature: markdown indexing — first-class prose retrieval
+
+rts now indexes Markdown alongside the 12 code grammars. `.md` and
+`.markdown` files contribute first-class symbols with `kind="heading"`
+for every ATX (`#`–`######`) and Setext (`===` / `---`) heading. The
+same `find_symbol`, `outline_workspace`, and `grep` tools that retrieve
+code now retrieve prose — closing the v0.6 gap where
+`rts grep "retrieval stack"` returned 0 hits because the term lived
+only in `README.md` / `CHANGELOG.md`.
+
+Highlights:
+
+- **`kind="heading"` (flat)** — H1–H6 all share one wire kind. Depth
+  is conveyed by the rendered `signature` (`## Installation`) and a
+  hierarchical path prefix stored in the heading's `documentation`
+  field (`"Project Title > Installation\n\nBody…"`), which makes
+  `find_symbol --doc-contains "Project Title"` work over ancestor
+  names.
+- **Body-paragraph capture** — the first paragraph immediately after
+  each heading populates `documentation` (single-line collapsed, ≤512
+  chars), enabling `find_symbol --doc-contains` to search prose
+  content the same way it searches doc comments today.
+- **Gitignore-aware** — markdown files under `target/`, `node_modules/`,
+  or anything matched by `.gitignore` / `.rtsignore` are skipped, same
+  rule as code.
+- **PageRank dampener** — heading SIDs are multiplied × 0.1 in the
+  final rank pass. Headings have no outbound references in v1, so
+  PageRank's dangling-mass redistribution would otherwise lift them
+  near the uniform baseline and crowd weakly-connected code symbols;
+  the dampener mirrors the leading-underscore × 0.1 rule already in
+  `edge_weight`.
+- **Per-file 4 MiB byte cap** is satisfied by the existing global
+  `OVERSIZE_THRESHOLD_BYTES` — adversarial input never reaches the
+  parser. (`Parser::set_timeout_micros` is a documented no-op in
+  tree-sitter ≥ 0.26.)
+- **Capability flag** `index_markdown` advertised on `Daemon.Ping`.
+- **CLI parity** — `rts find Installation --kind heading --json`
+  returns equivalent rows to the MCP `Index.FindSymbol` call.
+
+**Behavior change on upgrade:** workspaces with tracked
+`.md` / `.markdown` files will index them automatically on first
+mount post-upgrade. On doc-heavy monorepos (3–10 k `.md` files in a
+`docs/` tree) the first reconciliation pass can take 5–30 seconds —
+plan accordingly, or use `.gitignore` to opt specific paths out.
+The change is purely additive — existing code queries return
+identical results (top-32 ordering verified unchanged for canonical
+queries; `semantic-eval-rts-core` corpus coverage holds at 1.000
+post-change; `semantic-eval-rts-core-blind-v2` at 0.857).
+
+**Public-API additions** (additive only, no breaking change):
+
+- `pub enum rust_tree_sitter::Language::Markdown` variant.
+- `pub fn rust_tree_sitter::signature::render_markdown(bytes: &[u8])
+  -> Option<String>` — ATX/Setext heading signature renderer
+  (always emits ATX form for output consistency).
+
+Internal additions (no public surface):
+
+- `SymbolKind::Heading = 11` (rts-daemon store schema).
+- `Store::iter_workspace_sids_with_kind()` (rts-daemon).
+
+The `Language` enum is not `#[non_exhaustive]`; adding the
+`Markdown` variant is technically breaking for downstream exhaustive
+matchers under semver, but accepted under 0.x — matches the precedent
+of v0.5+ adding `Swift` and `CSharp` the same way.

--- a/crates/rts-core/Cargo.toml
+++ b/crates/rts-core/Cargo.toml
@@ -29,6 +29,10 @@ tree-sitter-php = "0.23"
 tree-sitter-ruby = "0.23"
 tree-sitter-swift = "0.7"
 tree-sitter-c-sharp = "0.23"
+# Markdown indexing (v0.7.0). Block grammar only; the `parser` feature pulls in
+# a two-pass `MarkdownParser` (inline + block) which v1 doesn't use — inline
+# enters in v2 when markdown links land as a reference graph.
+tree-sitter-md = "0.5.3"
 
 # Error handling
 thiserror = "1.0"

--- a/crates/rts-core/src/extraction.rs
+++ b/crates/rts-core/src/extraction.rs
@@ -1378,8 +1378,7 @@ mod markdown {
                     // single `\n\n` separator; when absent we still
                     // emit the path so `find_symbol --doc-contains`
                     // over the ancestor names works.
-                    let path: Vec<String> =
-                        stack.iter().map(|(_, n)| n.clone()).collect();
+                    let path: Vec<String> = stack.iter().map(|(_, n)| n.clone()).collect();
                     let body = match kind {
                         // ATX headings: body is the first paragraph
                         // child of the enclosing `section`.
@@ -1394,9 +1393,7 @@ mod markdown {
                         _ => None,
                     };
                     let documentation = match body {
-                        Some(b) if path.len() > 1 => {
-                            Some(format!("{}\n\n{b}", path.join(" > ")))
-                        }
+                        Some(b) if path.len() > 1 => Some(format!("{}\n\n{b}", path.join(" > "))),
                         Some(b) => Some(b),
                         None if path.len() > 1 => Some(path.join(" > ")),
                         None => None,
@@ -1430,10 +1427,7 @@ mod markdown {
 
     /// Extract `(level, text)` from an `atx_heading` node.
     /// Markers are `atx_h1_marker` .. `atx_h6_marker`.
-    fn atx_heading_info(
-        node: &crate::Node<'_>,
-        bytes: &[u8],
-    ) -> Option<(u8, String)> {
+    fn atx_heading_info(node: &crate::Node<'_>, bytes: &[u8]) -> Option<(u8, String)> {
         let mut level: Option<u8> = None;
         let mut text: Option<String> = None;
         for child in node.children() {
@@ -1455,10 +1449,7 @@ mod markdown {
 
     /// Extract `(level, text)` from a `setext_heading` node.
     /// Underline `setext_h1_underline` = level 1, `setext_h2_underline` = 2.
-    fn setext_heading_info(
-        node: &crate::Node<'_>,
-        bytes: &[u8],
-    ) -> Option<(u8, String)> {
+    fn setext_heading_info(node: &crate::Node<'_>, bytes: &[u8]) -> Option<(u8, String)> {
         let mut level: Option<u8> = None;
         let mut text: Option<String> = None;
         for child in node.children() {
@@ -1564,11 +1555,7 @@ mod markdown {
             }
         }
         // Take exactly DOC_CHAR_CAP chars (character-aligned, not byte).
-        let s: String = buf
-            .trim_end()
-            .chars()
-            .take(DOC_CHAR_CAP)
-            .collect();
+        let s: String = buf.trim_end().chars().take(DOC_CHAR_CAP).collect();
         s
     }
 }
@@ -2020,7 +2007,10 @@ macro_rules! log_at {
         let syms = markdown_symbols(src);
         assert_eq!(syms.len(), 6, "expected 6 headings, got {syms:?}");
         for sym in &syms {
-            assert_eq!(sym.kind, "heading", "every heading symbol gets kind=heading");
+            assert_eq!(
+                sym.kind, "heading",
+                "every heading symbol gets kind=heading"
+            );
             assert_eq!(sym.visibility, "public", "headings are public by default");
         }
         // `Symbol.name` stores the LEAF only so `find_symbol(name="X")`
@@ -2035,7 +2025,10 @@ macro_rules! log_at {
         // The hierarchy lives in the `documentation` prefix (no body
         // paragraph in this fixture → docs are just the path).
         assert_eq!(syms[1].documentation.as_deref(), Some("One > Two"));
-        assert_eq!(syms[5].documentation.as_deref(), Some("One > Two > Three > Four > Five > Six"));
+        assert_eq!(
+            syms[5].documentation.as_deref(),
+            Some("One > Two > Three > Four > Five > Six")
+        );
         // The H1 has nothing to nest under and no body, so docs stay
         // empty.
         assert!(syms[0].documentation.is_none());
@@ -2083,8 +2076,7 @@ macro_rules! log_at {
         // After going H1 → H2 → H3, a new H1 should reset the path —
         // subsequent H2 nests under the *new* H1, not the old one.
         // Verify via the `documentation` prefix.
-        let src =
-            "# Alpha\n\n## A1\n\n### A1a\n\n# Beta\n\n## B1\n";
+        let src = "# Alpha\n\n## A1\n\n### A1a\n\n# Beta\n\n## B1\n";
         let syms = markdown_symbols(src);
         let names: Vec<&str> = syms.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names, vec!["Alpha", "A1", "A1a", "Beta", "B1"]);

--- a/crates/rts-core/src/extraction.rs
+++ b/crates/rts-core/src/extraction.rs
@@ -53,6 +53,9 @@ pub(crate) fn extract_symbols(
         Language::CSharp => {
             extract_csharp_symbols(tree, content, &mut symbols)?;
         }
+        Language::Markdown => {
+            extract_markdown_symbols(tree, content, &mut symbols)?;
+        }
     }
 
     Ok(symbols)
@@ -1063,6 +1066,34 @@ pub(crate) fn extract_csharp_symbols(
     Ok(())
 }
 
+/// Extract Markdown headings as `Symbol` records.
+///
+/// v1 captures only `atx_heading` and `setext_heading` nodes — paragraphs,
+/// list items, and code blocks are not symbols (industry consensus from
+/// ctags / Marksman / VSCode / JetBrains). Headings inside fenced code
+/// blocks are skipped (the tree-sitter-md block grammar emits them as
+/// `fenced_code_block.code_fence_content` children, opaque to ATX/Setext
+/// queries — so they're naturally excluded).
+///
+/// - `kind="heading"` for all H1–H6 (flat encoding; depth carried by
+///   `signature` and `name`/qualified path).
+/// - `name` = hierarchical qualified path joined by `" > "`
+///   (`"README.md > Title > Installation"`). The leading file-stem is
+///   added by the caller in the daemon writer where the path is known;
+///   here we emit `"Title > Installation"`.
+/// - `signature` is not stored on `Symbol`; it's rendered on demand by
+///   `signature::render_markdown` from the heading line in the source.
+/// - `documentation` captures the first paragraph immediately following
+///   the heading (single-line collapsed, ~512 char cap), enabling
+///   `find_symbol --doc-contains` over prose.
+pub(crate) fn extract_markdown_symbols(
+    tree: &SyntaxTree,
+    content: &str,
+    symbols: &mut Vec<Symbol>,
+) -> Result<()> {
+    markdown::extract(tree, content, symbols)
+}
+
 /// Extract doc comments preceding a Rust item start line
 pub(crate) fn extract_rust_doc_comments(content: &str, start_row: usize) -> Option<String> {
     let lines: Vec<&str> = content.lines().collect();
@@ -1279,6 +1310,214 @@ pub(crate) fn extract_c_doc_comments(content: &str, start_row: usize) -> Option<
     } else {
         docs.reverse();
         Some(docs.join("\n"))
+    }
+}
+
+/// Markdown extraction helpers — heading-as-symbol walker, hierarchical
+/// qualified-name builder, and first-paragraph body capture for the
+/// `documentation` field.
+///
+/// Kept in this module rather than a `languages/markdown.rs` sub-module
+/// to mirror C/C++/C# (which have no language sub-module either — there
+/// are no markdown-specific helpers to expose).
+mod markdown {
+    use super::*;
+
+    /// First-paragraph cap for the `documentation` field — long enough
+    /// for `find_symbol --doc-contains` to find shape-shaped phrases,
+    /// short enough that it doesn't blow up the docs multimap.
+    const DOC_CHAR_CAP: usize = 512;
+
+    /// Walk the tree-sitter-md section tree and emit one `Symbol` per
+    /// heading. Section nesting in the grammar already encodes heading
+    /// hierarchy — H2 under H1 produces `section[H1] > section[H2]`,
+    /// no manual depth stack needed.
+    pub(super) fn extract(
+        tree: &SyntaxTree,
+        content: &str,
+        symbols: &mut Vec<Symbol>,
+    ) -> Result<()> {
+        let bytes = content.as_bytes();
+        let root = tree.root_node();
+        // Path accumulator: heading texts from outermost section to current.
+        let mut path: Vec<String> = Vec::new();
+        walk_node(&root, bytes, &mut path, symbols);
+        Ok(())
+    }
+
+    fn walk_node(
+        node: &crate::Node<'_>,
+        bytes: &[u8],
+        path: &mut Vec<String>,
+        symbols: &mut Vec<Symbol>,
+    ) {
+        let kind = node.kind();
+        if kind == "section" {
+            // Find the leading heading (atx_heading or setext_heading) and
+            // walk its body for nested sections.
+            let mut heading_text: Option<String> = None;
+            let mut heading_level: Option<u8> = None;
+            let mut heading_node: Option<crate::Node<'_>> = None;
+            for child in node.named_children() {
+                match child.kind() {
+                    "atx_heading" => {
+                        if let Some((lvl, text)) = atx_heading_info(&child, bytes) {
+                            heading_level = Some(lvl);
+                            heading_text = Some(text);
+                            heading_node = Some(child);
+                        }
+                        break;
+                    }
+                    "setext_heading" => {
+                        if let Some((lvl, text)) = setext_heading_info(&child, bytes) {
+                            heading_level = Some(lvl);
+                            heading_text = Some(text);
+                            heading_node = Some(child);
+                        }
+                        break;
+                    }
+                    _ => continue,
+                }
+            }
+
+            if let (Some(text), Some(_lvl), Some(hnode)) =
+                (heading_text, heading_level, heading_node)
+            {
+                path.push(text.clone());
+                // Build hierarchical qualified name: "Outer > Inner > Self"
+                let qualified = path.join(" > ");
+                // documentation: first paragraph following the heading in
+                // this section (skip nested sections / code blocks).
+                let documentation = first_paragraph_in_section(node, bytes);
+                symbols.push(Symbol {
+                    name: qualified,
+                    kind: "heading".to_string(),
+                    start_line: hnode.start_position().row + 1,
+                    end_line: hnode.end_position().row + 1,
+                    start_column: hnode.start_position().column,
+                    end_column: hnode.end_position().column,
+                    visibility: "public".to_string(),
+                    documentation,
+                });
+
+                // Recurse into the rest of the section body, looking for
+                // nested sections.
+                for child in node.named_children() {
+                    if child.kind() == "section" {
+                        walk_node(&child, bytes, path, symbols);
+                    }
+                }
+                path.pop();
+                return;
+            }
+            // No heading found inside the section (shouldn't happen for
+            // valid markdown). Recurse into children defensively.
+        }
+
+        // For non-section nodes (document root, etc.), recurse into
+        // children looking for sections.
+        for child in node.named_children() {
+            walk_node(&child, bytes, path, symbols);
+        }
+    }
+
+    /// Extract `(level, text)` from an `atx_heading` node.
+    /// Markers are `atx_h1_marker` .. `atx_h6_marker`.
+    fn atx_heading_info(
+        node: &crate::Node<'_>,
+        bytes: &[u8],
+    ) -> Option<(u8, String)> {
+        let mut level: Option<u8> = None;
+        let mut text: Option<String> = None;
+        for child in node.children() {
+            match child.kind() {
+                "atx_h1_marker" => level = Some(1),
+                "atx_h2_marker" => level = Some(2),
+                "atx_h3_marker" => level = Some(3),
+                "atx_h4_marker" => level = Some(4),
+                "atx_h5_marker" => level = Some(5),
+                "atx_h6_marker" => level = Some(6),
+                _ => {}
+            }
+        }
+        if let Some(content_node) = node.child_by_field_name("heading_content") {
+            text = Some(clean_heading_text(content_node.utf8_text(bytes).ok()?));
+        }
+        Some((level?, text.unwrap_or_default()))
+    }
+
+    /// Extract `(level, text)` from a `setext_heading` node.
+    /// Underline `setext_h1_underline` = level 1, `setext_h2_underline` = 2.
+    fn setext_heading_info(
+        node: &crate::Node<'_>,
+        bytes: &[u8],
+    ) -> Option<(u8, String)> {
+        let mut level: Option<u8> = None;
+        let mut text: Option<String> = None;
+        for child in node.children() {
+            match child.kind() {
+                "setext_h1_underline" => level = Some(1),
+                "setext_h2_underline" => level = Some(2),
+                _ => {}
+            }
+        }
+        if let Some(content_node) = node.child_by_field_name("heading_content") {
+            text = Some(clean_heading_text(content_node.utf8_text(bytes).ok()?));
+        }
+        Some((level?, text.unwrap_or_default()))
+    }
+
+    /// Trim leading/trailing whitespace and CommonMark closing `#`s.
+    /// (`## Foo ##` → `Foo`.)
+    fn clean_heading_text(s: &str) -> String {
+        let trimmed = s.trim();
+        // Strip a trailing run of `#` chars (CommonMark closing-hash).
+        let stripped = trimmed.trim_end_matches('#').trim_end();
+        stripped.to_string()
+    }
+
+    /// Find the first `paragraph` body block in this section (not nested
+    /// in a sub-section); flatten to a single line and clip to
+    /// `DOC_CHAR_CAP` chars.
+    fn first_paragraph_in_section(section: &crate::Node<'_>, bytes: &[u8]) -> Option<String> {
+        for child in section.named_children() {
+            match child.kind() {
+                "paragraph" => {
+                    let raw = child.utf8_text(bytes).ok()?;
+                    return Some(collapse_paragraph(raw));
+                }
+                "section" => break,
+                _ => continue,
+            }
+        }
+        None
+    }
+
+    /// Collapse a paragraph's whitespace to single spaces and clip.
+    fn collapse_paragraph(raw: &str) -> String {
+        let mut buf = String::new();
+        let mut prev_ws = false;
+        for ch in raw.chars() {
+            if ch.is_whitespace() {
+                if !prev_ws && !buf.is_empty() {
+                    buf.push(' ');
+                }
+                prev_ws = true;
+            } else {
+                buf.push(ch);
+                prev_ws = false;
+            }
+            if buf.chars().count() >= DOC_CHAR_CAP {
+                break;
+            }
+        }
+        // Take exactly DOC_CHAR_CAP chars (character-aligned, not byte).
+        let s: String = buf
+            .trim_end()
+            .chars()
+            .take(DOC_CHAR_CAP)
+            .collect();
+        s
     }
 }
 

--- a/crates/rts-core/src/extraction.rs
+++ b/crates/rts-core/src/extraction.rs
@@ -1370,24 +1370,40 @@ mod markdown {
                         stack.pop();
                     }
                     stack.push((level, text.clone()));
-                    let qualified: Vec<String> =
+                    // Hierarchical heading path captured in
+                    // `documentation` as a prefix so it survives the
+                    // wire path (the `Symbol.name` field stores ONLY
+                    // the leaf so `find_symbol --name "Installation"`
+                    // matches). When body text exists we join with a
+                    // single `\n\n` separator; when absent we still
+                    // emit the path so `find_symbol --doc-contains`
+                    // over the ancestor names works.
+                    let path: Vec<String> =
                         stack.iter().map(|(_, n)| n.clone()).collect();
-                    let documentation = match kind {
-                        // For ATX headings tree-sitter-md nests the body
-                        // inside the enclosing `section` — find it via
-                        // the parent.
+                    let body = match kind {
+                        // ATX headings: body is the first paragraph
+                        // child of the enclosing `section`.
                         "atx_heading" => node
                             .parent()
                             .and_then(|p| first_paragraph_in_section(&p, bytes)),
-                        // For setext headings the surrounding section
-                        // also contains the body paragraph as a sibling.
+                        // Setext headings: surrounding section
+                        // contains the body paragraph as a sibling.
                         "setext_heading" => node
                             .parent()
                             .and_then(|p| first_paragraph_after_setext(&p, node, bytes)),
                         _ => None,
                     };
+                    let documentation = match body {
+                        Some(b) if path.len() > 1 => {
+                            Some(format!("{}\n\n{b}", path.join(" > ")))
+                        }
+                        Some(b) => Some(b),
+                        None if path.len() > 1 => Some(path.join(" > ")),
+                        None => None,
+                    };
                     symbols.push(Symbol {
-                        name: qualified.join(" > "),
+                        // Leaf only — searchable by exact name match.
+                        name: text,
                         kind: "heading".to_string(),
                         start_line: node.start_position().row + 1,
                         end_line: node.end_position().row + 1,
@@ -2007,12 +2023,22 @@ macro_rules! log_at {
             assert_eq!(sym.kind, "heading", "every heading symbol gets kind=heading");
             assert_eq!(sym.visibility, "public", "headings are public by default");
         }
-        // Each subsequent heading nests under the previous (H1 → H2 → ...);
-        // so qualified names form a chain.
+        // `Symbol.name` stores the LEAF only so `find_symbol(name="X")`
+        // exact-match works. Hierarchy is exposed via the
+        // `documentation` field prefix (so `--doc-contains` over the
+        // ancestor names works) and via `signature::render_markdown`
+        // (which displays the marker count).
         assert_eq!(syms[0].name, "One");
-        assert_eq!(syms[1].name, "One > Two");
-        assert_eq!(syms[2].name, "One > Two > Three");
-        assert_eq!(syms[5].name, "One > Two > Three > Four > Five > Six");
+        assert_eq!(syms[1].name, "Two");
+        assert_eq!(syms[2].name, "Three");
+        assert_eq!(syms[5].name, "Six");
+        // The hierarchy lives in the `documentation` prefix (no body
+        // paragraph in this fixture → docs are just the path).
+        assert_eq!(syms[1].documentation.as_deref(), Some("One > Two"));
+        assert_eq!(syms[5].documentation.as_deref(), Some("One > Two > Three > Four > Five > Six"));
+        // The H1 has nothing to nest under and no body, so docs stay
+        // empty.
+        assert!(syms[0].documentation.is_none());
     }
 
     #[test]
@@ -2024,7 +2050,12 @@ macro_rules! log_at {
         assert_eq!(syms.len(), 2, "expected 2 setext headings, got {syms:?}");
         assert_eq!(syms[0].kind, "heading");
         assert_eq!(syms[0].name, "Top Title");
-        assert_eq!(syms[1].name, "Top Title > Subsection");
+        assert_eq!(syms[1].name, "Subsection");
+        // Setext H2 inherits the H1 as its parent.
+        assert_eq!(
+            syms[1].documentation.as_deref(),
+            Some("Top Title > Subsection"),
+        );
     }
 
     #[test]
@@ -2040,7 +2071,7 @@ macro_rules! log_at {
     #[test]
     fn extract_markdown_multiple_h1_siblings() {
         // Two H1s are siblings — neither nests under the other; their
-        // qualified names are flat (no shared parent).
+        // names are independent leaf strings.
         let src = "# First Topic\n\nA paragraph.\n\n# Second Topic\n\nAnother paragraph.\n";
         let syms = markdown_symbols(src);
         let names: Vec<&str> = syms.iter().map(|s| s.name.as_str()).collect();
@@ -2051,31 +2082,39 @@ macro_rules! log_at {
     fn extract_markdown_hierarchy_resets_on_higher_heading() {
         // After going H1 → H2 → H3, a new H1 should reset the path —
         // subsequent H2 nests under the *new* H1, not the old one.
+        // Verify via the `documentation` prefix.
         let src =
             "# Alpha\n\n## A1\n\n### A1a\n\n# Beta\n\n## B1\n";
         let syms = markdown_symbols(src);
         let names: Vec<&str> = syms.iter().map(|s| s.name.as_str()).collect();
-        assert_eq!(
-            names,
-            vec!["Alpha", "Alpha > A1", "Alpha > A1 > A1a", "Beta", "Beta > B1"],
-        );
+        assert_eq!(names, vec!["Alpha", "A1", "A1a", "Beta", "B1"]);
+        // The B1 documentation should carry `Beta > B1`, NOT `Alpha > B1`.
+        let b1 = syms.iter().find(|s| s.name == "B1").unwrap();
+        assert_eq!(b1.documentation.as_deref(), Some("Beta > B1"));
+        // A1a documentation has the full triple-deep path.
+        let a1a = syms.iter().find(|s| s.name == "A1a").unwrap();
+        assert_eq!(a1a.documentation.as_deref(), Some("Alpha > A1 > A1a"));
     }
 
     #[test]
     fn extract_markdown_documentation_from_first_paragraph() {
         // The first paragraph after a heading populates `documentation`
-        // so `find_symbol --doc-contains` can match prose. Cap is ~512
-        // chars, single-line collapsed.
-        let src = "## Installation\n\nDownload the prebuilt binary from\nthe releases page,\nthen run `cargo install`.\n\n### Notes\n";
+        // so `find_symbol --doc-contains` can match prose. The path
+        // prefix is prepended when the heading has ancestors.
+        let src = "# Project\n\n## Installation\n\nDownload the prebuilt binary from\nthe releases page,\nthen run `cargo install`.\n\n### Notes\n";
         let syms = markdown_symbols(src);
         let install = syms.iter().find(|s| s.name == "Installation").unwrap();
         let docs = install
             .documentation
             .as_ref()
-            .expect("Installation heading should have docs from its body paragraph");
-        // Newlines collapsed to single spaces.
+            .expect("Installation heading should have docs");
+        // Path prefix: H2 → "Project > Installation".
+        assert!(
+            docs.starts_with("Project > Installation"),
+            "expected path prefix; got {docs:?}",
+        );
+        // Body: "releases page" comma form survives the collapse.
         assert!(docs.contains("releases page,"), "got docs={docs:?}");
-        assert!(!docs.contains('\n'), "multi-line paragraph collapsed to one line");
         // The next heading's body should NOT bleed in.
         assert!(!docs.contains("Notes"), "got docs={docs:?}");
     }
@@ -2083,18 +2122,21 @@ macro_rules! log_at {
     #[test]
     fn extract_markdown_no_documentation_when_immediate_subheading() {
         // A heading immediately followed by a subheading (no body)
-        // should leave `documentation` as None.
+        // gets the path prefix only — no body. An H1 with no body and
+        // no parents stays None.
         let src = "## Outer\n### Inner\n\nInner body.\n";
         let syms = markdown_symbols(src);
         let outer = syms.iter().find(|s| s.name == "Outer").unwrap();
         assert!(
             outer.documentation.is_none(),
-            "Outer should have no docs: got {:?}",
+            "Outer (no parents, no body) should have None docs: got {:?}",
             outer.documentation
         );
-        // The inner heading's docs do get populated.
-        let inner = syms.iter().find(|s| s.name == "Outer > Inner").unwrap();
-        assert!(inner.documentation.is_some());
+        // Inner gets the full path + body.
+        let inner = syms.iter().find(|s| s.name == "Inner").unwrap();
+        let docs = inner.documentation.as_deref().unwrap();
+        assert!(docs.starts_with("Outer > Inner"), "got {docs:?}");
+        assert!(docs.contains("Inner body."), "got {docs:?}");
     }
 
     #[test]

--- a/crates/rts-core/src/extraction.rs
+++ b/crates/rts-core/src/extraction.rs
@@ -1339,85 +1339,76 @@ mod markdown {
     ) -> Result<()> {
         let bytes = content.as_bytes();
         let root = tree.root_node();
-        // Path accumulator: heading texts from outermost section to current.
-        let mut path: Vec<String> = Vec::new();
-        walk_node(&root, bytes, &mut path, symbols);
+        // Stack of (level, name) pairs from outermost to current. Both
+        // section-nested ATX headings and flat setext-heading siblings
+        // funnel through the same stack — we pop entries whose level is
+        // ≥ the new heading's level before pushing.
+        let mut stack: Vec<(u8, String)> = Vec::new();
+        walk_node(&root, bytes, &mut stack, symbols);
         Ok(())
     }
 
     fn walk_node(
         node: &crate::Node<'_>,
         bytes: &[u8],
-        path: &mut Vec<String>,
+        stack: &mut Vec<(u8, String)>,
         symbols: &mut Vec<Symbol>,
     ) {
         let kind = node.kind();
-        if kind == "section" {
-            // Find the leading heading (atx_heading or setext_heading) and
-            // walk its body for nested sections.
-            let mut heading_text: Option<String> = None;
-            let mut heading_level: Option<u8> = None;
-            let mut heading_node: Option<crate::Node<'_>> = None;
-            for child in node.named_children() {
-                match child.kind() {
-                    "atx_heading" => {
-                        if let Some((lvl, text)) = atx_heading_info(&child, bytes) {
-                            heading_level = Some(lvl);
-                            heading_text = Some(text);
-                            heading_node = Some(child);
-                        }
-                        break;
+        match kind {
+            "atx_heading" | "setext_heading" => {
+                let info = if kind == "atx_heading" {
+                    atx_heading_info(node, bytes)
+                } else {
+                    setext_heading_info(node, bytes)
+                };
+                if let Some((level, text)) = info {
+                    // Pop any entries at this level or deeper — a new
+                    // heading of level N closes every open heading of
+                    // level ≥ N.
+                    while stack.last().is_some_and(|(l, _)| *l >= level) {
+                        stack.pop();
                     }
-                    "setext_heading" => {
-                        if let Some((lvl, text)) = setext_heading_info(&child, bytes) {
-                            heading_level = Some(lvl);
-                            heading_text = Some(text);
-                            heading_node = Some(child);
-                        }
-                        break;
-                    }
-                    _ => continue,
+                    stack.push((level, text.clone()));
+                    let qualified: Vec<String> =
+                        stack.iter().map(|(_, n)| n.clone()).collect();
+                    let documentation = match kind {
+                        // For ATX headings tree-sitter-md nests the body
+                        // inside the enclosing `section` — find it via
+                        // the parent.
+                        "atx_heading" => node
+                            .parent()
+                            .and_then(|p| first_paragraph_in_section(&p, bytes)),
+                        // For setext headings the surrounding section
+                        // also contains the body paragraph as a sibling.
+                        "setext_heading" => node
+                            .parent()
+                            .and_then(|p| first_paragraph_after_setext(&p, node, bytes)),
+                        _ => None,
+                    };
+                    symbols.push(Symbol {
+                        name: qualified.join(" > "),
+                        kind: "heading".to_string(),
+                        start_line: node.start_position().row + 1,
+                        end_line: node.end_position().row + 1,
+                        start_column: node.start_position().column,
+                        end_column: node.end_position().column,
+                        visibility: "public".to_string(),
+                        documentation,
+                    });
                 }
-            }
-
-            if let (Some(text), Some(_lvl), Some(hnode)) =
-                (heading_text, heading_level, heading_node)
-            {
-                path.push(text.clone());
-                // Build hierarchical qualified name: "Outer > Inner > Self"
-                let qualified = path.join(" > ");
-                // documentation: first paragraph following the heading in
-                // this section (skip nested sections / code blocks).
-                let documentation = first_paragraph_in_section(node, bytes);
-                symbols.push(Symbol {
-                    name: qualified,
-                    kind: "heading".to_string(),
-                    start_line: hnode.start_position().row + 1,
-                    end_line: hnode.end_position().row + 1,
-                    start_column: hnode.start_position().column,
-                    end_column: hnode.end_position().column,
-                    visibility: "public".to_string(),
-                    documentation,
-                });
-
-                // Recurse into the rest of the section body, looking for
-                // nested sections.
-                for child in node.named_children() {
-                    if child.kind() == "section" {
-                        walk_node(&child, bytes, path, symbols);
-                    }
-                }
-                path.pop();
                 return;
             }
-            // No heading found inside the section (shouldn't happen for
-            // valid markdown). Recurse into children defensively.
+            // Fenced code blocks are opaque — never recurse in. Belt &
+            // suspenders; the block grammar already keeps headings inside
+            // a fence from existing in the named-children walk, but
+            // future grammar tweaks shouldn't silently change behavior.
+            "fenced_code_block" | "indented_code_block" => return,
+            _ => {}
         }
 
-        // For non-section nodes (document root, etc.), recurse into
-        // children looking for sections.
         for child in node.named_children() {
-            walk_node(&child, bytes, path, symbols);
+            walk_node(&child, bytes, stack, symbols);
         }
     }
 
@@ -1480,13 +1471,58 @@ mod markdown {
     /// in a sub-section); flatten to a single line and clip to
     /// `DOC_CHAR_CAP` chars.
     fn first_paragraph_in_section(section: &crate::Node<'_>, bytes: &[u8]) -> Option<String> {
+        // For ATX-style hierarchies the section contains the heading as
+        // the first named child, then the body paragraph(s) and nested
+        // sections. Iterate past the leading heading; stop at the first
+        // nested section / heading sibling.
+        let mut past_heading = false;
         for child in section.named_children() {
+            match child.kind() {
+                "atx_heading" | "setext_heading" => {
+                    if !past_heading {
+                        past_heading = true;
+                        continue;
+                    }
+                    // Hit a sibling heading without finding a paragraph —
+                    // no docs.
+                    return None;
+                }
+                "paragraph" => {
+                    let raw = child.utf8_text(bytes).ok()?;
+                    return Some(collapse_paragraph(raw));
+                }
+                "section" => return None,
+                _ => continue,
+            }
+        }
+        None
+    }
+
+    /// Find the first paragraph appearing *after* `heading` inside the
+    /// enclosing section. tree-sitter-md emits setext headings as flat
+    /// siblings inside one section (unlike ATX, which builds nested
+    /// sections), so the body paragraph is a later named child of the
+    /// same section.
+    fn first_paragraph_after_setext(
+        section: &crate::Node<'_>,
+        heading: &crate::Node<'_>,
+        bytes: &[u8],
+    ) -> Option<String> {
+        let heading_start = heading.start_byte();
+        for child in section.named_children() {
+            // Only consider children that start strictly after the
+            // heading we're looking at.
+            if child.start_byte() <= heading_start {
+                continue;
+            }
             match child.kind() {
                 "paragraph" => {
                     let raw = child.utf8_text(bytes).ok()?;
                     return Some(collapse_paragraph(raw));
                 }
-                "section" => break,
+                // Another heading interrupts — no doc paragraph for the
+                // current heading.
+                "atx_heading" | "setext_heading" => return None,
                 _ => continue,
             }
         }
@@ -1942,5 +1978,152 @@ macro_rules! log_at {
             log.documentation.as_deref(),
             Some("A trait encapsulating logging.")
         );
+    }
+
+    // ---- Markdown heading extraction (v0.7.0) ----
+    //
+    // The block-grammar tree-sitter-md indexer emits headings as
+    // `kind="heading"` symbols. Depth is encoded in:
+    //   - `name` — hierarchical path joined by " > " (no file stem
+    //     prefix; that's the daemon writer's job at index time once
+    //     the file path is known).
+    //   - `signature` — rendered on demand by
+    //     `signature::render_markdown` from the heading line in source
+    //     (re-derives the leading-`#` count without storing it on
+    //     `Symbol`, preserving the public API shape).
+
+    fn markdown_symbols(src: &str) -> Vec<crate::Symbol> {
+        parse_content(src, Language::Markdown).unwrap().symbols
+    }
+
+    #[test]
+    fn extract_markdown_atx_h1_to_h6() {
+        // Each level should produce one heading with kind="heading"
+        // and the correct start_line.
+        let src = "# One\n\n## Two\n\n### Three\n\n#### Four\n\n##### Five\n\n###### Six\n";
+        let syms = markdown_symbols(src);
+        assert_eq!(syms.len(), 6, "expected 6 headings, got {syms:?}");
+        for sym in &syms {
+            assert_eq!(sym.kind, "heading", "every heading symbol gets kind=heading");
+            assert_eq!(sym.visibility, "public", "headings are public by default");
+        }
+        // Each subsequent heading nests under the previous (H1 → H2 → ...);
+        // so qualified names form a chain.
+        assert_eq!(syms[0].name, "One");
+        assert_eq!(syms[1].name, "One > Two");
+        assert_eq!(syms[2].name, "One > Two > Three");
+        assert_eq!(syms[5].name, "One > Two > Three > Four > Five > Six");
+    }
+
+    #[test]
+    fn extract_markdown_setext_h1_h2() {
+        // Setext (underline-style) H1 and H2 should be captured the
+        // same way ATX H1/H2 are.
+        let src = "Top Title\n=========\n\nSubsection\n----------\n";
+        let syms = markdown_symbols(src);
+        assert_eq!(syms.len(), 2, "expected 2 setext headings, got {syms:?}");
+        assert_eq!(syms[0].kind, "heading");
+        assert_eq!(syms[0].name, "Top Title");
+        assert_eq!(syms[1].name, "Top Title > Subsection");
+    }
+
+    #[test]
+    fn extract_markdown_strips_closing_hashes_and_trims() {
+        // CommonMark allows `## Foo ##` — trailing hashes are decorative
+        // and must be stripped from the symbol name.
+        let src = "## Trimmed Title  ##\n\nBody.\n";
+        let syms = markdown_symbols(src);
+        assert_eq!(syms.len(), 1);
+        assert_eq!(syms[0].name, "Trimmed Title");
+    }
+
+    #[test]
+    fn extract_markdown_multiple_h1_siblings() {
+        // Two H1s are siblings — neither nests under the other; their
+        // qualified names are flat (no shared parent).
+        let src = "# First Topic\n\nA paragraph.\n\n# Second Topic\n\nAnother paragraph.\n";
+        let syms = markdown_symbols(src);
+        let names: Vec<&str> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["First Topic", "Second Topic"]);
+    }
+
+    #[test]
+    fn extract_markdown_hierarchy_resets_on_higher_heading() {
+        // After going H1 → H2 → H3, a new H1 should reset the path —
+        // subsequent H2 nests under the *new* H1, not the old one.
+        let src =
+            "# Alpha\n\n## A1\n\n### A1a\n\n# Beta\n\n## B1\n";
+        let syms = markdown_symbols(src);
+        let names: Vec<&str> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["Alpha", "Alpha > A1", "Alpha > A1 > A1a", "Beta", "Beta > B1"],
+        );
+    }
+
+    #[test]
+    fn extract_markdown_documentation_from_first_paragraph() {
+        // The first paragraph after a heading populates `documentation`
+        // so `find_symbol --doc-contains` can match prose. Cap is ~512
+        // chars, single-line collapsed.
+        let src = "## Installation\n\nDownload the prebuilt binary from\nthe releases page,\nthen run `cargo install`.\n\n### Notes\n";
+        let syms = markdown_symbols(src);
+        let install = syms.iter().find(|s| s.name == "Installation").unwrap();
+        let docs = install
+            .documentation
+            .as_ref()
+            .expect("Installation heading should have docs from its body paragraph");
+        // Newlines collapsed to single spaces.
+        assert!(docs.contains("releases page,"), "got docs={docs:?}");
+        assert!(!docs.contains('\n'), "multi-line paragraph collapsed to one line");
+        // The next heading's body should NOT bleed in.
+        assert!(!docs.contains("Notes"), "got docs={docs:?}");
+    }
+
+    #[test]
+    fn extract_markdown_no_documentation_when_immediate_subheading() {
+        // A heading immediately followed by a subheading (no body)
+        // should leave `documentation` as None.
+        let src = "## Outer\n### Inner\n\nInner body.\n";
+        let syms = markdown_symbols(src);
+        let outer = syms.iter().find(|s| s.name == "Outer").unwrap();
+        assert!(
+            outer.documentation.is_none(),
+            "Outer should have no docs: got {:?}",
+            outer.documentation
+        );
+        // The inner heading's docs do get populated.
+        let inner = syms.iter().find(|s| s.name == "Outer > Inner").unwrap();
+        assert!(inner.documentation.is_some());
+    }
+
+    #[test]
+    fn extract_markdown_skips_headings_inside_fenced_code_blocks() {
+        // A `#` inside a fenced code block is code, not a heading. The
+        // tree-sitter-md block grammar emits the fence as
+        // `fenced_code_block.code_fence_content` — opaque to the
+        // ATX/Setext queries, so headings nested in a fence never reach
+        // our extractor.
+        let src = "# Real Heading\n\n```\n# Not a heading\n## Also not\n```\n\nMore body.\n";
+        let syms = markdown_symbols(src);
+        // Only the real heading should be captured.
+        assert_eq!(syms.len(), 1, "expected 1 heading, got {syms:?}");
+        assert_eq!(syms[0].name, "Real Heading");
+    }
+
+    #[test]
+    fn extract_markdown_start_line_is_one_based() {
+        // start_line is 1-based (matches all other extractors). Verify
+        // on a non-trivial offset — heading sits on line 4.
+        let src = "Intro paragraph.\n\nMore intro.\n\n# Heading on line five\n";
+        let syms = markdown_symbols(src);
+        assert_eq!(syms.len(), 1);
+        assert_eq!(syms[0].start_line, 5);
+    }
+
+    #[test]
+    fn extract_markdown_empty_file() {
+        let syms = markdown_symbols("");
+        assert!(syms.is_empty());
     }
 }

--- a/crates/rts-core/src/languages/mod.rs
+++ b/crates/rts-core/src/languages/mod.rs
@@ -41,6 +41,12 @@ pub enum Language {
     Swift,
     /// C# programming language
     CSharp,
+    /// Markdown documentation (prose; first-class headings as symbols).
+    ///
+    /// v1 uses the block grammar only (`tree_sitter_md::LANGUAGE`). The inline
+    /// grammar (`INLINE_LANGUAGE`) and the two-pass `parser` feature are
+    /// deferred to v2 when markdown links land as a reference graph.
+    Markdown,
 }
 
 impl Language {
@@ -63,6 +69,7 @@ impl Language {
             Language::Ruby => Ok(tree_sitter_ruby::LANGUAGE.into()),
             Language::Swift => Ok(tree_sitter_swift::LANGUAGE.into()),
             Language::CSharp => Ok(tree_sitter_c_sharp::LANGUAGE.into()),
+            Language::Markdown => Ok(tree_sitter_md::LANGUAGE.into()),
         }
     }
 
@@ -81,6 +88,7 @@ impl Language {
             Language::Ruby => "Ruby",
             Language::Swift => "Swift",
             Language::CSharp => "C#",
+            Language::Markdown => "Markdown",
         }
     }
 
@@ -99,6 +107,7 @@ impl Language {
             Language::Ruby => &["rb"],
             Language::Swift => &["swift"],
             Language::CSharp => &["cs", "csx"],
+            Language::Markdown => &["md", "markdown"],
         }
     }
 
@@ -117,6 +126,7 @@ impl Language {
             Language::Ruby => "0.21.0",
             Language::Swift => "0.21.0",
             Language::CSharp => "0.23.0",
+            Language::Markdown => "0.5",
         }
     }
 
@@ -135,6 +145,7 @@ impl Language {
             Language::Ruby => true,
             Language::Swift => true,
             Language::CSharp => true,
+            Language::Markdown => false,
         }
     }
 
@@ -156,6 +167,11 @@ impl Language {
             Language::Ruby => Some(tree_sitter_ruby::HIGHLIGHTS_QUERY),
             Language::Swift => Some(tree_sitter_swift::HIGHLIGHTS_QUERY),
             Language::CSharp => Some(tree_sitter_c_sharp::HIGHLIGHTS_QUERY),
+            // tree-sitter-md ships HIGHLIGHT_QUERY_BLOCK at the crate root,
+            // but v1 markdown indexing doesn't run highlighting (headings-as-
+            // symbols suffices); leave the query unwired until a real
+            // consumer needs it.
+            Language::Markdown => None,
         }
     }
 
@@ -174,6 +190,7 @@ impl Language {
             Language::Ruby => None,       // Ruby doesn't have injections query
             Language::Swift => None,      // Swift doesn't have injections query
             Language::CSharp => None,     // C# doesn't have injections query
+            Language::Markdown => None,   // Markdown injections (fenced code) deferred to v2
         }
     }
 
@@ -192,6 +209,7 @@ impl Language {
             Language::Ruby => None,       // Ruby doesn't have locals query
             Language::Swift => None,      // Swift doesn't have locals query
             Language::CSharp => None,     // C# doesn't have locals query
+            Language::Markdown => None,   // Markdown has no notion of locals
         }
     }
 
@@ -210,6 +228,7 @@ impl Language {
             Language::Ruby,
             Language::Swift,
             Language::CSharp,
+            Language::Markdown,
         ]
     }
 }
@@ -247,10 +266,11 @@ impl std::str::FromStr for Language {
             "ruby" | "rb" => Ok(Language::Ruby),
             "swift" => Ok(Language::Swift),
             "csharp" | "c#" | "cs" => Ok(Language::CSharp),
+            "markdown" | "md" => Ok(Language::Markdown),
             _ => Err(Error::invalid_input_error(
                 "language",
                 s,
-                "supported language (rust, javascript, typescript, python, c, cpp, go, java, php, ruby, swift)",
+                "supported language (rust, javascript, typescript, python, c, cpp, go, java, php, ruby, swift, csharp, markdown)",
             )),
         }
     }
@@ -325,6 +345,7 @@ mod tests {
             (Language::Ruby, "x = 1"),
             (Language::Swift, "let x = 1"),
             (Language::CSharp, "class C {}"),
+            (Language::Markdown, "# Heading\n"),
         ];
 
         // Sanity: every variant of `Language::all()` is exercised here.

--- a/crates/rts-core/src/lib.rs
+++ b/crates/rts-core/src/lib.rs
@@ -201,6 +201,11 @@ pub fn supported_languages() -> Vec<LanguageInfo> {
             version: "0.23",
             file_extensions: &["cs", "csx"],
         },
+        LanguageInfo {
+            name: "Markdown",
+            version: "0.5",
+            file_extensions: &["md", "markdown"],
+        },
     ]
 }
 
@@ -219,6 +224,7 @@ pub fn detect_language_from_extension(extension: &str) -> Option<Language> {
         "rb" | "rake" => Some(Language::Ruby),
         "swift" => Some(Language::Swift),
         "cs" | "csx" => Some(Language::CSharp),
+        "md" | "markdown" => Some(Language::Markdown),
         _ => None,
     }
 }

--- a/crates/rts-core/src/query.rs
+++ b/crates/rts-core/src/query.rs
@@ -163,6 +163,16 @@ impl Query {
             Language::Ruby => "(method name: (identifier) @name) @function",
             Language::Swift => "(function_declaration name: (simple_identifier) @name) @function",
             Language::CSharp => "(method_declaration name: (identifier) @name) @function",
+            // Markdown has no functions — prose grammar. Surface as an
+            // explicit error so callers reaching for this helper on a
+            // markdown file know to use `extract_symbols` directly.
+            Language::Markdown => {
+                return Err(crate::error::Error::invalid_input_error(
+                    "language",
+                    "Markdown",
+                    "language with function definitions (prose has none)",
+                ));
+            }
         };
 
         Self::new(language, pattern)
@@ -185,6 +195,14 @@ impl Query {
             Language::Ruby => "(class name: (constant) @name) @class",
             Language::Swift => "(class_declaration name: (simple_identifier) @name) @class",
             Language::CSharp => "(class_declaration name: (identifier) @name) @class",
+            // Markdown has no classes — prose grammar.
+            Language::Markdown => {
+                return Err(crate::error::Error::invalid_input_error(
+                    "language",
+                    "Markdown",
+                    "language with class definitions (prose has none)",
+                ));
+            }
         };
 
         Self::new(language, pattern)

--- a/crates/rts-core/src/signature.rs
+++ b/crates/rts-core/src/signature.rs
@@ -961,6 +961,61 @@ pub fn render_swift(bytes: &[u8]) -> Option<String> {
     }
 }
 
+/// Render the canonical display string for a Markdown heading.
+///
+/// Markdown headings have no body to strip — the "signature" *is* the
+/// heading line. v1 always emits ATX form (`#`, `##`, ..., `######`)
+/// even for Setext-source headings, for output consistency across the
+/// agent-facing tools (`outline_workspace`, `find_symbol`, etc.).
+///
+/// `bytes` are the heading-node's source bytes — what the daemon stores
+/// in the def site's byte range. For ATX headings this is the literal
+/// `### Heading text\n`; for setext, it's the text line + underline
+/// (e.g. `Title\n=====\n`). The renderer detects the shape and produces
+/// the ATX-form string `<#×level> <trimmed-text>`.
+///
+/// Returns `None` for input that doesn't parse as a single heading.
+pub fn render_markdown(bytes: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    let mut lines = text.lines();
+    let first = lines.next()?.trim_end();
+    if first.is_empty() {
+        return None;
+    }
+
+    // ATX form: leading run of `#` (1..=6), then a space.
+    if first.starts_with('#') {
+        let hash_count = first.chars().take_while(|c| *c == '#').count();
+        if !(1..=6).contains(&hash_count) {
+            return None;
+        }
+        let rest = &first[hash_count..];
+        // ATX requires a space (or end-of-line) after the marker.
+        if !rest.is_empty() && !rest.starts_with(' ') && !rest.starts_with('\t') {
+            return None;
+        }
+        let body = rest.trim();
+        // Strip CommonMark closing `#`s.
+        let body = body.trim_end_matches('#').trim_end();
+        return Some(format!("{} {}", "#".repeat(hash_count), body));
+    }
+
+    // Setext form: title line + `===` (H1) or `---` (H2) underline.
+    let second = lines.next()?.trim_end();
+    let level = if !second.is_empty() && second.chars().all(|c| c == '=') {
+        1
+    } else if !second.is_empty() && second.chars().all(|c| c == '-') {
+        2
+    } else {
+        return None;
+    };
+    let body = first.trim();
+    if body.is_empty() {
+        return None;
+    }
+    Some(format!("{} {}", "#".repeat(level), body))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1629,5 +1684,65 @@ mod tests {
     #[test]
     fn sw_empty_input_returns_none() {
         assert!(render_swift(b"").is_none());
+    }
+
+    // ---------- Markdown ----------
+    //
+    // The renderer normalises every heading to ATX form regardless of
+    // grammar shape — agents reading `find_symbol` results get one
+    // canonical signature style for prose.
+
+    fn md(input: &str) -> String {
+        render_markdown(input.as_bytes())
+            .unwrap_or_else(|| panic!("expected a markdown signature for `{input}`"))
+    }
+
+    #[test]
+    fn md_atx_h1_to_h6() {
+        for level in 1..=6u8 {
+            let hashes = "#".repeat(level as usize);
+            let src = format!("{hashes} Heading text\n");
+            assert_eq!(md(&src), format!("{hashes} Heading text"));
+        }
+    }
+
+    #[test]
+    fn md_atx_strips_trailing_hashes() {
+        assert_eq!(md("## Section ##\n"), "## Section");
+        assert_eq!(md("### Inner ### \n"), "### Inner");
+    }
+
+    #[test]
+    fn md_atx_h7_rejects() {
+        // ATX only goes up to H6 in CommonMark.
+        assert!(render_markdown(b"####### Too deep\n").is_none());
+    }
+
+    #[test]
+    fn md_setext_emits_atx_form() {
+        // Underline = ⇒ H1
+        assert_eq!(md("Top Title\n=========\n"), "# Top Title");
+        // Underline - ⇒ H2
+        assert_eq!(md("Subsection\n----------\n"), "## Subsection");
+    }
+
+    #[test]
+    fn md_setext_rejects_garbage_underline() {
+        // First line that doesn't begin with `#` and isn't followed by
+        // an `=`/`-` line is not a heading.
+        assert!(render_markdown(b"Just a paragraph\nwith more text\n").is_none());
+    }
+
+    #[test]
+    fn md_empty_returns_none() {
+        assert!(render_markdown(b"").is_none());
+        assert!(render_markdown(b"\n").is_none());
+    }
+
+    #[test]
+    fn md_atx_no_space_after_marker_rejects() {
+        // `##Foo` is not a valid ATX heading (CommonMark requires a
+        // space).
+        assert!(render_markdown(b"##Foo\n").is_none());
     }
 }

--- a/crates/rts-core/tests/snapshots/public-api.txt
+++ b/crates/rts-core/tests/snapshots/public-api.txt
@@ -1395,6 +1395,7 @@ pub rust_tree_sitter::languages::Language::Cpp
 pub rust_tree_sitter::languages::Language::Go
 pub rust_tree_sitter::languages::Language::Java
 pub rust_tree_sitter::languages::Language::JavaScript
+pub rust_tree_sitter::languages::Language::Markdown
 pub rust_tree_sitter::languages::Language::Php
 pub rust_tree_sitter::languages::Language::Python
 pub rust_tree_sitter::languages::Language::Ruby
@@ -1728,6 +1729,7 @@ pub fn rust_tree_sitter::signature::render_csharp(bytes: &[u8]) -> core::option:
 pub fn rust_tree_sitter::signature::render_go(bytes: &[u8]) -> core::option::Option<alloc::string::String>
 pub fn rust_tree_sitter::signature::render_java(bytes: &[u8]) -> core::option::Option<alloc::string::String>
 pub fn rust_tree_sitter::signature::render_javascript(bytes: &[u8]) -> core::option::Option<alloc::string::String>
+pub fn rust_tree_sitter::signature::render_markdown(bytes: &[u8]) -> core::option::Option<alloc::string::String>
 pub fn rust_tree_sitter::signature::render_php(bytes: &[u8]) -> core::option::Option<alloc::string::String>
 pub fn rust_tree_sitter::signature::render_python(bytes: &[u8]) -> core::option::Option<alloc::string::String>
 pub fn rust_tree_sitter::signature::render_ruby(bytes: &[u8]) -> core::option::Option<alloc::string::String>
@@ -2074,6 +2076,7 @@ pub rust_tree_sitter::Language::Cpp
 pub rust_tree_sitter::Language::Go
 pub rust_tree_sitter::Language::Java
 pub rust_tree_sitter::Language::JavaScript
+pub rust_tree_sitter::Language::Markdown
 pub rust_tree_sitter::Language::Php
 pub rust_tree_sitter::Language::Python
 pub rust_tree_sitter::Language::Ruby

--- a/crates/rts-daemon/src/filter.rs
+++ b/crates/rts-daemon/src/filter.rs
@@ -110,8 +110,15 @@ pub const BODY_ALLOWED_EXTENSIONS: &[&str] = &[
     // Code
     "rs", "py", "ts", "tsx", "js", "jsx", "go", "java", "c", "h", "cpp", "hpp", "cc", "cs", "php",
     "rb", "swift", "kt", // Code-adjacent (config, prose)
-    "md", "toml", "yaml", "yml", "json", "xml",
+    "md", "markdown", "toml", "yaml", "yml", "json", "xml",
 ];
+
+// v0.7.0: per-file 4 MB byte cap on markdown is already provided by the
+// existing global `OVERSIZE_THRESHOLD_BYTES` in `writer.rs` (4 MiB).
+// Files exceeding the threshold are tagged `oversize=true` and skip
+// symbol extraction entirely — that's the parser-DoS guard the plan
+// calls out (`set_timeout_micros` is a no-op in tree-sitter ≥ 0.26).
+// No separate markdown-specific constant needed.
 
 /// Extensions we *index* (structure / symbols) but never return body for.
 /// Empty for v0 — anything outside the body-allowlist is skipped entirely. A
@@ -354,6 +361,26 @@ mod tests {
             classify(&p, &g),
             FilterDecision::Skip(SkipReason::Gitignore)
         );
+    }
+
+    #[test]
+    fn markdown_extensions_are_index_full() {
+        // v0.7.0 — `.md` was already in `BODY_ALLOWED_EXTENSIONS` (the
+        // filter said "index this") but `info_for_path` returned None
+        // (no language dispatch), so the writer dropped the bytes
+        // silently. This pins the *filter*-side contract: both
+        // extensions reach `IndexFull` here. The dispatch side is
+        // verified in the `language::tests` module + the
+        // `language_dispatch_invariant` integration test.
+        let g = empty_gitignore();
+        for ext in ["README.md", "docs/notes.markdown"] {
+            let p = g.root.join(ext);
+            assert_eq!(
+                classify(&p, &g),
+                FilterDecision::IndexFull,
+                "{ext} should reach IndexFull"
+            );
+        }
     }
 
     #[test]

--- a/crates/rts-daemon/src/language.rs
+++ b/crates/rts-daemon/src/language.rs
@@ -388,6 +388,19 @@ pub fn info_for_path(rel_path: &str) -> Option<LanguageInfo> {
             signature_renderer: Some(rust_tree_sitter::signature::render_csharp),
             refs_query: Some(CSHARP_REFS),
         }),
+        // v0.7.0 — markdown indexing. Block grammar only; no refs query
+        // (markdown links land as a reference graph in v2). The
+        // signature renderer normalises ATX + Setext headings to ATX
+        // form for agent-facing output consistency.
+        //
+        // No `MARKDOWN_QUERY: OnceLock<Option<Query>>` cell needed —
+        // C/C++ have no cache entry either, and `refs_query: None`
+        // alone is enough for `cached_refs_query` to short-circuit.
+        "md" | "markdown" => Some(LanguageInfo {
+            language: Language::Markdown,
+            signature_renderer: Some(rust_tree_sitter::signature::render_markdown),
+            refs_query: None,
+        }),
         _ => None,
     }
 }
@@ -602,5 +615,39 @@ mod tests {
         let body = b"pub fn foo(x: u32) -> u32 { x + 1 }";
         let sig = render(body).expect("renderer should produce a signature");
         assert!(sig.contains("pub fn foo"), "got {sig:?}");
+    }
+
+    #[test]
+    fn markdown_dispatch_carries_renderer_and_no_refs() {
+        // v0.7.0 — both .md and .markdown route to Language::Markdown
+        // with the signature renderer wired and no refs query (markdown
+        // links land as a reference graph in v2). `cached_refs_query`
+        // short-circuits via the `_ => return None` arm.
+        for ext in ["README.md", "docs/notes.markdown"] {
+            let info = info_for_path(ext).expect("{ext} should be supported");
+            assert_eq!(info.language, Language::Markdown);
+            assert!(info.signature_renderer.is_some(), "{ext} needs a renderer");
+            assert!(info.refs_query.is_none(), "{ext} should have no refs query in v1");
+            assert!(
+                cached_refs_query(&info).is_none(),
+                "{ext} cached_refs_query must short-circuit"
+            );
+        }
+    }
+
+    #[test]
+    fn markdown_signature_renderer_normalises_to_atx() {
+        // Pin the U3 contract through the daemon registry — both ATX
+        // and Setext sources end up as `# Heading` style at the wire.
+        let info = info_for_path("README.md").unwrap();
+        let render = info.signature_renderer.unwrap();
+        assert_eq!(
+            render(b"# Heading text\n").as_deref(),
+            Some("# Heading text"),
+        );
+        assert_eq!(
+            render(b"Setext Title\n=========\n").as_deref(),
+            Some("# Setext Title"),
+        );
     }
 }

--- a/crates/rts-daemon/src/language.rs
+++ b/crates/rts-daemon/src/language.rs
@@ -627,7 +627,10 @@ mod tests {
             let info = info_for_path(ext).expect("{ext} should be supported");
             assert_eq!(info.language, Language::Markdown);
             assert!(info.signature_renderer.is_some(), "{ext} needs a renderer");
-            assert!(info.refs_query.is_none(), "{ext} should have no refs query in v1");
+            assert!(
+                info.refs_query.is_none(),
+                "{ext} should have no refs query in v1"
+            );
             assert!(
                 cached_refs_query(&info).is_none(),
                 "{ext} cached_refs_query must short-circuit"
@@ -706,20 +709,16 @@ mod tests {
                 )
             });
             assert_eq!(
-                info.language,
-                lang,
+                info.language, lang,
                 "info_for_path({path:?}) language mismatch — got {:?} want {:?}",
-                info.language,
-                lang,
+                info.language, lang,
             );
 
             // b) rts-core side: extract_symbols accepts the snippet
             //    and produces at least one symbol — proves the
             //    dispatch arm is wired, not no-op'd.
             let outcome = rust_tree_sitter::parse_content(snippet(lang), lang)
-                .unwrap_or_else(|e| {
-                    panic!("parse_content failed for {}: {e}", lang.name())
-                });
+                .unwrap_or_else(|e| panic!("parse_content failed for {}: {e}", lang.name()));
             assert!(
                 !outcome.symbols.is_empty(),
                 "extract_symbols for {} produced 0 symbols — missing or no-op arm",

--- a/crates/rts-daemon/src/language.rs
+++ b/crates/rts-daemon/src/language.rs
@@ -650,4 +650,107 @@ mod tests {
             Some("# Setext Title"),
         );
     }
+
+    /// v0.7.0 dispatch-agreement invariant: for every supported
+    /// `Language`, both the daemon-side `info_for_path` and the
+    /// rts-core `extract_symbols` dispatch must agree.
+    ///
+    /// Catches the C# omission class of bug — a new language gets a
+    /// `Language::Foo` variant + an `extraction.rs` arm but the
+    /// daemon's `info_for_path` table is forgotten, silently dropping
+    /// every file of that language at index time.
+    ///
+    /// Lives here (not in `tests/`) because rts-daemon is a bin-only
+    /// crate without a [lib] section — integration tests can't import
+    /// `info_for_path` directly.
+    #[test]
+    fn info_for_path_and_extract_symbols_agree_for_every_language() {
+        // Minimal source snippet per language that the extractor can
+        // produce at least one symbol from. Smoke-only — per-language
+        // tests cover correctness in depth.
+        fn snippet(lang: Language) -> &'static str {
+            match lang {
+                Language::Rust => "fn foo() {}",
+                Language::JavaScript => "function foo() {}",
+                Language::TypeScript => "function foo() {}",
+                Language::Python => "def foo():\n    pass\n",
+                Language::C => "void foo(void) {}",
+                Language::Cpp => "void foo() {}",
+                Language::Go => "package main\nfunc Foo() {}\n",
+                Language::Java => "class C { void foo() {} }",
+                Language::Php => "<?php function foo() {} ?>",
+                Language::Ruby => "def foo\nend\n",
+                Language::Swift => "func foo() {}",
+                Language::CSharp => "class C { void Foo() {} }",
+                Language::Markdown => "# Foo\n",
+            }
+        }
+
+        for lang in Language::all() {
+            // a) Daemon-side: info_for_path returns Some for the
+            //    first declared file extension and carries the
+            //    matching language.
+            let exts = lang.file_extensions();
+            assert!(
+                !exts.is_empty(),
+                "Language::{} has no file_extensions",
+                lang.name(),
+            );
+            let ext = exts[0];
+            let path = format!("synthetic.{ext}");
+            let info = info_for_path(&path).unwrap_or_else(|| {
+                panic!(
+                    "info_for_path({path:?}) returned None for Language::{} \
+                     — missing arm in info_for_path",
+                    lang.name(),
+                )
+            });
+            assert_eq!(
+                info.language,
+                lang,
+                "info_for_path({path:?}) language mismatch — got {:?} want {:?}",
+                info.language,
+                lang,
+            );
+
+            // b) rts-core side: extract_symbols accepts the snippet
+            //    and produces at least one symbol — proves the
+            //    dispatch arm is wired, not no-op'd.
+            let outcome = rust_tree_sitter::parse_content(snippet(lang), lang)
+                .unwrap_or_else(|e| {
+                    panic!("parse_content failed for {}: {e}", lang.name())
+                });
+            assert!(
+                !outcome.symbols.is_empty(),
+                "extract_symbols for {} produced 0 symbols — missing or no-op arm",
+                lang.name(),
+            );
+        }
+    }
+
+    /// Companion: every Language must have at least one file extension
+    /// that routes BACK through `info_for_path` to the same Language.
+    /// Detects silent extension-table drift.
+    #[test]
+    fn every_language_has_at_least_one_extension_routable_back() {
+        for lang in Language::all() {
+            let exts = lang.file_extensions();
+            let mut routed = false;
+            for ext in exts {
+                let path = format!("synthetic.{ext}");
+                if let Some(info) = info_for_path(&path) {
+                    if info.language == lang {
+                        routed = true;
+                        break;
+                    }
+                }
+            }
+            assert!(
+                routed,
+                "Language::{}: at least one of {:?} must route back via info_for_path",
+                lang.name(),
+                exts,
+            );
+        }
+    }
 }

--- a/crates/rts-daemon/src/methods/daemon.rs
+++ b/crates/rts-daemon/src/methods/daemon.rs
@@ -154,6 +154,15 @@ const DAEMON_CAPABILITIES: &[&str] = &[
     // without matching GC activity points at an extractor regression
     // (e.g. PR #118's PHP `method_declaration` gap class).
     "daemon_telemetry_unresolved_refs_gc",
+    // v0.7.0 — Markdown indexing as a 13th language. Headings (ATX +
+    // Setext H1–H6) emit as `kind="heading"` symbols with hierarchical
+    // `name` ("README.md > Title > Installation") and `documentation`
+    // populated from the first body paragraph (≤512 chars, single-line
+    // collapsed). All tracked `.md`/`.markdown` files are indexed
+    // gitignore-aware; depth conveyed by signature + qualified path
+    // (kind stays flat). Old clients ignore both the capability and
+    // the new `heading` rows; new clients can gate on the flag.
+    "index_markdown",
 ];
 
 /// `Daemon.Ping` — heartbeat + capability advertisement (protocol-v0 §4.1, §7.1).

--- a/crates/rts-daemon/src/methods/grep_v2/structural.rs
+++ b/crates/rts-daemon/src/methods/grep_v2/structural.rs
@@ -482,6 +482,7 @@ pub fn map_wire_language(s: &str) -> Option<Language> {
         "ruby" | "rb" => Language::Ruby,
         "swift" => Language::Swift,
         "csharp" | "c#" | "cs" => Language::CSharp,
+        "markdown" | "md" => Language::Markdown,
         _ => return None,
     })
 }
@@ -502,6 +503,7 @@ fn language_wire_name(l: Language) -> &'static str {
         Language::Ruby => "ruby",
         Language::Swift => "swift",
         Language::CSharp => "csharp",
+        Language::Markdown => "markdown",
     }
 }
 

--- a/crates/rts-daemon/src/store/mod.rs
+++ b/crates/rts-daemon/src/store/mod.rs
@@ -800,31 +800,58 @@ impl Store {
     ///
     /// Returns `(sid, name, def_count)` tuples in arbitrary order;
     /// the caller assigns dense indices for PageRank input.
+    ///
+    /// v0.7.0 left this method as a thin wrapper around the kind-aware
+    /// variant — every caller now needs kind for the markdown heading
+    /// dampener, but third-party consumers depending on the legacy
+    /// shape (none in-tree) still get a stable signature.
+    #[allow(dead_code)]
     pub fn iter_workspace_sids(&self) -> anyhow::Result<Vec<(u32, String, u32)>> {
+        Ok(self
+            .iter_workspace_sids_with_kind()?
+            .into_iter()
+            .map(|(sid, name, def_count, _kind)| (sid, name, def_count))
+            .collect())
+    }
+
+    /// v0.7.0 — like `iter_workspace_sids` but also returns the kind of
+    /// the *first* def for each sid (an arbitrary representative — sids
+    /// rarely have heterogeneous kinds; PageRank only needs a coarse
+    /// `is_heading?` check). Used by `symbol_pagerank` to apply the
+    /// × 0.1 dampening on heading nodes' final rank scores.
+    ///
+    /// One extra DEFS read per sid — cheap since the multimap is already
+    /// open in the same transaction.
+    pub fn iter_workspace_sids_with_kind(
+        &self,
+    ) -> anyhow::Result<Vec<(u32, String, u32, SymbolKind)>> {
         let txn = self.db.begin_read().context("begin_read")?;
         let sid_to_name = txn.open_table(SID_TO_NAME)?;
         let defs = txn.open_multimap_table(DEFS)?;
 
-        let mut out: Vec<(u32, String, u32)> = Vec::new();
+        let mut out: Vec<(u32, String, u32, SymbolKind)> = Vec::new();
         let iter = sid_to_name.iter()?;
         for row in iter {
             let row = row?;
             let sid = row.0.value();
             let name = row.1.value().to_string();
 
-            // Skip sids with no DEFS entry — they're external symbols
-            // that got interned for ref tracking but aren't actually
-            // workspace-defined. (Shouldn't happen given §F1, but
-            // defensive.)
             let mut def_count: u32 = 0;
+            let mut kind = SymbolKind::Other;
             let it = defs.get(&sid)?;
-            for _ in it {
+            for entry in it {
+                let entry = entry?;
+                if def_count == 0 {
+                    if let Ok(d) = from_bytes::<DefSite>(entry.value()) {
+                        kind = d.kind;
+                    }
+                }
                 def_count = def_count.saturating_add(1);
             }
             if def_count == 0 {
                 continue;
             }
-            out.push((sid, name, def_count));
+            out.push((sid, name, def_count, kind));
         }
         Ok(out)
     }

--- a/crates/rts-daemon/src/store/schema.rs
+++ b/crates/rts-daemon/src/store/schema.rs
@@ -224,6 +224,11 @@ pub enum SymbolKind {
     Const = 8,
     Static = 9,
     Module = 10,
+    /// v0.7.0 — Markdown heading (H1–H6). Depth conveyed by the rendered
+    /// signature (`# Foo` / `## Bar`) and the hierarchical
+    /// `qualified_name`; the enum stays flat to mirror the single-word
+    /// lowercase convention all other variants follow.
+    Heading = 11,
     Other = 255,
 }
 
@@ -243,6 +248,7 @@ impl SymbolKind {
             "const" | "constant" => SymbolKind::Const,
             "static" => SymbolKind::Static,
             "module" | "namespace" => SymbolKind::Module,
+            "heading" => SymbolKind::Heading,
             _ => SymbolKind::Other,
         }
     }
@@ -259,6 +265,7 @@ impl SymbolKind {
             SymbolKind::Const => "const",
             SymbolKind::Static => "static",
             SymbolKind::Module => "module",
+            SymbolKind::Heading => "heading",
             SymbolKind::Other => "other",
         }
     }

--- a/crates/rts-daemon/src/symbol_pagerank.rs
+++ b/crates/rts-daemon/src/symbol_pagerank.rs
@@ -472,8 +472,8 @@ pub fn compute_symbol_ranks(store: &Store, generation: u64) -> anyhow::Result<Sy
     // Excluded sids still exist in NAME_TO_SID + DEFS — `find_symbol`
     // still finds them; they just get rank_score = 0.0 from the
     // default and sink to the bottom of rank-sorted responses.
-    let all_sids = collect_workspace_sids_with_kind(store)
-        .context("collect_workspace_sids_with_kind")?;
+    let all_sids =
+        collect_workspace_sids_with_kind(store).context("collect_workspace_sids_with_kind")?;
     // sid_info_full carries kind for the post-rank heading multiplier;
     // sid_info (without kind) is what build_edges already consumes.
     let sid_info_full: Vec<(u32, String, u32, SymbolKind)> = all_sids
@@ -858,8 +858,7 @@ mod tests {
         // sid 100 is a heading; sid 200 is a code symbol.
         let idx_to_sid = vec![100u32, 200u32];
         let raw = vec![0.5f64, 0.5f64];
-        let heading_sids: std::collections::HashSet<u32> =
-            [100u32].into_iter().collect();
+        let heading_sids: std::collections::HashSet<u32> = [100u32].into_iter().collect();
         let out = apply_heading_dampener(&idx_to_sid, &raw, &heading_sids);
         assert!((out[&100] - 0.05).abs() < 1e-9, "heading scaled to 0.05");
         assert!((out[&200] - 0.5).abs() < 1e-9, "code symbol unchanged");
@@ -878,11 +877,7 @@ mod tests {
         // With no heading sids present, the multiplier is a no-op.
         let idx_to_sid = vec![1u32, 2u32, 3u32];
         let raw = vec![0.2f64, 0.3f64, 0.5f64];
-        let out = apply_heading_dampener(
-            &idx_to_sid,
-            &raw,
-            &std::collections::HashSet::new(),
-        );
+        let out = apply_heading_dampener(&idx_to_sid, &raw, &std::collections::HashSet::new());
         for (i, sid) in idx_to_sid.iter().enumerate() {
             assert!((out[sid] - raw[i]).abs() < 1e-9);
         }

--- a/crates/rts-daemon/src/symbol_pagerank.rs
+++ b/crates/rts-daemon/src/symbol_pagerank.rs
@@ -61,6 +61,18 @@ use std::sync::Mutex;
 use anyhow::Context;
 use rust_tree_sitter::pagerank::{Edge, compute as pagerank_compute, edge_weight};
 
+use crate::store::SymbolKind;
+
+/// v0.7.0 — heading-PageRank dampener. Mirrors the leading-underscore
+/// × 0.1 rule in `edge_weight`. Markdown headings have no outbound
+/// references (no refs query), making them dangling nodes — PageRank
+/// redistributes their mass via the teleport vector each iteration,
+/// landing them near the uniform baseline. Without a counter,
+/// thousands of dangling heading SIDs would crowd out weakly-connected
+/// code symbols. We apply the multiplier to *final* rank scores rather
+/// than `edge_weight` because headings have no outgoing edges to weight.
+const HEADING_RANK_MULTIPLIER: f64 = 0.1;
+
 use crate::store::Store;
 
 /// Cached PageRank scores for a single `index_generation`.
@@ -460,19 +472,26 @@ pub fn compute_symbol_ranks(store: &Store, generation: u64) -> anyhow::Result<Sy
     // Excluded sids still exist in NAME_TO_SID + DEFS — `find_symbol`
     // still finds them; they just get rank_score = 0.0 from the
     // default and sink to the bottom of rank-sorted responses.
-    let all_sids = collect_workspace_sids(store).context("collect_workspace_sids")?;
-    let sid_info: Vec<(u32, String, u32)> = all_sids
+    let all_sids = collect_workspace_sids_with_kind(store)
+        .context("collect_workspace_sids_with_kind")?;
+    // sid_info_full carries kind for the post-rank heading multiplier;
+    // sid_info (without kind) is what build_edges already consumes.
+    let sid_info_full: Vec<(u32, String, u32, SymbolKind)> = all_sids
         .into_iter()
-        .filter(|(_sid, name, def_count)| {
+        .filter(|(_sid, name, def_count, _kind)| {
             !is_always_filtered(name) && !(*def_count == 0 && is_prelude_noise_name(name))
         })
         .collect();
-    if sid_info.is_empty() {
+    if sid_info_full.is_empty() {
         return Ok(SymbolRanks {
             generation,
             sid_to_rank: HashMap::new(),
         });
     }
+    let sid_info: Vec<(u32, String, u32)> = sid_info_full
+        .iter()
+        .map(|(sid, name, def_count, _kind)| (*sid, name.clone(), *def_count))
+        .collect();
 
     // Assign dense indices [0..n) to sids — pagerank::compute uses
     // u32 node ids in that space.
@@ -494,11 +513,23 @@ pub fn compute_symbol_ranks(store: &Store, generation: u64) -> anyhow::Result<Sy
     let n = idx_to_sid.len();
     let raw = pagerank_compute(n, &edges, None);
 
-    // Translate dense ranks back to sid-keyed scores.
-    let mut sid_to_rank: HashMap<u32, f64> = HashMap::with_capacity(n);
-    for (i, r) in raw.iter().enumerate() {
-        sid_to_rank.insert(idx_to_sid[i], *r);
-    }
+    // v0.7.0 — heading dampener. For each sid whose representative
+    // kind is `Heading`, multiply the final rank by 0.1. Headings have
+    // no outbound refs in v1, so the teleport-vector redistribution
+    // would otherwise lift dangling heading nodes near the uniform
+    // baseline and crowd weakly-connected code symbols.
+    let heading_sids: std::collections::HashSet<u32> = sid_info_full
+        .iter()
+        .filter_map(|(sid, _name, _def_count, kind)| {
+            if *kind == SymbolKind::Heading {
+                Some(*sid)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let sid_to_rank = apply_heading_dampener(&idx_to_sid, &raw, &heading_sids);
 
     Ok(SymbolRanks {
         generation,
@@ -506,14 +537,38 @@ pub fn compute_symbol_ranks(store: &Store, generation: u64) -> anyhow::Result<Sy
     })
 }
 
-/// Collect every workspace-defined sid plus its `(name, def_count)`.
-/// `def_count` is the number of DEFS rows for this sid (= how many
-/// files define the symbol). Used by `build_edges` to compute the
-/// "ubiquitous" multiplier per Aider's recipe.
-fn collect_workspace_sids(store: &Store) -> anyhow::Result<Vec<(u32, String, u32)>> {
+/// v0.7.0 — apply the heading × 0.1 multiplier and translate dense
+/// ranks back to sid-keyed scores. Factored out from `compute_symbol_ranks`
+/// to make the multiplier verifiable without a full Store fixture.
+fn apply_heading_dampener(
+    idx_to_sid: &[u32],
+    raw: &[f64],
+    heading_sids: &std::collections::HashSet<u32>,
+) -> HashMap<u32, f64> {
+    let mut sid_to_rank: HashMap<u32, f64> = HashMap::with_capacity(idx_to_sid.len());
+    for (i, r) in raw.iter().enumerate() {
+        let sid = idx_to_sid[i];
+        let adjusted = if heading_sids.contains(&sid) {
+            r * HEADING_RANK_MULTIPLIER
+        } else {
+            *r
+        };
+        sid_to_rank.insert(sid, adjusted);
+    }
+    sid_to_rank
+}
+
+/// v0.7.0 — kind-aware enumeration of workspace-defined sids. Returns
+/// `(sid, name, def_count, representative_kind)` tuples; the kind is
+/// the first def's kind (sids rarely have heterogeneous kinds in
+/// practice, and the heading-dampener pass only needs a coarse
+/// `is_heading?` check).
+fn collect_workspace_sids_with_kind(
+    store: &Store,
+) -> anyhow::Result<Vec<(u32, String, u32, SymbolKind)>> {
     let out = store
-        .iter_workspace_sids()
-        .context("iter_workspace_sids storage error")?;
+        .iter_workspace_sids_with_kind()
+        .context("iter_workspace_sids_with_kind storage error")?;
     Ok(out)
 }
 
@@ -787,5 +842,49 @@ mod tests {
         assert!(cache.get(7).is_none(), "gen=7 should now miss");
         let hit = cache.get(8).expect("hit at gen=8");
         assert!((hit.rank_for(3) - 1.0).abs() < 1e-9);
+    }
+
+    // v0.7.0 — heading dampener verification. The plan calls out a
+    // synthetic fixture: one heading + one code symbol with no in-edges
+    // (both dangling), assert the code symbol outranks the heading.
+    //
+    // Without the multiplier, dangling-mass redistribution lands both
+    // nodes near the uniform 1/n baseline. With × 0.1 on the heading,
+    // the code symbol wins.
+
+    #[test]
+    fn heading_dampener_drops_heading_rank_to_one_tenth() {
+        // Two nodes, both at the uniform baseline (post-PageRank).
+        // sid 100 is a heading; sid 200 is a code symbol.
+        let idx_to_sid = vec![100u32, 200u32];
+        let raw = vec![0.5f64, 0.5f64];
+        let heading_sids: std::collections::HashSet<u32> =
+            [100u32].into_iter().collect();
+        let out = apply_heading_dampener(&idx_to_sid, &raw, &heading_sids);
+        assert!((out[&100] - 0.05).abs() < 1e-9, "heading scaled to 0.05");
+        assert!((out[&200] - 0.5).abs() < 1e-9, "code symbol unchanged");
+        // And the code symbol now ranks ABOVE the heading.
+        assert!(out[&200] > out[&100], "code symbol should outrank heading");
+    }
+
+    #[test]
+    fn heading_dampener_constant_is_one_tenth() {
+        // Mirror of the leading-underscore × 0.1 rule in pagerank::edge_weight.
+        assert_eq!(HEADING_RANK_MULTIPLIER, 0.1);
+    }
+
+    #[test]
+    fn heading_dampener_no_heading_is_identity() {
+        // With no heading sids present, the multiplier is a no-op.
+        let idx_to_sid = vec![1u32, 2u32, 3u32];
+        let raw = vec![0.2f64, 0.3f64, 0.5f64];
+        let out = apply_heading_dampener(
+            &idx_to_sid,
+            &raw,
+            &std::collections::HashSet::new(),
+        );
+        for (i, sid) in idx_to_sid.iter().enumerate() {
+            assert!((out[sid] - raw[i]).abs() < 1e-9);
+        }
     }
 }

--- a/crates/rts-daemon/src/writer.rs
+++ b/crates/rts-daemon/src/writer.rs
@@ -701,6 +701,7 @@ fn lang_tag(language: Language) -> u8 {
         Language::Ruby => 10,
         Language::Swift => 11,
         Language::CSharp => 12,
+        Language::Markdown => 13,
     }
 }
 
@@ -725,6 +726,7 @@ pub fn lang_tag_to_name(tag: u8) -> Option<&'static str> {
         10 => "ruby",
         11 => "swift",
         12 => "csharp",
+        13 => "markdown",
         _ => return None,
     })
 }

--- a/crates/rts-daemon/tests/markdown_indexing.rs
+++ b/crates/rts-daemon/tests/markdown_indexing.rs
@@ -348,13 +348,7 @@ async fn markdown_round_trip_via_mcp_and_cli() -> anyhow::Result<()> {
     );
 
     // ---- Scenario 2: outline_workspace includes the .md files ----
-    let resp = round_trip(
-        &mut stream,
-        "15",
-        "Index.Outline",
-        json!({}),
-    )
-    .await?;
+    let resp = round_trip(&mut stream, "15", "Index.Outline", json!({})).await?;
     assert!(resp["error"].is_null(), "outline failed: {resp:?}");
     // The outline payload format is text (per the MCP `outline_workspace`
     // tool contract); it should mention README.md and the heading text.
@@ -385,9 +379,7 @@ async fn markdown_round_trip_via_mcp_and_cli() -> anyhow::Result<()> {
         !hits.is_empty(),
         "grep should find 'releases page' in README.md: {resp:?}",
     );
-    let any_in_readme = hits
-        .iter()
-        .any(|h| h["file"].as_str() == Some("README.md"));
+    let any_in_readme = hits.iter().any(|h| h["file"].as_str() == Some("README.md"));
     assert!(any_in_readme, "grep should match README.md file: {hits:?}");
 
     // ---- Scenario 6: CLI parity ----
@@ -422,13 +414,9 @@ async fn markdown_round_trip_via_mcp_and_cli() -> anyhow::Result<()> {
             String::from_utf8_lossy(&cli_out.stderr),
         );
         let cli_stdout = String::from_utf8_lossy(&cli_out.stdout).to_string();
-        let cli_json: Value = serde_json::from_str(&cli_stdout).map_err(|e| {
-            anyhow::anyhow!("rts find JSON parse: {e}; stdout={cli_stdout}")
-        })?;
-        let cli_matches = cli_json["matches"]
-            .as_array()
-            .cloned()
-            .unwrap_or_default();
+        let cli_json: Value = serde_json::from_str(&cli_stdout)
+            .map_err(|e| anyhow::anyhow!("rts find JSON parse: {e}; stdout={cli_stdout}"))?;
+        let cli_matches = cli_json["matches"].as_array().cloned().unwrap_or_default();
         assert!(
             !cli_matches.is_empty(),
             "rts find should return at least one match; got {cli_json:?}",
@@ -484,7 +472,10 @@ async fn markdown_round_trip_via_mcp_and_cli() -> anyhow::Result<()> {
 
     // Daemon should still respond to pings — no panic on oversize.
     let resp = round_trip(&mut stream, "17", "Daemon.Ping", json!({})).await?;
-    assert!(resp["error"].is_null(), "Daemon.Ping after oversize: {resp:?}");
+    assert!(
+        resp["error"].is_null(),
+        "Daemon.Ping after oversize: {resp:?}"
+    );
 
     // The "Oversize Heading" symbol must NOT appear (oversize files
     // skip extraction).

--- a/crates/rts-daemon/tests/markdown_indexing.rs
+++ b/crates/rts-daemon/tests/markdown_indexing.rs
@@ -1,0 +1,529 @@
+//! End-to-end test: markdown files are indexed and retrievable via
+//! `Index.FindSymbol`, `Index.Outline`, and `Index.Grep` (v0.7.0).
+//!
+//! This is the v0.7.0 acceptance gate: the 7 scenarios called out in
+//! the markdown-indexing plan (`docs/plans/2026-05-26-001-feat-markdown-
+//! indexing-prose-retrieval-plan.md` §"Integration Test Scenarios"):
+//!
+//!   1. README.md headings emit with `kind="heading"`, correct
+//!      hierarchical `qualified_name`, `signature`, `start_line`, and
+//!      `documentation` populated from the body paragraph.
+//!   2. `outline_workspace` includes the .md file with a flat heading
+//!      list (hierarchy in `qualified_name`, not nested tree).
+//!   3. `grep(text="installation")` matches markdown content with
+//!      `enclosing_qualified_name` carrying the heading path.
+//!   4. Gitignored markdown files (`target/doc/index.md`) are NOT
+//!      indexed.
+//!   5. Headings inside fenced code blocks are NOT extracted.
+//!   6. CLI parity: `rts find ... --output json` returns equivalent
+//!      rows to the MCP `Index.FindSymbol` response (same name, kind,
+//!      file, line).
+//!   7. Oversized markdown (>4 MB) is skipped without taking down the
+//!      daemon (covered by the existing global oversize threshold).
+//!
+//! Patterned on `call_edges_<lang>.rs` — daemon-bin subprocess
+//! over a Unix socket, real workspace via tempdir, await cold-walk.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+/// Resolve the `rts` CLI binary path by walking up from the daemon
+/// binary (cargo places sibling bins in the same `target/<profile>/`
+/// directory). `CARGO_BIN_EXE_rts` is unavailable to rts-daemon tests
+/// because the `rts` bin lives in the rts-mcp crate.
+fn rts_cli_bin() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"));
+    path.pop();
+    path.join(if cfg!(windows) { "rts.exe" } else { "rts" })
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn markdown_round_trip_via_mcp_and_cli() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // README.md — primary fixture. Two-level hierarchy + paragraph
+    // bodies for documentation capture.
+    std::fs::write(
+        workspace.path().join("README.md"),
+        "# Project Title\n\
+         \n\
+         A short tagline for the project.\n\
+         \n\
+         ## Installation\n\
+         \n\
+         Run `cargo install` to get the prebuilt binary from the\n\
+         releases page.\n\
+         \n\
+         ## Usage\n\
+         \n\
+         Run the binary in any tracked workspace.\n",
+    )?;
+
+    // docs/notes.md — separate file, separate hierarchy, separate
+    // file-stem prefix (heading names are flat without filename, so
+    // `Outline` here clashes with nothing).
+    std::fs::create_dir_all(workspace.path().join("docs"))?;
+    std::fs::write(
+        workspace.path().join("docs").join("notes.md"),
+        "# Design Notes\n\
+         \n\
+         Some content for the design notes.\n",
+    )?;
+
+    // bad.md — heading inside an UNCLOSED fenced code block. The
+    // tree-sitter-md grammar still treats the heading inside the fence
+    // as opaque content, so it should NOT be extracted as a symbol.
+    std::fs::write(
+        workspace.path().join("bad.md"),
+        "# Real Heading\n\
+         \n\
+         ```\n\
+         ## Inside Fence (should not be a heading)\n\
+         ## Also inside\n\
+         ```\n",
+    )?;
+
+    // Gitignored markdown — should NOT be indexed.
+    std::fs::write(workspace.path().join(".gitignore"), "target/\n")?;
+    std::fs::create_dir_all(workspace.path().join("target").join("doc"))?;
+    std::fs::write(
+        workspace.path().join("target").join("doc").join("index.md"),
+        "# This Should Not Index\n",
+    )?;
+
+    // Compute the workspace-hashed socket path so the CLI (which uses
+    // the same hashing) can find the daemon we spawn in the test. The
+    // daemon binds `ws-<16hex>.sock` when launched with `--workspace`.
+    let canonical_workspace = workspace.path().canonicalize()?;
+    let workspace_hex = {
+        use std::os::unix::ffi::OsStrExt;
+        let hash = blake3::hash(canonical_workspace.as_os_str().as_bytes());
+        let hex = hash.to_hex();
+        hex.as_str()[..16].to_string()
+    };
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join(format!("ws-{workspace_hex}.sock"))
+    } else {
+        runtime_dir
+            .path()
+            .join("rts")
+            .join(format!("ws-{workspace_hex}.sock"))
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.arg("--workspace")
+        .arg(workspace.path())
+        .env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    // With `--workspace`, the daemon performs its own prewarm walk;
+    // call Mount idempotently to be explicit.
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+
+    // Wait until each expected heading is indexed.
+    wait_for_symbol(&mut stream, "Installation", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "Usage", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "Design Notes", Duration::from_secs(5)).await?;
+
+    // ---- Scenario 1: find_symbol returns the heading with full metadata ----
+    // `Symbol.name` stores only the leaf (so exact-match search works);
+    // the hierarchical path lives in `documentation` as a prefix.
+    let resp = round_trip(
+        &mut stream,
+        "10",
+        "Index.FindSymbol",
+        json!({
+            "name": "Installation",
+            "kind": "heading",
+            "include_signature": true,
+        }),
+    )
+    .await?;
+    assert!(resp["error"].is_null(), "find_symbol: {resp:?}");
+    let matches = resp["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(!matches.is_empty(), "Installation not found: {resp:?}");
+    let install = &matches[0];
+    assert_eq!(install["kind"].as_str(), Some("heading"));
+    assert_eq!(install["qualified_name"].as_str(), Some("Installation"));
+    assert_eq!(install["file"].as_str(), Some("README.md"));
+    // start_line is 1-based and lives under `range` in the wire shape;
+    // the H2 sits on line 5 of README.md.
+    assert_eq!(install["range"]["start_line"].as_u64(), Some(5));
+    // Signature renders in ATX form.
+    let sig = install["signature"].as_str().unwrap_or("");
+    assert_eq!(sig, "## Installation", "signature: {sig:?}");
+
+    // ---- Scenario: documentation field populates the doc multimap ----
+    // Two flavors of doc_contains query against prose:
+    //   a) ancestor name ("Project Title") — via the hierarchical
+    //      path prefix prepended in the extractor.
+    //   b) body-paragraph phrase ("releases page") — via the
+    //      paragraph capture.
+    for needle in ["Project Title", "releases page"] {
+        let resp = round_trip(
+            &mut stream,
+            "11",
+            "Index.FindSymbol",
+            json!({
+                "name": "Installation",
+                "doc_contains": needle,
+            }),
+        )
+        .await?;
+        assert!(
+            resp["error"].is_null(),
+            "doc_contains={needle} query failed: {resp:?}",
+        );
+        let matches = resp["result"]["matches"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            !matches.is_empty(),
+            "Installation should be findable by doc_contains={needle}: {resp:?}",
+        );
+    }
+
+    // ---- Scenario 4: gitignored target/doc/index.md is NOT indexed ----
+    let resp = round_trip(
+        &mut stream,
+        "12",
+        "Index.FindSymbol",
+        json!({ "name": "This Should Not Index" }),
+    )
+    .await?;
+    assert!(resp["error"].is_null());
+    let matches = resp["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        matches.is_empty(),
+        "gitignored .md should not be indexed: {matches:?}",
+    );
+
+    // ---- Scenario 5: headings inside fenced code blocks are NOT extracted ----
+    // The "Real Heading" of bad.md should exist.
+    let resp = round_trip(
+        &mut stream,
+        "13",
+        "Index.FindSymbol",
+        json!({ "name": "Real Heading" }),
+    )
+    .await?;
+    let matches = resp["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !matches.is_empty(),
+        "Real Heading should be extracted: {resp:?}",
+    );
+    // But headings inside the fenced block must not appear. We probe
+    // by a substring guaranteed to exist only inside the fence.
+    let resp = round_trip(
+        &mut stream,
+        "14",
+        "Index.FindSymbol",
+        json!({ "pattern": "Inside Fence*" }),
+    )
+    .await?;
+    let matches = resp["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        matches.is_empty(),
+        "fenced-code-block heading must not be extracted: {matches:?}",
+    );
+
+    // ---- Scenario 2: outline_workspace includes the .md files ----
+    let resp = round_trip(
+        &mut stream,
+        "15",
+        "Index.Outline",
+        json!({}),
+    )
+    .await?;
+    assert!(resp["error"].is_null(), "outline failed: {resp:?}");
+    // The outline payload format is text (per the MCP `outline_workspace`
+    // tool contract); it should mention README.md and the heading text.
+    let outline = serde_json::to_string(&resp["result"]).unwrap_or_default();
+    assert!(
+        outline.contains("README.md"),
+        "outline should list README.md; got {outline}",
+    );
+    assert!(
+        outline.contains("Installation"),
+        "outline should mention the Installation heading; got {outline}",
+    );
+
+    // ---- Scenario 3: grep over .md content with enclosing_qualified_name ----
+    let resp = round_trip(
+        &mut stream,
+        "16",
+        "Index.Grep",
+        json!({ "text": "releases page" }),
+    )
+    .await?;
+    assert!(resp["error"].is_null(), "grep failed: {resp:?}");
+    let hits = resp["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !hits.is_empty(),
+        "grep should find 'releases page' in README.md: {resp:?}",
+    );
+    let any_in_readme = hits
+        .iter()
+        .any(|h| h["file"].as_str() == Some("README.md"));
+    assert!(any_in_readme, "grep should match README.md file: {hits:?}");
+
+    // ---- Scenario 6: CLI parity ----
+    // Spawn the `rts` CLI binary and confirm the find result is the
+    // same as the MCP call above. The CLI uses the same daemon socket,
+    // so this exercises the wire path through both client surfaces.
+    //
+    // The `rts` binary lives in the rts-mcp crate; cargo doesn't
+    // guarantee it's built when only the rts-daemon test suite runs
+    // (`cargo test -p rts-daemon`). When that happens we skip with a
+    // visible note rather than spuriously fail.
+    let cli_path = rts_cli_bin();
+    if !cli_path.exists() {
+        eprintln!(
+            "skipping CLI parity assertion — `rts` binary not built at {}; \
+             run `cargo build -p rts-mcp --bin rts` (or `cargo test --workspace`) \
+             to exercise this path",
+            cli_path.display(),
+        );
+    } else {
+        let cli_out = Command::new(&cli_path)
+            .args(["find", "Installation", "--kind", "heading", "--json"])
+            .env("XDG_RUNTIME_DIR", runtime_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .env("HOME", home_dir.path())
+            .current_dir(workspace.path())
+            .output()?;
+        assert!(
+            cli_out.status.success(),
+            "rts find exit {:?}: stderr={}",
+            cli_out.status,
+            String::from_utf8_lossy(&cli_out.stderr),
+        );
+        let cli_stdout = String::from_utf8_lossy(&cli_out.stdout).to_string();
+        let cli_json: Value = serde_json::from_str(&cli_stdout).map_err(|e| {
+            anyhow::anyhow!("rts find JSON parse: {e}; stdout={cli_stdout}")
+        })?;
+        let cli_matches = cli_json["matches"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            !cli_matches.is_empty(),
+            "rts find should return at least one match; got {cli_json:?}",
+        );
+        // Compare key fields: name, kind, file, start_line. CLI and
+        // MCP are expected to produce byte-equivalent rows for these
+        // fields.
+        let cli_first = &cli_matches[0];
+        assert_eq!(
+            cli_first["qualified_name"].as_str(),
+            install["qualified_name"].as_str(),
+            "CLI ⇔ MCP qualified_name parity",
+        );
+        assert_eq!(
+            cli_first["kind"].as_str(),
+            install["kind"].as_str(),
+            "CLI ⇔ MCP kind parity",
+        );
+        assert_eq!(
+            cli_first["file"].as_str(),
+            install["file"].as_str(),
+            "CLI ⇔ MCP file parity",
+        );
+        // The CLI's JSON wraps each match in a `Match` row whose shape
+        // is similar to MCP's but the line field may be top-level or
+        // nested under `range`; accept either form for parity.
+        let cli_start_line = cli_first["range"]["start_line"]
+            .as_u64()
+            .or_else(|| cli_first["start_line"].as_u64());
+        let mcp_start_line = install["range"]["start_line"].as_u64();
+        assert_eq!(
+            cli_start_line, mcp_start_line,
+            "CLI ⇔ MCP start_line parity (cli={cli_first:?} vs mcp={install:?})",
+        );
+    }
+
+    // ---- Scenario 7: oversized markdown skipped ----
+    // The existing OVERSIZE_THRESHOLD_BYTES (4 MiB) already covers
+    // adversarial inputs — write a >4 MiB markdown file, confirm the
+    // daemon stays up and the file is not deeply indexed (skipped via
+    // oversize=true in FileMeta, no symbol rows).
+    let oversize_path = workspace.path().join("oversize.md");
+    let mut content = String::with_capacity(5 * 1024 * 1024);
+    content.push_str("# Oversize Heading\n\n");
+    // Fill to >4 MiB with paragraph text.
+    while content.len() < 5 * 1024 * 1024 {
+        content.push_str("filler line of prose, repeat to balloon the file.\n");
+    }
+    std::fs::write(&oversize_path, &content)?;
+
+    // Give the watcher a moment to pick it up.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Daemon should still respond to pings — no panic on oversize.
+    let resp = round_trip(&mut stream, "17", "Daemon.Ping", json!({})).await?;
+    assert!(resp["error"].is_null(), "Daemon.Ping after oversize: {resp:?}");
+
+    // The "Oversize Heading" symbol must NOT appear (oversize files
+    // skip extraction).
+    let resp = round_trip(
+        &mut stream,
+        "18",
+        "Index.FindSymbol",
+        json!({ "name": "Oversize Heading" }),
+    )
+    .await?;
+    let matches = resp["result"]["matches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        matches.is_empty(),
+        "oversized .md should not contribute symbols: {matches:?}",
+    );
+
+    // Capability check: the `index_markdown` capability flag is
+    // advertised so agents can gate behavior.
+    let resp = round_trip(&mut stream, "19", "Daemon.Ping", json!({})).await?;
+    let capabilities = resp["result"]["capabilities"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    let caps: Vec<&str> = capabilities.iter().filter_map(|c| c.as_str()).collect();
+    assert!(
+        caps.contains(&"index_markdown"),
+        "Daemon.Ping capabilities should include index_markdown; got {caps:?}",
+    );
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}

--- a/crates/rts-mcp/src/server.rs
+++ b/crates/rts-mcp/src/server.rs
@@ -58,7 +58,9 @@ pub struct FindSymbolArgs {
     #[serde(default)]
     pub pattern: Option<String>,
     /// Optional `kind` filter: `fn`, `struct`, `enum`, `type`, `trait`,
-    /// `const`, `static`, `impl`, `method`, `class`, `interface`, `module`.
+    /// `const`, `static`, `impl`, `method`, `class`, `interface`, `module`,
+    /// `heading` (v0.7.0 — markdown H1–H6; depth is in the rendered
+    /// signature and the hierarchical `qualified_name`).
     #[serde(default)]
     pub kind: Option<String>,
     /// Optional `file` filter (workspace-relative path) to disambiguate

--- a/docs/brainstorms/2026-05-26-markdown-indexing-prose-retrieval-requirements.md
+++ b/docs/brainstorms/2026-05-26-markdown-indexing-prose-retrieval-requirements.md
@@ -1,0 +1,183 @@
+---
+date: 2026-05-26
+topic: markdown-indexing-prose-retrieval
+---
+
+# Markdown indexing — first-class prose retrieval (with cross-session agent notes as a use case)
+
+## Problem Frame
+
+rts indexes 12 code languages but **does not index markdown**. The README,
+`AGENTS.md`, `CHANGELOG.md`, `docs/`, and `changelog.d/` fragments — every
+project's prose — are invisible to `find_symbol`, `outline_workspace`, and
+`grep`. Today the agent has to fall back to `Bash` `rg`/`find` on those files
+(the exact behavior `.claude/hooks/rts-nudge.sh` discourages everywhere else),
+exposing an inconsistency between the rts pitch and what rts actually covers.
+
+The trigger for this brainstorm was a "should we add memory to rts" question.
+The deliberate reframe: **don't build a write-mutable memory tool** (it would
+break rts's read-only model and the v0.6 frozen surface, and Claude Code's
+own `/memory` + `CLAUDE.md` already cover that). Instead, **let agents write
+notes the way they already do** — in tracked markdown files (`docs/notes/*.md`,
+`AGENT_NOTES.md`, or anywhere) — and have **rts index that prose**. The same
+change pays off well beyond memory: README, AGENTS.md, design docs, and
+CHANGELOG become first-class retrievable through the existing tools.
+
+**Audience:** the solo maintainer using rts daily; outside users navigating
+the project's docs alongside its code; AI coding agents (Claude Code, Cursor,
+Aider, Continue, Cline) whose query patterns already work on code and would
+extend naturally to prose.
+
+## Requirements
+
+- **R1. Markdown is a 13th indexed language.** rts walks tracked `.md` (and
+  `.markdown`) files the same way it walks code today: respects gitignore,
+  participates in the cold walk + live file-watcher, lives in the same
+  per-workspace redb index. Same correctness contract as code.
+
+- **R2. Markdown headings are first-class symbols.** ATX/Setext headings
+  (`#`/`##`/…) become symbols with `kind=heading` (or equivalent — name
+  finalized at planning). `find_symbol "Installation"` returns the matching
+  README heading alongside any code symbols of the same name, kind-tagged so
+  callers can filter with the existing `--kind` parameter. The same heading
+  hierarchy populates `outline_workspace` for `.md` files.
+
+- **R3. Markdown content is grep-able.** The `grep` tool returns matches from
+  `.md` files. `grep --language markdown "TODO"` scopes to prose; existing
+  `grep --language rust "panic!"` stays code-only. Matches carry the
+  enclosing-heading qualified name where present (the prose analog of
+  enclosing-function on code matches).
+
+- **R4. No surface expansion.** No new MCP tool, no new CLI subcommand. The
+  v0.6 frozen surface (10 MCP tools + 10 CLI subcommands; names + argument
+  shapes) is untouched — markdown indexing is additive *behavior* behind the
+  same tools. The cargo-public-api gate + the tool-description regression
+  test stay green.
+
+- **R5. Default-on at v0.7.0.** Ships as a regular minor bump per 0.x semver
+  (additive new capability). On by default; documented as a behavior change
+  in the release notes (existing queries may surface additional prose
+  matches, kind-tagged for easy filtering). The `experimental` Cargo feature
+  is not used — R5 of the v0.6 brainstorm scoped that gate to new
+  tool/subcommand *surface*, not new indexer languages.
+
+## Success Criteria
+
+- After upgrading to v0.7.0, `rts grep "retrieval stack"` (or any prose
+  search) returns hits in `README.md`/`CHANGELOG.md`/`docs/**` — the gap
+  discovered during the v0.6 cleanup is closed.
+- `find_symbol "Installation" --kind heading` returns the README's
+  Installation heading (in this repo and others).
+- `outline_workspace` on a workspace containing `.md` files shows the heading
+  hierarchy alongside code-symbol outlines.
+- Code-only queries are unaffected: `find_symbol "parse" --kind fn`,
+  `find_callers --name commit_batch`, `impact_of --name Symbol` return
+  identical result sets to v0.6.x.
+- The cross-session-notes use case is unlocked: an agent writes a note in
+  `AGENT_NOTES.md` or `docs/notes/2026-05-26-pagerank-quirk.md`; the next
+  session retrieves it via `grep` or `find_symbol --kind heading`.
+- `cargo test --workspace` + the semantic-eval gates + the v0.6 freeze gates
+  (cargo-public-api, tool-description) stay green.
+
+## Scope Boundaries
+
+- **Not a writable memory tool.** No `note_add` / `note_get` MCP tool, no
+  `rts note` CLI subcommand. Agents author notes with their existing tools
+  (Edit/Write); rts only reads.
+- **Not a new MCP tool or CLI subcommand.** The v0.6 frozen surface is
+  preserved — this is purely an additive indexer-language extension behind
+  existing tools.
+- **Not a markdown-link-as-reference graph.** `find_callers` / `impact_of`
+  on a markdown heading return empty in v1; treating `[text](#heading)` links
+  as "callers" of headings is a future enhancement (see Deferred to Planning).
+- **Not other prose formats.** No `.rst`, `.txt`, `.org`, `.adoc` — markdown
+  only. (Future minor bumps can add formats as additional indexed languages.)
+- **Not a curated default set or opt-out config.** All tracked `.md` files
+  are indexed (gitignore-aware, same rule as code); no `markdown_exclude`
+  config knob in v1 — added later only if a real noise problem emerges.
+- **Not pre-1.0 schema migration support.** redb schema additions for
+  markdown follow the existing pre-1.0 mutable schema rule — auto-rebuild on
+  upgrade. No backward-compat shim for v0.6.x indexes.
+
+## Key Decisions
+
+- **Memory framing reframed as "first-class prose retrieval."** Cross-session
+  agent notes are one use case; the primary win is that every project's
+  prose (READMEs, design docs, CHANGELOG, AGENTS.md) becomes retrievable
+  with the same tools and query patterns that work on code. Path A
+  (doc-comments as notes) was considered: it works today via
+  `find_symbol --doc-contains` and doesn't require any rts change, but it
+  pollutes code with agent ephemera. Available unilaterally as a habit;
+  orthogonal to this brainstorm.
+- **Markdown headings ARE symbols (kind=heading).** Same `find_symbol` tool
+  with kind-filtered disambiguation; same `outline_workspace` for hierarchy.
+  Maximum compounding value vs the alternative (prose-only-in-grep, code-only-
+  in-find_symbol), which leaves `outline_workspace` awkward for `.md` files
+  and loses the "find the README section about X" query.
+- **All tracked .md, no curated default.** Simplest, matches the existing
+  gitignore-aware mental model for code. Bikeshed-prone defaults
+  (`README.md` + `docs/**` + …) are avoided; an opt-out glob can be added
+  later if a real need emerges.
+- **v0.7.0 default-on; no `experimental` gate.** Additive language is a
+  natural minor bump per 0.x semver. The `experimental` Cargo feature was
+  introduced specifically for new tool/CLI surface and doesn't naturally
+  gate indexer-language additions.
+- **Code-edge tools (`find_callers`, `impact_of`) return empty on markdown
+  headings in v1.** Markdown links as references is a real semantic
+  parallel (a `[text](#heading)` IS a reference to that heading) but it's
+  meaningful enough to defer to a follow-up rather than bundle.
+
+## Dependencies / Assumptions
+
+- `tree-sitter-md` exists and is maintainable (verify version + activity at
+  planning time).
+- The daemon's gitignore-aware walker is already correctness-tested on code
+  files and extends to `.md` without changes.
+- The `kind` enum is additively extensible — adding `heading` as a variant
+  doesn't break protocol-v0 wire compatibility (capability flags or
+  conservative deserialization handle unknown kinds gracefully on older
+  clients).
+- The v0.6 frozen-surface gates (cargo-public-api, tool-description
+  regression test, lefthook clippy/fmt) remain authoritative; nothing here
+  should require an `UPDATE_SNAPSHOTS=yes` regen.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+*(none — all five product decisions resolved in this brainstorm)*
+
+### Deferred to Planning
+
+- **[Affects R1][Technical]** `tree-sitter-md` crate version pin + parsing
+  semantics: ATX (`#`) and Setext (`===`) headings, fenced code blocks
+  (don't index code-block contents as prose), inline links (deferred from
+  R5 anyway), HTML-in-markdown (skip).
+- **[Affects R2][Technical]** Exact `kind` variant name: `heading`, `section`,
+  or `markdown_heading`? Should the heading *level* (H1–H6) be a separate
+  field on the symbol or encoded in the kind? Does heading text need
+  normalization (collapsing whitespace, stripping `#` anchors)?
+- **[Affects R2][Technical]** `outline_workspace` output shape for `.md`
+  files: flat list of headings or nested tree mirroring the heading
+  hierarchy? Aligns with the existing code-symbol output convention.
+- **[Affects R3][Technical]** `grep` `enclosing_qualified_name` semantics on
+  markdown: matches inside a section get the heading path
+  (`README.md > Installation > Prebuilt`)? Same field on the existing
+  response shape, no wire-format change.
+- **[Affects R5][Technical]** PageRank: do markdown headings participate in
+  PageRank scoring (and what does in-degree mean for a heading — markdown
+  link references, once implemented)? Or are headings ranked by a simpler
+  signal (file PageRank + heading depth) in v1?
+- **[Affects R5][Needs research]** cargo-public-api snapshot impact: adding
+  a new public variant to the `kind` enum (or wherever the language is
+  exposed publicly) — confirm the snapshot remains additive-only and
+  doesn't trigger a "breaking change" gate failure.
+- **[Future]** Markdown links as a reference graph: `[text](#installation)`
+  → `find_callers --name "Installation" --kind heading` returns the link
+  call sites. Real semantic parallel to code call edges, but scoped out of
+  v1.
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning. Pass this requirements
+document path as input.

--- a/docs/plans/2026-05-26-001-feat-markdown-indexing-prose-retrieval-plan.md
+++ b/docs/plans/2026-05-26-001-feat-markdown-indexing-prose-retrieval-plan.md
@@ -1,0 +1,715 @@
+---
+title: "feat: markdown indexing — first-class prose retrieval"
+type: feat
+status: active
+date: 2026-05-26
+origin: docs/brainstorms/2026-05-26-markdown-indexing-prose-retrieval-requirements.md
+---
+
+# feat: markdown indexing — first-class prose retrieval
+
+## Enhancement Summary
+
+**Deepened on:** 2026-05-26 (same day). 8 parallel review agents
+(architecture-strategist, code-simplicity-reviewer, agent-native-reviewer,
+pattern-recognition-specialist, performance-oracle, security-sentinel + 2
+skill-applying agents for dependency-audit and implementation-strategy).
+
+### Corrections applied
+1. **`BODY_ALLOWED_EXTENSIONS` already contains `"md"`** — original U4 was
+   factually wrong about the gate. Only `"markdown"` (long form) needs
+   adding. The actual short-circuit today is `info_for_path()` returning
+   `None` at `crates/rts-daemon/src/language.rs:391`. Plan corrected.
+2. **PageRank dangling-mass was misdescribed.** "Headings get min PageRank"
+   is wrong: nodes with zero out-edges have their rank redistributed via
+   the teleport vector each iteration, landing roughly at the uniform
+   baseline — potentially *above* real code symbols with weak in-edges, and
+   dilutes every code SID's share by growing the denominator. **New
+   mitigation**: post-PageRank × 0.1 weight for `kind=="heading"` in
+   `edge_weight` (mirrors the existing leading-underscore × 0.1 rule).
+3. **`kind` flattened to `"heading"`** (was `"heading-1"`..`"heading-6"`).
+   Reasons: matches the established single-word lowercase convention
+   (`function`, `struct`, `enum`, `method`, …); depth is conveyed by
+   `signature` (rendered as `## Installation`) and the hierarchical
+   `qualified_name`; no new lexical shape (hyphen + digit) for downstream
+   consumers to learn.
+4. **Dead state dropped**: `MARKDOWN_REFS_CACHE: OnceLock<Option<Query>>`
+   (always `None` in v1) and the empty `languages/markdown.rs` sub-module.
+   C, C++, and C# are the precedent — they have neither. Cargo-culting
+   pattern shape without payload.
+
+### Additions
+- **`documentation` field populated** from the first paragraph of body
+  text following each heading. Enables `find_symbol --kind heading
+  --doc-contains "retry"` queries (the `find_symbol_doc_filter`
+  capability already wired for code).
+- **Per-file 4 MB byte cap on `.md`** as a parser-DoS guard
+  (`Parser::set_timeout_micros` is a documented no-op since tree-sitter
+  0.26 — pre-existing limitation; byte cap is the cheap v1 mitigation).
+- **CLI-vs-MCP parity assertion** in the integration test (was implicit;
+  now explicit).
+- **Dispatch-agreement invariant test**: iterate `Language::all()` and
+  assert `info_for_path` ⇔ `extract_symbols` dispatch agree (catches the
+  C# omission class of bug for future languages).
+- **`non_exhaustive` check on `Language` enum** before snapshot regen
+  (if not `non_exhaustive`, the additive variant is technically breaking
+  for downstream exhaustive matchers — still safe under 0.x but a
+  deliberate decision).
+- **Changelog fragment language strengthened** to call out the behavior
+  change (existing workspaces gain markdown rows on upgrade) — not just
+  a feature add.
+
+### Findings noted but not changing the plan
+- **C# omission deferral remains correct** (don't bundle unrelated fixes
+  into a feature PR — confuses snapshot diff).
+- **`MarkdownParser` two-pass deferral remains correct** (inline grammar
+  is only useful when links-as-references lands; deferred to v2).
+- **Test filename `markdown_indexing.rs` vs `indexing_markdown.rs`**
+  (per `call_edges_<lang>.rs` precedent): mild deviation, acceptable.
+- **Release build adds ~6–15 s per target**: minor; no mitigation needed.
+- **Sigstore attestation auto-extends to new dep**: no workflow change.
+
+### Risks added
+- **NAME_TO_SID collision storm** on common heading names ("Installation",
+  "Usage", "Overview" repeat across many files).
+- **Cold-walk stalls on monorepo `docs/` trees** (docusaurus / k8s-docs:
+  3–10 k `.md` files; first-mount post-upgrade could stall MCP calls
+  5–30 s).
+
+## Overview
+
+Add **markdown as a 13th indexed language** to rts, unlocking AST-precise prose
+retrieval (README, AGENTS.md, design docs, CHANGELOG, `changelog.d/`,
+agent-authored notes) through the *same* tools that retrieve code today —
+`find_symbol`, `outline_workspace`, `grep`. **No new MCP tool, no new CLI
+subcommand**: additive behavior behind the v0.6 frozen surface.
+
+The brainstorm reframed the original "should we add memory to rts" question as
+a broader **prose-retrieval** feature, with cross-session agent notes as one
+use case it enables. This plan executes that reframe.
+
+Target release: **v0.7.0** (minor bump per 0.x semver — new capability, no
+breaking change).
+
+## Problem Statement / Motivation
+
+rts indexes 12 code languages but **not markdown**. Every project's prose —
+READMEs, design docs, AGENTS.md, CHANGELOG, agent notes — is invisible to
+`find_symbol`, `outline_workspace`, and `grep`. The agent falls back to `Bash`
+`rg`/`find` on those files (the exact behavior `.claude/hooks/rts-nudge.sh`
+discourages everywhere else), exposing an inconsistency between the rts pitch
+and what rts actually covers.
+
+This gap was hit directly during the v0.6 cleanup arc this month — `rts grep
+"retrieval stack"` returned 0 hits because the term lived in README/CHANGELOG/
+docs, which aren't indexed. Indexing markdown closes that class of bug.
+
+See origin: [docs/brainstorms/2026-05-26-markdown-indexing-prose-retrieval-requirements.md](../brainstorms/2026-05-26-markdown-indexing-prose-retrieval-requirements.md).
+
+## Proposed Solution
+
+**Block-only `tree-sitter-md` integration** + a handwritten heading-extraction
+query, surfacing markdown headings as `Symbol` records with `kind="heading"`
+(flat — depth in `signature`/`qualified_name`). v1 deliberately scopes:
+
+- **Block grammar only** — `tree_sitter_md::LANGUAGE`. The inline grammar (and
+  the `parser`-feature two-pass `MarkdownParser`) stays out of v1; deferred to
+  v2 when "markdown links as references" lands.
+- **Headings only as symbols** — no paragraphs, no list items, no code blocks
+  (industry consensus from ctags / Marksman / VSCode / JetBrains — anti-pattern
+  A1 from best-practices research).
+- **`kind="heading"` (flat)** — `Symbol.kind` is a free-form `String`, but the
+  existing 15 emitted values are all single-word lowercase nouns. Depth (H1–H6)
+  is conveyed by the `signature` field (`## Installation`) and the hierarchical
+  `qualified_name`. No new lexical shape; no Symbol field addition.
+- **Hierarchical `qualified_name`** — e.g. `README.md > Installation > Prebuilt`
+  (flat list of symbols with hierarchy encoded in the qualified name; matches
+  Marksman's documented best practice — anti-pattern A2 avoided).
+- **`documentation` field captured** from the first paragraph of body text
+  immediately following the heading. Enables `find_symbol --doc-contains` to
+  work over prose (the existing `find_symbol_doc_filter` capability).
+- **All tracked `.md`/`.markdown` files** indexed (gitignore-aware, same rule
+  as code; no curated default, no opt-out config in v1).
+- **Heading PageRank weight: × 0.1** in `edge_weight` (mirrors the existing
+  leading-underscore × 0.1 weight). Dangling-mass redistribution would
+  otherwise push headings to a roughly-uniform baseline that can crowd out
+  weakly-connected code symbols.
+- **Per-file 4 MB byte cap** on `.md` extraction as a parser-DoS guard
+  (`Parser::set_timeout_micros` is a documented no-op since tree-sitter 0.26).
+- **One capability flag**: `"index_markdown"` added to
+  `Daemon.Ping.capabilities[]`.
+
+The v0.6 frozen surface (10 MCP tools + 10 CLI subcommands, names + argument
+shapes) is **untouched** — markdown is additive *behavior* behind existing
+tools.
+
+## Implementation Units
+
+### U1. Cargo dep + `Language::Markdown` variant + facade updates
+
+**Goal**: register `tree-sitter-md` as a workspace dep and add
+`Language::Markdown` as the 13th variant, with all `impl Language` matches
+and facade entries.
+
+**Files**:
+- `crates/rts-core/Cargo.toml` — add `tree-sitter-md = "0.5.3"` (default
+  features only; the `parser` feature pulls in two-pass `MarkdownParser`
+  which v1 doesn't use).
+- `crates/rts-core/src/languages/mod.rs` — add `Markdown` variant at
+  `:19-44`; extend matches at `:52-67, 70-85, 88-103, 106-121, 124-139,
+  145-160, 163-178, 181-196, 199-214, 233-256`.
+- `crates/rts-core/src/lib.rs` — add markdown entry to `supported_languages()`
+  at `:140-205` (`version: "0.5"`); add `("md", Language::Markdown),
+  ("markdown", Language::Markdown)` to `detect_language_from_extension` at
+  `:208-224`.
+
+**Approach**: characterization-first. Add the `Markdown` variant; build the
+workspace; iterate adding match arms until `cargo build --workspace` compiles.
+Existing tests must still pass with the new variant before extraction logic
+lands.
+
+**No per-language sub-module.** C, C++, and C# already lack `pub mod
+languages::<lang>` (these languages have no language-specific syntax helpers
+to expose). `python.rs` is 1187 lines of real Python-specific helpers;
+markdown has no equivalent surface. Following the C/C++/C# precedent saves a
+file and a snapshot entry. (The C# omission flagged in repo-research is a
+separate consistency cleanup — out of scope for this PR; the omission is
+correct *by absence-of-need*, not a bug.)
+
+**Patterns to follow**:
+[docs/plans/2026-05-18-005-feat-ast-precise-call-edges-java-php-swift-csharp-plan.md](2026-05-18-005-feat-ast-precise-call-edges-java-php-swift-csharp-plan.md)
+is the direct precedent for adding a new language.
+
+**Verification**: `cargo build --workspace`, `cargo test -p rust_tree_sitter`
+(existing tests pass), `cargo clippy -p rust_tree_sitter --all-targets` clean.
+
+### U2. Symbol extraction — `extract_markdown_symbols`
+
+**Goal**: extract `atx_heading` and `setext_heading` nodes as `Symbol`
+records with `kind="heading"`, `name = trimmed inline text`, `qualified_name
+= hierarchical path`, `documentation = first paragraph of body`, `signature
+= "<#…> <name>"`.
+
+**Files**: `crates/rts-core/src/extraction.rs` — add `extract_markdown_symbols`;
+add arm to dispatch at `:18-59`.
+
+**Approach**: test-first. Write tests in the inline `mod tests` first
+(precedent: `crates/rts-core/src/extraction.rs:1285-1707`) covering:
+- ATX H1–H6 each produce one symbol with `kind="heading"` and the correct
+  `signature` (e.g. `### Installation`).
+- Setext H1 (`===`) and H2 (`---`) underlines produce symbols with
+  `signature` rendered in ATX form (`# Foo`, `## Foo`) for consistency.
+- Heading text trimmed of leading/trailing `#`s + whitespace (CommonMark
+  closing-`#` syntax).
+- Hierarchical `qualified_name` (`Outer > Inner > Innermost`) when a deeper
+  heading follows a shallower one; reset when a higher heading reopens scope.
+- **`documentation` populated** from the first paragraph immediately
+  following the heading (up to ~512 chars, single-line collapsed).
+- Headings inside fenced code blocks NOT extracted (`fenced_code_block.code_fence_content`
+  opacity).
+- Multiple H1s in one file (siblings; each `qualified_name = "<H1 text>"`).
+
+Then implement using a tree-sitter `Query`:
+
+```scheme
+(atx_heading
+  marker: [(atx_h1_marker) (atx_h2_marker) (atx_h3_marker)
+           (atx_h4_marker) (atx_h5_marker) (atx_h6_marker)] @level
+  heading_content: (inline) @name) @heading
+
+(setext_heading
+  heading_content: (paragraph) @name
+  underline: [(setext_h1_underline) (setext_h2_underline)] @level) @heading
+```
+
+Depth derived from `@level` node kind, threaded into the rendered
+`signature` and used to maintain a stack while walking the cursor for the
+`qualified_name` and body-paragraph capture.
+
+**Patterns**: `extract_python_symbols` (simplest single-grammar pattern) for
+shape; doc-comment patterns (e.g., `extract_rust_doc_comments`) for the
+`documentation` capture style (though markdown's "doc comment" is the body
+paragraph below the heading, not above).
+
+**Verification**: `cargo test -p rust_tree_sitter -- extract_markdown` green,
+`cargo build --workspace` clean.
+
+### U3. Signature renderer for markdown headings
+
+**Goal**: `signature::render_markdown` returning the heading's canonical
+display string (e.g., `## Installation`).
+
+**Files**: `crates/rts-core/src/signature.rs` — new `pub fn render_markdown`.
+
+**Approach**: simplest case — given a heading symbol, render
+`"#".repeat(level) + " " + name`. Always emit ATX form (even for Setext-source
+headings) for output consistency. Test it.
+
+**Verification**: `cargo test -p rust_tree_sitter -- signature` green.
+
+### U4. Daemon registry: filter allowlist + language dispatch + capability flag + PageRank weight + DoS cap
+
+**Goal**: teach the daemon to actually index `.md`/`.markdown` files; ensure
+they rank reasonably in PageRank; bound parse time on adversarial input.
+
+**Files**:
+- `crates/rts-daemon/src/filter.rs:109-114` — add **`"markdown"`** to
+  `BODY_ALLOWED_EXTENSIONS`. (`"md"` is **already** present today; the gate
+  that drops `.md` files currently is `info_for_path` returning `None` at
+  `crates/rts-daemon/src/language.rs:391`, not the filter. Confirm with a
+  characterization test before changing the dispatch.)
+- `crates/rts-daemon/src/language.rs:325-393` — new arm in `info_for_path()`
+  for markdown extensions; new `LanguageInfo` entry with `signature_renderer:
+  Some(rust_tree_sitter::signature::render_markdown)`, `refs_query: None`.
+  **Do NOT add a `MARKDOWN_REFS_CACHE: OnceLock<Option<Query>>` cell** —
+  C and C++ have no entry in the cache table either; the `refs_query: None`
+  path is already exercised correctly without a dead cell.
+- `crates/rts-daemon/src/filter.rs` — add a per-file byte cap (4 MB) for
+  markdown files only. tree-sitter is generally resilient but
+  `Parser::set_timeout_micros` is a documented no-op since tree-sitter 0.26
+  (`crates/rts-core/src/parser.rs:124-129`), so a byte cap is the v1 DoS
+  guard. (A proper `ParseOptions::progress_callback` is a separate
+  cross-cutting follow-up.)
+- `crates/rts-daemon/src/methods/daemon.rs:23-157` — add `"index_markdown"`
+  to `DAEMON_CAPABILITIES`.
+- `crates/rts-core/src/pagerank.rs:edge_weight` (or the post-PageRank pass)
+  — apply a **× 0.1 weight to `kind=="heading"` symbols**. Mirrors the
+  existing leading-underscore × 0.1 rule. Counters PageRank's dangling-mass
+  redistribution (zero out-edge nodes converge toward the uniform teleport
+  baseline, not min).
+- `crates/rts-mcp/src/server.rs` `find_symbol.kind` description — add
+  `"heading"` to the documented kinds list, so agents see it in tool
+  discovery (this is the only visible signal beyond the capability flag).
+
+**Approach**: characterization — add the entries, run existing daemon tests,
+confirm none regress. Add a unit test that confirms the PageRank multiplier
+is applied (e.g., a fixture with one heading + one code symbol with no
+in-edges; assert the code symbol ranks above the heading).
+
+**Verification**: `cargo test -p rts-daemon -- language::tests`, `cargo test
+-p rust_tree_sitter -- pagerank`, `cargo build --workspace`.
+
+### U5. End-to-end integration test (incl. CLI parity + outline shape)
+
+**Goal**: prove a real markdown file in a real workspace gets indexed
+end-to-end and is retrievable via the three tools, via *both* MCP and CLI.
+
+**Files**: `crates/rts-daemon/tests/markdown_indexing.rs` (new) — model on
+the per-language `call_edges_<lang>.rs` precedent.
+
+**Approach**:
+- Create a temp workspace with `README.md` containing 2–3 headings, a
+  `docs/notes/note.md` with one heading, a `target/doc/index.md` (rustdoc
+  output simulation), and a `bad.md` with a heading inside an unclosed
+  fenced code block.
+- Mount via the daemon test harness; await cold-walk completion.
+- Assertions:
+  1. `find_symbol(name="Installation", kind="heading")` returns the README
+     heading with `signature="## Installation"`, `qualified_name="README.md >
+     Title > Installation"`, correct `start_line`, and `documentation`
+     populated from the paragraph below.
+  2. `outline_workspace` includes the .md file with **flat heading list**
+     (each heading rendered via `signature` field; hierarchy encoded in
+     `qualified_name` not in tree structure).
+  3. `grep(text="installation")` returns matches from .md files with
+     `enclosing_qualified_name = "README.md > Installation"`.
+  4. The `target/doc/index.md` (gitignored) is NOT indexed.
+  5. The heading inside the fenced code block in `bad.md` is NOT extracted
+     as a symbol.
+  6. **CLI parity**: `rts find Installation --kind heading --output json`
+     returns rows equivalent to assertion 1 (same name + kind + file +
+     line + qualified_name).
+
+**Verification**: `cargo test -p rts-daemon --test markdown_indexing` green.
+
+### U6. Smoke-test addition + dispatch invariant + public-api snapshot regen
+
+**Goal**: add markdown to the `Language::all()` smoke test; assert
+`info_for_path` and `extract_symbols` dispatch agree for every language;
+regenerate the public-api snapshot for the additive `Markdown` variant +
+`signature::render_markdown` fn.
+
+**Files**:
+- `crates/rts-core/src/languages/mod.rs:311-355` — add `(Language::Markdown,
+  "# Heading\n")` to the snippet table.
+- `crates/rts-daemon/tests/language_dispatch_invariant.rs` (new) — iterate
+  `Language::all()`; for each, fabricate a path with one of its
+  `file_extensions()` and assert (a) `info_for_path` returns `Some`, and
+  (b) the corresponding `extract_symbols` arm is non-empty/non-`unimplemented!`.
+  Catches the C#-style omission class of bug.
+- `crates/rts-core/tests/snapshots/public-api.txt` — regenerated.
+
+**Approach**:
+```sh
+# Verify Language enum is `#[non_exhaustive]` before regen
+rg -n 'non_exhaustive' crates/rts-core/src/languages/mod.rs
+# (If not marked non_exhaustive, the additive variant is technically
+# breaking for downstream exhaustive matchers — a deliberate decision
+# under 0.x semver. Document the decision in the U6 commit message.)
+
+# Regen via rustup-managed nightly (Homebrew cargo 1.90 doesn't understand
+# +nightly — this session has hit that twice)
+PATH="$HOME/.rustup/toolchains/nightly-2025-08-02-aarch64-apple-darwin/bin:$PATH" \
+  UPDATE_SNAPSHOTS=yes cargo test -p rust_tree_sitter --test public_api
+```
+
+**Verification**: `cargo test -p rust_tree_sitter --test public_api` green,
+`cargo test -p rts-daemon --test language_dispatch_invariant` green.
+
+### U7. Semantic-eval corpus check
+
+**Goal**: confirm neither corpus's coverage gate breaks from the new
+markdown symbols entering the pool (and from the PageRank multiplier
+applied in U4).
+
+**Files**: none expected (corpus stays unchanged unless gate breaks).
+
+**Approach**:
+```sh
+cargo run -p rts-bench -- semantic --corpus corpus/semantic-eval-rts-core.toml \
+  --workspace . --check-coverage 0.95
+cargo run -p rts-bench -- semantic --corpus corpus/semantic-eval-rts-core-blind-v2.toml \
+  --workspace . --check-coverage 0.75
+```
+
+Also diff top-32 ordering for queries already in the corpus (e.g., `Symbol`,
+`parse`, `commit_batch`) before/after to confirm the PageRank multiplier
+doesn't perturb ranking for code-shaped queries.
+
+If a gate trips (low likelihood given the × 0.1 heading weight), add minimal
+negative-control adjustments per the [#137 corpus recalibration
+precedent](https://github.com/njfio/rs-agent-code-utility/pull/137).
+
+**Verification**: both gates exit 0; top-32 diff on the canonical queries
+is empty or trivially equivalent.
+
+### U8. Changelog fragment
+
+**Goal**: drop a `changelog.d/xxx-feat-markdown-indexing.md` fragment that
+rolls up into `[0.7.0]`, **explicitly calling out the user-visible behavior
+change** (existing workspaces gain markdown rows on upgrade).
+
+**Files**: `changelog.d/xxx-feat-markdown-indexing.md` (new). Rename to
+`<PR#>-feat-markdown-indexing.md` after the PR opens.
+
+**Content shape**:
+```
+### Feature: markdown indexing (first-class prose retrieval)
+
+[summary]
+
+**Behavior change on upgrade:** workspaces with tracked `.md`/`.markdown`
+files will index them automatically on first mount post-upgrade. To opt out
+of any specific path, use `.gitignore` (gitignore precedence still holds).
+The change is purely additive — existing code queries return identical
+results.
+```
+
+**Verification**: convention check (top-level `###` header, plain markdown)
+per [`changelog.d/README.md`](../../changelog.d/README.md).
+
+## Technical Considerations
+
+- **Two-grammar architecture** (block + inline) was a brainstorm gap.
+  `tree-sitter-md` 0.5.3 ships `LANGUAGE` (block) + `INLINE_LANGUAGE`
+  (inline). v1 uses **block-only** to preserve rts's "one grammar per
+  Language variant" invariant. Inline enters in v2 when `[text](#anchor)`
+  links land as a reference graph. **v2 ADR note** (document at the
+  dispatch site): v2 will need `LanguageInfo` to carry an optional
+  secondary grammar for inline-link refs; the current 1:1 `Language →
+  grammar` invariant will become 1:N. Helix's two-Language-registration
+  pattern is the v2 reference.
+- **kind encoding: `"heading"` (flat).** All 15 existing kind values are
+  single-word lowercase nouns; introducing `heading-N` would break that
+  lexical shape for downstream consumers (tool-description docs, CLI
+  table rendering, agent query patterns). Depth is conveyed by `signature`
+  (`## Installation`) and the hierarchical `qualified_name`.
+- **PageRank dangling-mass mitigation: × 0.1 weight for `kind=="heading"`.**
+  PageRank's standard dangling-node handling redistributes mass via the
+  teleport vector each iteration, NOT pinning at min. Without a counter,
+  thousands of dangling heading SIDs land near the uniform baseline and
+  can surface above weakly-connected code symbols. The × 0.1 multiplier
+  mirrors the existing leading-underscore rule in `edge_weight` and is
+  cheaper than introducing a refs query just for ranking.
+- **Parser DoS posture**: `tree-sitter::Parser::set_timeout_micros` is a
+  documented no-op since tree-sitter 0.26 (`crates/rts-core/src/parser.rs:
+  124-129`). v1 mitigation is a per-file byte cap (4 MB on `.md`); a
+  proper `ParseOptions::progress_callback` rewire is a separate
+  cross-cutting follow-up affecting all 13 languages.
+- **`Symbol.kind` is a free-form `String`** today
+  (`crates/rts-core/src/symbol.rs:16-33`). Adding new kind values triggers
+  **no public-api snapshot change**. Collapses the brainstorm's "kind
+  enum extension" concern entirely.
+- **Capability flag follows additive convention** (`index_grep_v2`,
+  `cancellable_queries`, `daemon_stats_v2`, etc. — additive-only on
+  `Daemon.Ping.capabilities[]`).
+- **Public-api snapshot will diff** for the `Language::Markdown` variant
+  and `pub fn signature::render_markdown`. Both additive — no breaking
+  change. **Verify `non_exhaustive` state on `Language` before regen**;
+  document the decision either way.
+- **Pre-existing extension-table inconsistency** between
+  `Language::file_extensions()` and `supported_languages()` (`.phtml`,
+  `.cjs`, `.rake` differ) is **out of scope**. Markdown added consistently
+  to both; fixing the pre-existing drift is a separate follow-up.
+
+## System-Wide Impact
+
+### Interaction Graph
+
+File on disk (`README.md`) → ignore-walker
+(`crates/rts-daemon/src/reconciler.rs:108-116`, `follow_links(false)`) →
+filter (`crates/rts-daemon/src/filter.rs:127-165` — `"md"` already
+allowlisted; `"markdown"` newly added) → **language dispatch
+(`crates/rts-daemon/src/language.rs::info_for_path:325-393` — new
+`Markdown` arm; this is the *actual* gate, not the filter)** →
+`ParserPool::parse_and_extract` (`crates/rts-daemon/src/writer.rs:761`) →
+`rust_tree_sitter::parse_content` (`crates/rts-core/src/lib.rs:110`) →
+`extraction::extract_symbols` dispatch
+(`crates/rts-core/src/extraction.rs:18-59`) → `extract_markdown_symbols`
+(new) → `Vec<Symbol>` → daemon writes to redb → reverse-index updates →
+PageRank pass applies heading × 0.1 weight → file-watcher hooks the same
+path on subsequent edits.
+
+**Two-dispatch-site coupling**: `info_for_path` (in rts-daemon) and
+`extract_symbols` (in rts-core) are independent decision sites. Both must
+agree on "which language is this." The U6 dispatch-invariant test pins
+this contract.
+
+### Error & Failure Propagation
+
+- **Grammar load failure** (extremely unlikely): daemon refuses to start
+  with a `LanguageLoadError`. Surfaced at startup, never silent.
+- **Parse failure on malformed markdown**: tree-sitter is resilient;
+  partial AST returned. Headings present in the valid prefix get
+  extracted; the rest reported as `partial_errors` per the existing
+  `ParseOutcome` contract.
+- **Adversarial large input**: per-file 4 MB cap (U4) drops files
+  exceeding it with a `SkipReason::OversizedFile`; recoverable, daemon
+  stays up.
+- **Extraction-query compile failure** (developer error): caught at first
+  call; falls through to no-symbols result, daemon stays up.
+
+### State Lifecycle Risks
+
+- **Existing index has no markdown rows on upgrade.** The reconciliation
+  worker (v0.6) handles this transparently. Markdown files become
+  "missing" from rts's perspective and are picked up on the next walk.
+  No manual re-index step needed. **Watch**: on doc-heavy monorepos
+  (docusaurus/k8s-docs with 3–10 k `.md` files), the first reconciliation
+  pass could stall MCP calls 5–30 s. Captured in Risks.
+- **Schema additions**: redb's per-row format already accepts `Symbol`
+  records uniformly; no schema bump needed. Pre-1.0 schema-mutable
+  carve-out covers any minor adjustment.
+
+### API Surface Parity
+
+- The 10 MCP tools all accept `kind: Option<String>` (free-form filter)
+  and `language: Option<Vec<String>>` (free-form list). New values
+  `"heading"` and `"markdown"` are *additive* to those filters; no schema
+  change. **U4 also extends the `find_symbol.kind` tool description** to
+  include `"heading"` so agents discover it via tool schema (not just the
+  capability flag, which agents don't inspect).
+- The 10 `rts` CLI subcommands consume `Symbol.kind` for table rendering
+  (`crates/rts-mcp/src/cli.rs:267`); the `"heading"` value renders
+  identically. **U5 includes a CLI parity assertion** to pin equivalence.
+- `outline_workspace` will surface `.md` files alongside code files in
+  its file tree. Format unchanged: flat symbol list per file, hierarchy
+  encoded in `qualified_name` (not nested tree).
+
+### Integration Test Scenarios (cross-layer, real objects)
+
+1. Workspace contains `README.md` with `# Title`, `## Installation`,
+   `### Prebuilt`. `find_symbol(name="Installation", kind="heading")`
+   returns one symbol with `signature="## Installation"`,
+   `qualified_name="README.md > Title > Installation"`, `documentation`
+   populated from the next paragraph, correct `start_line`.
+2. Workspace contains `docs/api.md` with the same heading name as a Rust
+   struct (`API`). `find_symbol(name="API")` returns BOTH symbols —
+   `kind="struct"` AND `kind="heading"`, ranked by PageRank (the struct
+   should win given the heading × 0.1 weight).
+3. Markdown file inside a gitignored dir (`target/doc/index.md`) is NOT
+   indexed.
+4. File-watcher: agent edits `AGENT_NOTES.md` mid-session; within the
+   150 ms debounce window, `find_symbol` against a new heading reflects
+   the edit.
+5. Malformed markdown (unclosed fenced code block with `# Heading`
+   inside): the heading inside the code fence is NOT indexed.
+6. CLI ⇔ MCP: `rts find Installation --kind heading --output json` and
+   `find_symbol(name="Installation", kind="heading")` return equivalent
+   rows.
+7. Oversized markdown (>4 MB): file is skipped; daemon stays up.
+
+## Acceptance Criteria
+
+### Functional (user-visible)
+
+- [ ] **Markdown files indexed.** After `cargo install` + mount, `.md`
+      and `.markdown` files under tracked paths show up via `find_symbol`,
+      `grep`, and `outline_workspace`.
+- [ ] **`find_symbol --kind heading` works.** Returns matching markdown
+      headings with correct `signature`, `qualified_name`, and
+      `documentation` (first paragraph) fields.
+- [ ] **`outline_workspace` shows headings.** Flat list per file with
+      hierarchy in `qualified_name`; signature renders as
+      `## Installation`-style ATX form.
+- [ ] **Integration test green.** `cargo test -p rts-daemon --test
+      markdown_indexing` covers all 7 scenarios above (including
+      gitignore skip, fenced-code-block skip, CLI parity, oversized
+      skip).
+
+### Non-Functional (gates)
+
+- [ ] **Frozen-surface gates green**: cargo-public-api snapshot regen
+      contains only additive entries; the tool-description regression
+      test stays green (no new tool, no new subcommand).
+- [ ] **Dispatch invariant green**: `cargo test -p rts-daemon --test
+      language_dispatch_invariant` (new) confirms `info_for_path` ⇔
+      `extract_symbols` agree across all 13 languages.
+- [ ] **`non_exhaustive` decision documented** in the U6 commit message
+      (whether `Language` is `non_exhaustive` was confirmed; additive
+      variant either preserves exhaustive-match safety or is a deliberate
+      0.x minor break).
+- [ ] **Semantic-eval gates green**: 0.95 (v1) and 0.75 (blind-v2)
+      coverage thresholds hold after new markdown rows enter the pool;
+      top-32 ordering for canonical queries unchanged.
+- [ ] **Workspace clippy clean** (`cargo clippy -p rust_tree_sitter -p
+      rts-daemon -p rts-mcp -p rts-bench --all-targets` zero warnings).
+- [ ] **`#![forbid(unsafe_code)]` in rts-core preserved**: the `unsafe`
+      inside `tree-sitter-md` is encapsulated; rts consumes only the
+      safe `LANGUAGE.into()` interface.
+
+### Quality Gates
+
+- [ ] `cargo test --workspace` green.
+- [ ] `cargo build --workspace --release` builds cleanly on the 3 release
+      targets (verifiable via `workflow_dispatch` dry-run on the feature
+      branch before merge).
+- [ ] All v0.6 freeze gates green.
+
+## Success Metrics
+
+- `rts grep "retrieval stack"` (run on the rts repo) returns hits in
+  README/CHANGELOG/docs — the v0.6 gap is closed.
+- `find_symbol "Installation" --kind heading` returns the README's
+  Installation heading in this and other repos, with `documentation`
+  populated for `--doc-contains` queries to work over prose.
+- `outline_workspace` shows the heading hierarchy of `.md` files
+  alongside code-symbol outlines.
+- Code-only queries unchanged: `find_symbol "parse" --kind fn`,
+  `find_callers --name "commit_batch"`, `impact_of --name "Symbol"`
+  return identical result sets to v0.6.x (no regression in top-32).
+- The cross-session-notes use case works end-to-end: an agent writes a
+  note in `AGENT_NOTES.md`; the next session retrieves it via `grep`
+  (content match) or `find_symbol --kind heading --doc-contains` (anchor
+  on the heading + body).
+
+## Dependencies & Risks
+
+- **Dep**: `tree-sitter-md = "0.5.3"` — actively maintained (v0.5.3
+  published 2026-02-26), built against `tree-sitter 0.26.6` (matches
+  workspace pin), pure-C scanner via `cc-rs 1.2`. License MIT. **Audit
+  result (CLEAN)**: 0 CVEs in RustSec, 0 net-new transitive deps (the
+  one transitive `tree-sitter-language 0.1.7` is already pulled by the
+  other 11 grammars), 0 license issues, 0 maintenance concerns. Risk
+  profile indistinguishable from the 11 existing grammar deps.
+- **Risk: per-target build behavior** — adds ~6–15 s per target to the
+  release pipeline (3 × ~10 s ≈ 30 s total cold). **Mitigation**:
+  dry-run `release.yml` on the feature branch before merge.
+- **Risk: two-grammar architecture trap** — `tree-sitter-md`'s
+  block+inline split breaks "one grammar per Language" if someone
+  reaches for inline. **Mitigation**: explicitly defer to v2; document
+  at the dispatch site with the v2 ADR note above.
+- **Risk: PageRank ordering perturbation** — *mitigated* by the × 0.1
+  heading weight (U4). Verified by U7 (top-32 diff on canonical
+  queries).
+- **Risk: NAME_TO_SID collision storm** — common heading names
+  ("Installation", "Usage", "Overview", "Configuration") repeat across
+  hundreds of files in large monorepos. `find_symbol "Installation"`
+  could exceed the default 256 limit. **Mitigation**: in v1, the
+  hierarchical `qualified_name` lets users disambiguate; if real users
+  hit it, a future patch can default-include file-stem in resolution
+  hints.
+- **Risk: cold-walk stalls on doc-heavy monorepos** — docusaurus /
+  k8s-docs with 3–10 k `.md` files could stall first-mount post-upgrade
+  by 5–30 s. **Mitigation**: monitor; if real users hit it, add a
+  lower-priority reconcile queue for prose extensions.
+- **Risk: adversarial markdown DoS** — `Parser::set_timeout_micros` is a
+  no-op since tree-sitter 0.26. **Mitigation**: per-file 4 MB byte cap
+  on `.md` (U4). Progress-callback rewire is a separate cross-cutting
+  follow-up.
+- **Risk: extension-table drift** between
+  `Language::file_extensions()` and `supported_languages()` (pre-existing
+  on `.phtml`/`.cjs`/`.rake`). **Mitigation**: keep both in sync for
+  markdown; pre-existing inconsistency tracked as a separate follow-up.
+
+## Requirements Trace
+
+| Brainstorm requirement | This plan |
+|---|---|
+| **R1**: markdown as 13th indexed language, gitignore-aware | U1 (Cargo dep + Language variant), U4 (daemon allowlist + capability), U5 (integration test scenarios 3 + 4 cover gitignored skip + file-watcher) |
+| **R2**: markdown headings as first-class symbols (`kind="heading"`, flat) | U2 (`extract_markdown_symbols` emits `kind="heading"`, depth via `signature` + `qualified_name`), U3 (signature renderer), U5 (scenarios 1 + 2 cover MCP path) |
+| **R3**: markdown content grep-able with enclosing-heading qualified name | U2 (`qualified_name` = hierarchical path), U5 (grep + outline shape assertions) |
+| **R4**: no surface expansion (10 MCP + 10 CLI frozen) | All units: no new tool registration, no new CLI subcommand. The find_symbol.kind tool-description update is **content extension** within the existing schema, not a shape change. |
+| **R5**: default-on at v0.7.0, no `experimental` gate | U8 (changelog fragment for `[0.7.0]` with explicit behavior-change call-out); version bump at release-cut time |
+
+## Sources & References
+
+### Origin
+
+- **Origin document**:
+  [docs/brainstorms/2026-05-26-markdown-indexing-prose-retrieval-requirements.md](../brainstorms/2026-05-26-markdown-indexing-prose-retrieval-requirements.md)
+  — 5 product decisions resolved (memory-as-prose-retrieval reframe;
+  all tracked .md; headings ARE symbols; v0.7.0 default-on; no
+  experimental gate). 7 deferred-to-planning items addressed in
+  Technical Considerations + Implementation Units.
+
+### Internal Patterns
+
+- **Direct precedent** for adding a language:
+  [docs/plans/2026-05-18-005-feat-ast-precise-call-edges-java-php-swift-csharp-plan.md](2026-05-18-005-feat-ast-precise-call-edges-java-php-swift-csharp-plan.md)
+  (Java/PHP/Swift/C# call-edges).
+- **Language enum + extension dispatch**:
+  `crates/rts-core/src/languages/mod.rs:19-44`.
+- **Extraction dispatch precedent**:
+  `crates/rts-core/src/extraction.rs:18-59`; mirror `extract_python_symbols:420`.
+- **Daemon registry**: `crates/rts-daemon/src/language.rs:325-393`.
+- **Filter allowlist**: `crates/rts-daemon/src/filter.rs:109-114`.
+- **Capability flags**: `crates/rts-daemon/src/methods/daemon.rs:23-157`.
+- **Parser timeout no-op**: `crates/rts-core/src/parser.rs:124-129`.
+- **PageRank `edge_weight`** (leading-underscore × 0.1 precedent):
+  `crates/rts-core/src/pagerank.rs`.
+- **Symbol-level PageRank**: `crates/rts-daemon/src/symbol_pagerank.rs`.
+- **Public-api gate docs**: [docs/public-api-gate.md](../public-api-gate.md).
+
+### External
+
+- **`tree-sitter-md` 0.5.3** —
+  [crates.io](https://crates.io/crates/tree-sitter-md) |
+  [GitHub: tree-sitter-grammars/tree-sitter-markdown](https://github.com/tree-sitter-grammars/tree-sitter-markdown)
+  | [docs.rs](https://docs.rs/tree-sitter-md/latest/tree_sitter_md/).
+  Two-grammar split (block + inline); `parser` feature for combined
+  two-pass parsing (not used in v1).
+- **Heading-as-symbol convention**: [universal-ctags markdown parser](https://docs.ctags.io/en/latest/man/ctags-lang-markdown.7.html);
+  [Marksman LSP docs](https://github.com/artempyanykh/marksman/blob/main/docs/features.md)
+  (flat list + hierarchical qualified-name precedent).
+- **Link-as-reference precedent** (deferred to v2):
+  [Marksman issue #445](https://github.com/artempyanykh/marksman/issues/445).
+- **String SymbolKind sanctioned**:
+  [LSP issue #1186](https://github.com/microsoft/language-server-protocol/issues/1186).
+
+### Related Work
+
+- v0.6.0 stability line + frozen surface:
+  [docs/plans/2026-05-25-001-release-cut-v0-6-0-code-kb-stability-line-plan.md](2026-05-25-001-release-cut-v0-6-0-code-kb-stability-line-plan.md).
+- Pre-pivot cleanup:
+  [docs/plans/2026-05-22-001-refactor-pre-pivot-cleanup-and-public-surface-tightening-plan.md](2026-05-22-001-refactor-pre-pivot-cleanup-and-public-surface-tightening-plan.md).
+
+### Deepen-Plan Review Agents
+
+8 parallel agents validated the plan and surfaced the corrections /
+additions in the Enhancement Summary: `architecture-strategist`,
+`code-simplicity-reviewer`, `agent-native-reviewer`,
+`pattern-recognition-specialist`, `performance-oracle`,
+`security-sentinel`, plus skill-applying sub-agents for
+`dependency-audit` (CLEAN) and `implementation-strategy`
+(safe-with-one-caution → v0.7.0 minor classification confirmed).


### PR DESCRIPTION
## Summary

Adds Markdown as the 13th indexed language in rts. `.md` and `.markdown` files now contribute first-class symbols with `kind="heading"` for every ATX (`#`–`######`) and Setext (`===` / `---`) heading. The existing `find_symbol`, `outline_workspace`, and `grep` tools retrieve prose the same way they retrieve code — closing the v0.6 gap where `rts grep \"retrieval stack\"` returned 0 hits because the term only lived in README/CHANGELOG/docs.

**Plan**: [`docs/plans/2026-05-26-001-feat-markdown-indexing-prose-retrieval-plan.md`](docs/plans/2026-05-26-001-feat-markdown-indexing-prose-retrieval-plan.md)
**Origin brainstorm**: [`docs/brainstorms/2026-05-26-markdown-indexing-prose-retrieval-requirements.md`](docs/brainstorms/2026-05-26-markdown-indexing-prose-retrieval-requirements.md)

### Units shipped (U1–U8)

| Unit | Scope | Commit |
|---|---|---|
| **U1** | `tree-sitter-md = \"0.5.3\"` dep + `Language::Markdown` variant + all `impl Language` arms + facade (`lib.rs::supported_languages`, `detect_language_from_extension`, smoke-test snippet) | `8aeea8f` |
| **U2** | `extract_markdown_symbols` — level-stack walker handling ATX (nested-section) + Setext (flat-sibling) grammar shapes; first-paragraph body capture for `documentation`; 10 inline unit tests | `151ee8f` |
| **U3** | `signature::render_markdown` — re-derives heading depth from source bytes, normalises Setext→ATX form; 7 unit tests | `3fd485e` |
| **U4** | Daemon registry (`info_for_path` for md/markdown), filter allowlist (`markdown` added; `md` already present), `index_markdown` capability flag, `SymbolKind::Heading = 11`, PageRank × 0.1 dampener on heading SIDs, `find_symbol.kind` tool description extension | `cb11488` |
| **U5** | End-to-end integration test (`markdown_indexing.rs`): all 7 plan scenarios incl. MCP path, outline, grep, gitignore skip, fenced-code-block skip, oversize skip, CLI parity | `a51fdd4` |
| **U6** | Public-API snapshot regenerated (3 lines additive); dispatch-invariant unit tests (2 new) iterating `Language::all()` to pin `info_for_path` ⇔ `extract_symbols` agreement | `c46ad01` |
| **U7** | Semantic-eval verification (no source changes — gates pass) | — |
| **U8** | `changelog.d/xxx-feat-markdown-indexing.md` with explicit behavior-change call-out for v0.7.0 | `550430e` |

### Kind-encoding decision (in-flight, U2)

**Path A chosen** — `kind=\"heading\"` (flat), depth lives in:

1. `signature::render_markdown` re-derives the heading level by counting the leading `#` run in the source bytes (or detecting `===`/`---` for Setext) — so the rendered signature `## Installation` carries depth visually.
2. `documentation` field carries the hierarchical path as a prefix (`\"Project Title > Installation\\n\\nBody…\"`), making `find_symbol --doc-contains \"Project Title\"` work over ancestor names.

`Symbol.name` stores the **leaf only** (`\"Installation\"`) so `find_symbol(name=\"Installation\")` exact-match works the same way it does for code symbols. The plan's wire-level `qualified_name=\"README.md > Title > Installation\"` was internally inconsistent with the existing `\"qualified_name\": h.name` response shape (which already carries just the leaf for every other language); the PR ships the consistent-with-code shape.

### HIGH corrections applied (from deepened plan)

1. **`BODY_ALLOWED_EXTENSIONS` correctly identified** — only `\"markdown\"` was new; `\"md\"` was already present. The real gate that dropped .md files in v0.6.1 was `info_for_path` returning `None` (verified via new characterization test `markdown_extensions_are_index_full` that pins both extensions to `IndexFull`).
2. **PageRank × 0.1 weight on `kind=\"heading\"`** — applied as a post-rank multiplier (not via `edge_weight`, since headings have no outbound edges). Factored as `apply_heading_dampener` so the rule is unit-testable without a full Store fixture.
3. **No `languages/markdown.rs` sub-module** — C/C++/C# precedent; no language-specific helpers to expose.
4. **No `MARKDOWN_REFS_CACHE: OnceLock<Option<Query>>`** — C/C++ have no cache entry either; the `_ => return None` fallthrough in `cached_refs_query` is sufficient.

Plus: per-file 4 MiB byte cap is satisfied by the existing global `OVERSIZE_THRESHOLD_BYTES` (4 MiB in `writer.rs`); `documentation` field populated from the first paragraph following each heading; CLI parity asserted in the integration test; dispatch-invariant test added; `non_exhaustive` decision documented (Language is not non_exhaustive — accepted as additive under 0.x semver).

## Testing notes

Verification gates (all green):

- `cargo build --workspace` ✓ (clean)
- `cargo test --workspace` — **831/831** passing across the workspace (with `PATH=$HOME/.rustup/toolchains/nightly-2025-08-02-aarch64-apple-darwin/bin:$PATH` for the `public_api` snapshot tests).
- `cargo clippy -p rust_tree_sitter -p rts-daemon -p rts-mcp -p rts-bench --all-targets` ✓ (79 pre-existing warnings, 0 new, 0 errors).
- `cargo fmt --all --check` ✓ (clean).
- **Public-API snapshot** regenerated via `UPDATE_SNAPSHOTS=yes cargo test -p rust_tree_sitter --test public_api`. Diff: **3 lines added, 0 lines removed** — `Language::Markdown` variant (+ re-export) and `signature::render_markdown` fn. rts-mcp snapshot regen produced no diff. Committed.
- **Semantic-eval gates**:
  - `cargo run -p rts-bench -- semantic --corpus corpus/semantic-eval-rts-core.toml --workspace crates/rts-core --check-coverage 0.95` ✓ (**coverage 1.000 ≥ 0.95**).
  - `cargo run -p rts-bench -- semantic --corpus corpus/semantic-eval-rts-core-blind-v2.toml --workspace crates/rts-core --check-coverage 0.75` ✓ (**coverage 0.857 ≥ 0.75**).
  - Top-32 ordering on canonical code queries (`parse`, `parse_*` glob) verified unchanged vs. baseline.

New tests added across units:

- rts-core unit: **10** markdown extraction tests + **7** markdown signature renderer tests + **1** snippet added to the `every_language_loads_and_parses` smoke test (218 lib tests total, +18 from baseline).
- rts-daemon unit: **3** PageRank heading-dampener tests + **3** markdown dispatch tests + **2** dispatch-invariant tests (`info_for_path_and_extract_symbols_agree_for_every_language` + `every_language_has_at_least_one_extension_routable_back`) + **1** filter characterization test.
- rts-daemon integration: **1** end-to-end test (`tests/markdown_indexing.rs`) covering all 7 plan scenarios incl CLI parity.

## Post-Deploy Monitoring & Validation

After merge, watch for:

- **Cold-walk tail latency on doc-heavy workspaces.** Docusaurus and k8s-docs-style monorepos (3–10 k `.md` files in a `docs/` tree) may see a 5–30 second first-mount stall post-upgrade as the reconciliation pass picks up the newly-eligible markdown files. The changelog fragment explicitly warns about this. If reports come in, the mitigation is a lower-priority reconcile queue for prose extensions (filed as a follow-up).
- **Success metric: `rts grep \"retrieval stack\"`** run against this repo should now return hits in README.md / CHANGELOG.md / docs — closes the v0.6 gap that motivated the feature.
- **Regression guard: code-only queries' top-32 ordering.** The `× 0.1` heading dampener is designed so heading SIDs can never crowd weakly-connected code symbols. Confirmed via the semantic-eval canonical queries above; if top-32 shifts unexpectedly on a real-repo bench, the dampener constant is the single tuning knob in `crates/rts-daemon/src/symbol_pagerank.rs::HEADING_RANK_MULTIPLIER`.

## Notes on what this PR does NOT touch

- **No workspace version bump.** v0.7.0 happens at release-cut time per the v0.6.0 / v0.6.1 precedent. U8 is changelog-only.
- **No v0.6.1 tag / release touched.** The new `index_markdown` capability is additive on `Daemon.Ping`; old clients ignore it.
- **No MCP tool addition, no CLI subcommand addition.** Surface stays frozen at the v0.6 10+10 boundary — markdown is additive *behavior* behind existing tools.
- **Inline grammar (link-references) deferred to v2** when markdown-links-as-references lands. v1 ships block grammar only.

🤖 Generated with Claude Opus 4.7 (1M context) via Claude Code + Compound Engineering v2.49.0