### PR TITLE
feat(cli): expose structural-query grep flags on `rts grep`

### DIFF
--- a/crates/rts-mcp/src/bin/rts.rs
+++ b/crates/rts-mcp/src/bin/rts.rs
@@ -84,8 +84,9 @@ enum Cmd {
     Grep {
         /// Pattern to search for. Default: literal substring,
         /// case-insensitive. Pass `--regex` for the `regex` crate
-        /// syntax, `--case-sensitive` for exact case.
-        pattern: String,
+        /// syntax, `--case-sensitive` for exact case. Optional when
+        /// `--structural-query` provides the search source.
+        pattern: Option<String>,
         /// Treat PATTERN as a regex.
         #[arg(long)]
         regex: bool,
@@ -98,6 +99,29 @@ enum Cmd {
         /// Maximum number of matches.
         #[arg(long)]
         limit: Option<u32>,
+        /// Multi-line regex mode: `.` matches newlines and `^`/`$`
+        /// match line boundaries. Only valid together with `--regex`.
+        #[arg(long)]
+        multiline: bool,
+        /// Tree-sitter S-expression structural query, e.g.
+        /// `(string_literal) @s` or `(call_expression) @c`. Requires
+        /// `--language`. When combined with PATTERN (or `--regex`),
+        /// matches are filtered to text inside the captured nodes —
+        /// e.g. string literals containing a phrase.
+        #[arg(long)]
+        structural_query: Option<String>,
+        /// Restrict matches to the byte range of the named symbol.
+        #[arg(long)]
+        within_symbol: Option<String>,
+        /// Allow `--within-symbol` to resolve to multiple overloaded
+        /// definitions instead of erroring on ambiguity.
+        #[arg(long)]
+        within_symbol_allow_overload: bool,
+        /// Language for `--structural-query` (repeatable), e.g.
+        /// `--language rust`. Required whenever `--structural-query`
+        /// is set.
+        #[arg(long)]
+        language: Vec<String>,
     },
     /// Show direct callers of a symbol.
     Callers {
@@ -385,9 +409,19 @@ async fn run_command(
             case_sensitive,
             glob,
             limit,
+            multiline,
+            structural_query,
+            within_symbol,
+            within_symbol_allow_overload,
+            language,
         } => {
             let mut params = serde_json::Map::new();
-            params.insert("text".into(), Value::String(pattern.clone()));
+            // `text` is optional when `--structural-query` is the search
+            // source; pass it through only when present so the daemon's
+            // validator sees the same shape the caller emitted.
+            if let Some(p) = pattern {
+                params.insert("text".into(), Value::String(p.clone()));
+            }
             if *regex {
                 params.insert("regex".into(), Value::Bool(true));
             }
@@ -399,6 +433,24 @@ async fn run_command(
             }
             if let Some(n) = limit {
                 params.insert("limit".into(), Value::Number((*n).into()));
+            }
+            if *multiline {
+                params.insert("multiline".into(), Value::Bool(true));
+            }
+            if let Some(q) = structural_query {
+                params.insert("structural_query".into(), Value::String(q.clone()));
+            }
+            if let Some(s) = within_symbol {
+                params.insert("within_symbol".into(), Value::String(s.clone()));
+            }
+            if *within_symbol_allow_overload {
+                params.insert("within_symbol_allow_overload".into(), Value::Bool(true));
+            }
+            if !language.is_empty() {
+                params.insert(
+                    "language".into(),
+                    Value::Array(language.iter().cloned().map(Value::String).collect()),
+                );
             }
             let body =
                 match cli::call_method(&client, workspace, "Index.Grep", Value::Object(params))
@@ -421,7 +473,8 @@ async fn run_command(
             }
             let mut stdout = std::io::stdout().lock();
             let n =
-                cli::render_grep_lines(&body, pattern, &mut stdout, style).map_err(io_to_anyhow)?;
+                cli::render_grep_lines(&body, pattern.as_deref().unwrap_or(""), &mut stdout, style)
+                    .map_err(io_to_anyhow)?;
             stdout.flush().map_err(io_to_anyhow)?;
             Ok(if n == 0 { exit::NO_RESULTS } else { exit::OK })
         }

--- a/crates/rts-mcp/src/cli.rs
+++ b/crates/rts-mcp/src/cli.rs
@@ -354,15 +354,27 @@ pub fn render_grep_lines<W: Write>(
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .trim_end_matches('\n');
-        let col = compute_col(line_text, pattern);
-        let highlighted = highlight_match(line_text, pattern, style);
+        // Structural-query matches carry no `line_text`; they expose the
+        // captured node(s) under `captures`. Fall back to the first
+        // capture's text/column so the output stays informative.
+        let (col, content) = if line_text.is_empty() {
+            match structural_capture(m) {
+                Some((text, cap_col)) => (cap_col, highlight_match(&text, pattern, style)),
+                None => (compute_col(line_text, pattern), String::new()),
+            }
+        } else {
+            (
+                compute_col(line_text, pattern),
+                highlight_match(line_text, pattern, style),
+            )
+        };
         writeln!(
             w,
             "{}:{}:{}:{}",
             style.magenta(file),
             style.green(&line.to_string()),
             col,
-            highlighted
+            content
         )?;
     }
     Ok(matches.len())
@@ -371,6 +383,33 @@ pub fn render_grep_lines<W: Write>(
 /// Compute the 1-indexed column (byte offset) of the first
 /// case-insensitive substring match of `pattern` inside `line`. Falls
 /// back to 1 when not found.
+/// Extract a display string + 1-indexed column from a structural-query
+/// match's first capture. Structural matches expose captured nodes under
+/// `captures.<name>[]` (each with `text` and a 0-indexed `start.col`)
+/// instead of the `line_text` that literal/regex matches carry. We show
+/// the first line of the first capture's text.
+fn structural_capture(m: &Value) -> Option<(String, usize)> {
+    let caps = m.get("captures")?.as_object()?;
+    let first = caps
+        .values()
+        .find_map(|arr| arr.as_array().and_then(|a| a.first()))?;
+    let text = first
+        .get("text")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .lines()
+        .next()
+        .unwrap_or("")
+        .to_string();
+    let col = first
+        .get("start")
+        .and_then(|s| s.get("col"))
+        .and_then(|c| c.as_u64())
+        .map(|c| c as usize + 1)
+        .unwrap_or(1);
+    Some((text, col))
+}
+
 fn compute_col(line: &str, pattern: &str) -> usize {
     if pattern.is_empty() {
         return 1;

--- a/crates/rts-mcp/src/cli.rs
+++ b/crates/rts-mcp/src/cli.rs
@@ -340,7 +340,7 @@ pub fn render_grep_lines<W: Write>(
     for m in &matches {
         let file = m.get("file").and_then(|v| v.as_str()).unwrap_or("?");
         let range = m.get("range");
-        let line = range
+        let mut line = range
             .and_then(|r| r.get("start_line"))
             .and_then(|n| n.as_u64())
             .unwrap_or(0);
@@ -355,11 +355,16 @@ pub fn render_grep_lines<W: Write>(
             .unwrap_or("")
             .trim_end_matches('\n');
         // Structural-query matches carry no `line_text`; they expose the
-        // captured node(s) under `captures`. Fall back to the first
-        // capture's text/column so the output stays informative.
+        // captured node(s) under `captures`. Render the first capture and
+        // take its line *and* column so the emitted `path:line:col`
+        // coordinate points at the content we display — the displayed
+        // capture may start on a different line than the match range.
         let (col, content) = if line_text.is_empty() {
             match structural_capture(m) {
-                Some((text, cap_col)) => (cap_col, highlight_match(&text, pattern, style)),
+                Some((cap_line, cap_col, text)) => {
+                    line = cap_line;
+                    (cap_col, highlight_match(&text, pattern, style))
+                }
                 None => (compute_col(line_text, pattern), String::new()),
             }
         } else {
@@ -380,19 +385,28 @@ pub fn render_grep_lines<W: Write>(
     Ok(matches.len())
 }
 
-/// Compute the 1-indexed column (byte offset) of the first
-/// case-insensitive substring match of `pattern` inside `line`. Falls
-/// back to 1 when not found.
-/// Extract a display string + 1-indexed column from a structural-query
-/// match's first capture. Structural matches expose captured nodes under
-/// `captures.<name>[]` (each with `text` and a 0-indexed `start.col`)
-/// instead of the `line_text` that literal/regex matches carry. We show
-/// the first line of the first capture's text.
-fn structural_capture(m: &Value) -> Option<(String, usize)> {
+/// Extract a structural-query match's first capture as a
+/// `(line, 1-indexed col, first-line-of-text)` triple. Structural
+/// matches expose captured nodes under `captures.<name>[]` (each with
+/// `text` and a 0-indexed `start.{line,col}`) instead of the `line_text`
+/// that literal/regex matches carry. Returning the capture's own line
+/// (not the enclosing match `range`) keeps the emitted `path:line:col`
+/// pointing at the rendered content.
+fn structural_capture(m: &Value) -> Option<(u64, usize, String)> {
     let caps = m.get("captures")?.as_object()?;
     let first = caps
         .values()
         .find_map(|arr| arr.as_array().and_then(|a| a.first()))?;
+    let start = first.get("start");
+    let line = start
+        .and_then(|s| s.get("line"))
+        .and_then(|n| n.as_u64())
+        .unwrap_or(0);
+    let col = start
+        .and_then(|s| s.get("col"))
+        .and_then(|c| c.as_u64())
+        .map(|c| c as usize + 1)
+        .unwrap_or(1);
     let text = first
         .get("text")
         .and_then(|v| v.as_str())
@@ -401,15 +415,12 @@ fn structural_capture(m: &Value) -> Option<(String, usize)> {
         .next()
         .unwrap_or("")
         .to_string();
-    let col = first
-        .get("start")
-        .and_then(|s| s.get("col"))
-        .and_then(|c| c.as_u64())
-        .map(|c| c as usize + 1)
-        .unwrap_or(1);
-    Some((text, col))
+    Some((line, col, text))
 }
 
+/// Compute the 1-indexed column (byte offset) of the first
+/// case-insensitive substring match of `pattern` inside `line`. Falls
+/// back to 1 when not found.
 fn compute_col(line: &str, pattern: &str) -> usize {
     if pattern.is_empty() {
         return 1;

--- a/crates/rts-mcp/tests/cli_grep.rs
+++ b/crates/rts-mcp/tests/cli_grep.rs
@@ -85,7 +85,29 @@ async fn grep_structural_string_literal_with_text_filter() {
             p[3].contains("w#"),
             "content should be the matched string literal; got {p:?}"
         );
+        assert_content_on_reported_line(env.workspace_path(), &p);
     }
+}
+
+/// Verify the ripgrep contract for structural matches: the reported
+/// `path:line:col` actually points at the displayed content. Guards the
+/// multi-capture coordinate bug where the rendered capture could start on
+/// a different line than the enclosing match range.
+fn assert_content_on_reported_line(workspace: &std::path::Path, parts: &[&str]) {
+    let (path, line_no, content) = (parts[0], parts[1], parts[3]);
+    let src = std::fs::read_to_string(workspace.join(path))
+        .unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let n: usize = line_no.parse().unwrap();
+    let actual = src.lines().nth(n - 1).unwrap_or_else(|| {
+        panic!(
+            "reported line {n} out of range for {path} ({} lines)",
+            src.lines().count()
+        )
+    });
+    assert!(
+        actual.contains(content.trim()),
+        "reported {path}:{n} must contain shown content {content:?}; line is {actual:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -123,6 +145,7 @@ async fn grep_structural_identifier_usages() {
             p[3].contains("make_widget"),
             "content should be the identifier; got {p:?}"
         );
+        assert_content_on_reported_line(env.workspace_path(), &p);
     }
 }
 

--- a/crates/rts-mcp/tests/cli_grep.rs
+++ b/crates/rts-mcp/tests/cli_grep.rs
@@ -50,6 +50,111 @@ async fn grep_emits_ripgrep_shaped_lines() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_structural_string_literal_with_text_filter() {
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    // The fixture's `format!("w#{w}")` contains a string literal. Scope
+    // to `string_literal` nodes and filter to those containing `w#` —
+    // the thing plain grep cannot do (it would also match comments/code).
+    let out = env
+        .run(&[
+            "--no-color",
+            "grep",
+            "w#",
+            "--structural-query",
+            "(string_literal) @s",
+            "--language",
+            "rust",
+        ])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 0,
+        "string-literal match expected; stdout={stdout:?} stderr={stderr:?}"
+    );
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(!lines.is_empty(), "expected a string-literal match");
+    for line in &lines {
+        let p: Vec<&str> = line.splitn(4, ':').collect();
+        assert_eq!(p.len(), 4, "ripgrep shape required; got {line:?}");
+        assert!(p[1].parse::<u32>().is_ok(), "line numeric; got {p:?}");
+        assert!(p[2].parse::<u32>().is_ok(), "col numeric; got {p:?}");
+        // Content is the captured node text — a string literal with `w#`.
+        assert!(
+            p[3].contains("w#"),
+            "content should be the matched string literal; got {p:?}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_structural_identifier_usages() {
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    // `make_widget` appears as a definition (hub.rs) and call sites
+    // (callers.rs). `(identifier) @i` + text filter finds the usages.
+    let out = env
+        .run(&[
+            "--no-color",
+            "grep",
+            "make_widget",
+            "--structural-query",
+            "(identifier) @i",
+            "--language",
+            "rust",
+        ])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 0,
+        "make_widget usages expected; stdout={stdout:?} stderr={stderr:?}"
+    );
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(
+        lines.len() >= 2,
+        "expected multiple make_widget identifier usages; got {lines:?}"
+    );
+    for line in &lines {
+        let p: Vec<&str> = line.splitn(4, ':').collect();
+        assert_eq!(p.len(), 4, "ripgrep shape required; got {line:?}");
+        assert!(
+            p[3].contains("make_widget"),
+            "content should be the identifier; got {p:?}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_structural_without_language_errors() {
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    // `--structural-query` requires `--language`; the daemon rejects the
+    // call and the CLI surfaces a non-zero exit with a clear message.
+    let out = env
+        .run(&[
+            "--no-color",
+            "grep",
+            "make_widget",
+            "--structural-query",
+            "(identifier) @i",
+        ])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_ne!(
+        code, 0,
+        "structural query without --language must fail; stdout={stdout:?}"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("language"),
+        "error should mention the language requirement; got {combined:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn grep_no_match_exits_one_with_no_output() {
     let env = TestEnv::new();
     seed_minimal_rust_workspace(env.workspace_path());

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,7 +56,7 @@ rts find 'make_*' --pattern
 
 Flags: `--pattern`, `--kind <fn|struct|…>`, `--file <REL>`, `--limit <N>`.
 
-### `rts grep <PATTERN>`
+### `rts grep [PATTERN]`
 
 Literal-substring search across indexed file bytes. Output is
 ripgrep-shaped (`path:line:col:content`), so it composes:
@@ -66,7 +66,25 @@ rts grep TODO | awk -F: '{print $1}' | sort -u
 rts grep --regex '\bunsafe\b' --glob 'crates/**/*.rs'
 ```
 
-Flags: `--regex`, `--case-sensitive`, `--glob <PATTERN>`, `--limit <N>`.
+`--structural-query` scopes matches to tree-sitter node kinds (requires
+`--language`), and combines with `PATTERN`/`--regex` to filter to the text
+inside the captured nodes — searches plain text can't express:
+
+```sh
+# string literals containing a phrase (not comments or code)
+rts grep "connection refused" --structural-query '(string_literal) @s' --language rust
+# usages of a symbol as an identifier node
+rts grep make_widget --structural-query '(identifier) @i' --language rust
+# every call expression in a file (no text filter)
+rts grep --structural-query '(call_expression) @c' --language rust --glob 'src/lib.rs'
+```
+
+`PATTERN` is optional when `--structural-query` provides the search source.
+
+Flags: `--regex`, `--case-sensitive`, `--glob <PATTERN>`, `--limit <N>`,
+`--multiline` (with `--regex`), `--structural-query <QUERY>`,
+`--language <LANG>` (repeatable), `--within-symbol <NAME>`,
+`--within-symbol-allow-overload`.
 
 ### `rts callers <NAME>`
 


### PR DESCRIPTION
## Summary

The daemon's `Index.Grep` and the MCP `grep` tool already implement tree-sitter **structural queries** (`structural_query`, `language`, `within_symbol`, `multiline`), but the `rts grep` *CLI* only exposed `--regex/--case-sensitive/--glob/--limit`. This PR wires the remaining v0.6 grep params through the CLI so terminal users get the same AST-aware search the agent surface already has.

## What this adds to `rts grep`
- `--structural-query <QUERY>` — tree-sitter S-expression node filter, e.g. `(string_literal) @s`. Requires `--language`. Combines with `PATTERN`/`--regex` to filter to text inside the captured nodes.
- `--language <LANG>` (repeatable) — grammar(s) for the structural query.
- `--within-symbol <NAME>` / `--within-symbol-allow-overload` — scope matches to a symbol's byte range.
- `--multiline` — multi-line regex (only with `--regex`).

`PATTERN` is now optional (a structural query can be the sole source), mirroring the daemon/MCP shape. The grep renderer falls back to the captured node's text when a match carries no `line_text`, keeping the `path:line:col:content` contract intact.

## Why
Closes the CLI gaps for **string-literal-scoped search** and **AST-precise usage search** — things plain text/regex grep can't express:

```sh
# string literals containing a phrase (not comments or code)
rts grep "connection refused" --structural-query '(string_literal) @s' --language rust
# usages of a symbol as identifier nodes
rts grep make_widget --structural-query '(identifier) @i' --language rust
```

The CLI stays thin: it only forwards params; the daemon owns validation and execution (the `Index.Grep` v2 composition matrix), so e.g. a structural query without `--language` returns a clear `INVALID_PARAMS` message.

## Testing
- New `cli_grep` tests: string-literal + text filter, identifier-usage, and the missing-`--language` error path.
- Verified end-to-end against the workspace index (string literals, identifier usages, structural-only, validation).
- `cargo fmt --all --check` clean; `cargo clippy -p rts-mcp` clean; `cargo build --workspace --bins` and `cargo test -p rts-mcp` pass.
- Updated `docs/cli.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)