### PR TITLE
fix(daemon): structural grep limit must bound filtered matches, not raw scan

### DIFF
--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -1316,6 +1316,25 @@ pub async fn grep(
             // their CPU-bound compute) — see the v0.3.x comments
             // around `read_symbol_body`'s closure walk for the
             // rationale.
+            // The user's `limit` bounds RETURNED matches. When a
+            // post-scan filter follows (combine literal/regex, or
+            // within_symbol), the scanner must NOT stop at `limit` raw
+            // structural matches — otherwise filtering can shrink the
+            // result below `limit` (often to zero) while matching nodes
+            // remain unscanned (issue #147: `(identifier) @i` + text was
+            // returning empty under a small limit). In that case scan up
+            // to the hard cap and truncate the filtered set to `limit`
+            // below; bounded by STRUCTURAL_MAX_ROWS + the wall-clock
+            // budget. Structural-only queries keep capping at `limit`.
+            let has_post_filter =
+                !matches!(combine, super::grep_v2::compose::StructuralCombine::None)
+                    || shared_filters.within_symbol.is_some();
+            let scan_limit = if has_post_filter {
+                super::grep_v2::limits::STRUCTURAL_MAX_ROWS
+            } else {
+                limit
+            };
+
             let state_clone = state.clone();
             let root_owned = root.clone();
             let query_owned = query.clone();
@@ -1331,7 +1350,7 @@ pub async fn grep(
                     &query_owned,
                     &languages_owned,
                     glob_owned.as_ref(),
-                    limit,
+                    scan_limit,
                     &token_owned,
                 )
             })
@@ -1416,7 +1435,7 @@ pub async fn grep(
 
             // Apply within_symbol filter post-scan if requested.
             // Mirrors the literal/regex path's filter ordering.
-            let final_matches: Vec<_> = if let Some(name) = &shared_filters.within_symbol {
+            let mut final_matches: Vec<_> = if let Some(name) = &shared_filters.within_symbol {
                 let defs = match store_arc.find_symbol(name) {
                     Ok(v) => v,
                     Err(e) => {
@@ -1461,6 +1480,25 @@ pub async fn grep(
                     .collect()
             } else {
                 combine_filtered
+            };
+
+            // Now that all post-scan filters have run, enforce the
+            // user's `limit` on the RETURNED set (issue #147). When a
+            // filter was applied the scan ran up to STRUCTURAL_MAX_ROWS,
+            // so the filtered set may exceed `limit`; truncate here and
+            // flag it. files_with_matches is recomputed from the final
+            // set so it reflects what the caller actually receives.
+            let post_filter_truncated = final_matches.len() > limit;
+            if post_filter_truncated {
+                final_matches.truncate(limit);
+            }
+            let truncated = result.truncated || post_filter_truncated;
+            let files_with_matches = {
+                let mut seen = std::collections::HashSet::new();
+                final_matches
+                    .iter()
+                    .filter(|m| seen.insert(m.file.as_str()))
+                    .count()
             };
 
             // Serialize structural matches to JSON.
@@ -1525,11 +1563,11 @@ pub async fn grep(
 
             return Ok(serde_json::json!({
                 "matches": match_records,
-                "truncated": result.truncated,
+                "truncated": truncated,
                 "rows_seen": result.rows_seen,
                 "rows_returned": final_matches.len(),
                 "files_scanned": result.files_scanned,
-                "files_with_matches": result.files_with_matches,
+                "files_with_matches": files_with_matches,
                 "partial_failures": pfs_json,
             }));
         }

--- a/crates/rts-mcp/tests/cli_grep.rs
+++ b/crates/rts-mcp/tests/cli_grep.rs
@@ -150,6 +150,76 @@ async fn grep_structural_identifier_usages() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_structural_limit_does_not_truncate_before_filter() {
+    // Regression for #147. `format_widget` is the *last* fn def in
+    // hub.rs, so it is never among the first identifier node scanned.
+    // With `--limit 1` the old code capped the raw structural scan at 1
+    // node (`make_widget`), then applied the text filter → 0 matches.
+    // The limit must bound RETURNED matches, so the scan has to continue
+    // past the filtered-out nodes and still find `format_widget`.
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    let out = env
+        .run(&[
+            "--no-color",
+            "grep",
+            "format_widget",
+            "--structural-query",
+            "(identifier) @i",
+            "--language",
+            "rust",
+            "--glob",
+            "**/hub.rs",
+            "--limit",
+            "1",
+        ])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 0,
+        "limit=1 must still find format_widget (not truncate before the \
+         text filter); stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.lines().any(|l| l.contains("format_widget")),
+        "expected format_widget match; got {stdout:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_structural_limit_caps_returned_matches() {
+    // The limit must still be enforced on the returned set. `make_widget`
+    // occurs 4× (def + use + 2 call sites); `--limit 2` returns exactly 2.
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    let out = env
+        .run(&[
+            "--no-color",
+            "grep",
+            "make_widget",
+            "--structural-query",
+            "(identifier) @i",
+            "--language",
+            "rust",
+            "--limit",
+            "2",
+        ])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 0,
+        "expected matches; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert_eq!(
+        stdout.lines().count(),
+        2,
+        "limit=2 must cap returned matches to 2; got {stdout:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn grep_structural_without_language_errors() {
     let env = TestEnv::new();
     seed_minimal_rust_workspace(env.workspace_path());


### PR DESCRIPTION
Fixes #147.

## Problem
Structural grep + a `text`/`regex` filter applied `limit` to the **raw structural scan** before the filter ran, so a small limit returned false empties:

```
rts grep extract_references --structural-query '(identifier) @i' --language rust --glob 'crates/rts-daemon/**' --limit 3
# → matches: [], rows_seen: 6, truncated: true   (matches clearly exist)
```

## Root cause
`structural::run` stops at `cap = row_limit` raw matches (`break 'files`), but the `combine` (literal/regex) and `within_symbol` filters run *afterward* in the grep handler. So the limit capped pre-filter candidates and filtering shrank the set below `limit` (often to zero).

## Fix
When a post-scan filter applies (combine ≠ None, or `within_symbol`), scan up to the hard cap `STRUCTURAL_MAX_ROWS` (4096, already wall-clock bounded at 5s), then truncate the **filtered** result to `limit` and flag `truncated`. `files_with_matches` is recomputed from the returned set. Structural-only queries keep capping at `limit` directly — no behavior/perf change.

## Tests (rts-mcp `cli_grep`, end-to-end through the daemon)
- `grep_structural_limit_does_not_truncate_before_filter`: `--limit 1` still finds `format_widget` (the last def in the file), which the old code truncated away before the text filter. Genuinely fails pre-fix (returned 0 / exit 1).
- `grep_structural_limit_caps_returned_matches`: `--limit 2` still caps the returned set to 2.
- All 7 `cli_grep` tests pass; `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)