### PR TITLE
fix(daemon): serialize mount to stop cold-start redb double-open

### DIFF
--- a/changelog.d/150-fix-mount-race.md
+++ b/changelog.d/150-fix-mount-race.md
@@ -1,0 +1,11 @@
+### Fix: cold-start mount race that wedged the daemon
+
+`Workspace.Mount` now serializes its open-the-store critical section. The
+idempotency check dropped its lock before `Store::open`'s `.await`, so the
+startup prewarm and an explicit `Mount` RPC (or two concurrent RPCs) could
+both open the same redb file — redb refused the second open with "Database
+already open" and the daemon wedged, returning `STORAGE_FULL` on every
+later request until killed. A new `mount_serialize` guard makes mounts
+mutually exclusive: the first opens the store; the rest take the idempotent
+path (and now correctly hold a mount ref). The guarded wait is
+cancel-aware, so a `Daemon.Cancel` no longer hangs a queued mount.

--- a/crates/rts-daemon/src/methods/workspace.rs
+++ b/crates/rts-daemon/src/methods/workspace.rs
@@ -90,6 +90,17 @@ pub(super) async fn mount_inner(
     state: &Arc<DaemonState>,
     cancel: CancelToken,
 ) -> Result<serde_json::Value, ProtocolError> {
+    // Serialize the whole mount critical section. The idempotency check
+    // below drops the `workspace` lock before `Store::open`'s `.await`
+    // (the `MutexGuard` is `!Send`), so without this guard the startup
+    // prewarm task and an explicit `Workspace.Mount` RPC can both pass the
+    // check and both call `Store::open` on the same redb file — redb
+    // refuses the second open with "Database already open" and the daemon
+    // wedges (issue #150). Holding this across check → open → set makes
+    // mounts mutually exclusive: the first opens the store; any concurrent
+    // mount waits here, then falls into the idempotent path below.
+    let _mount_guard = state.mount_serialize.lock().await;
+
     // Idempotent within a connection: a second Mount for the same canonical
     // path returns current status. Held in its own scope so the lock is
     // released before we await the initial walk further down (the
@@ -119,6 +130,19 @@ pub(super) async fn mount_inner(
             }
         }
         // No existing mount; fall through. `current` drops here.
+    }
+
+    // Test-only seam (issue #150 regression). Widens the window between
+    // the idempotency check and `Store::open` so the concurrency test can
+    // deterministically provoke the Mount-vs-Mount / prewarm-vs-Mount
+    // race. No-op unless `RTS_TEST_MOUNT_OPEN_DELAY_MS` is set; never read
+    // in production. With the `mount_serialize` guard held above, only one
+    // mount sits in this window at a time, so the race cannot occur —
+    // which is exactly what the test asserts.
+    if let Ok(ms) = std::env::var("RTS_TEST_MOUNT_OPEN_DELAY_MS") {
+        if let Ok(ms) = ms.parse::<u64>() {
+            tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
+        }
     }
 
     let mounted = workspace::mount(&user_path)?;

--- a/crates/rts-daemon/src/methods/workspace.rs
+++ b/crates/rts-daemon/src/methods/workspace.rs
@@ -99,7 +99,21 @@ pub(super) async fn mount_inner(
     // wedges (issue #150). Holding this across check → open → set makes
     // mounts mutually exclusive: the first opens the store; any concurrent
     // mount waits here, then falls into the idempotent path below.
-    let _mount_guard = state.mount_serialize.lock().await;
+    //
+    // Cancel-aware acquisition: `Workspace.Mount` is a documented
+    // cancellable handler and a mount can queue behind a long cold mount
+    // or prewarm. `CancelToken` is a bare `AtomicBool` with no async wait
+    // primitive, so poll for the guard and honor `Daemon.Cancel` between
+    // ticks instead of hanging for the full mount (#150 review).
+    let _mount_guard = loop {
+        if cancel.is_cancelled() {
+            return Err(ProtocolError::new(ErrorCode::Cancelled, "cancelled"));
+        }
+        match state.mount_serialize.try_lock() {
+            Ok(g) => break g,
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(25)).await,
+        }
+    };
 
     // Idempotent within a connection: a second Mount for the same canonical
     // path returns current status. Held in its own scope so the lock is
@@ -115,6 +129,12 @@ pub(super) async fn mount_inner(
                 Ok(canonical) if canonical.path == existing.canonical.path => {
                     workspace::verify_unchanged(existing)?;
                     let store_snapshot = state.store.lock().ok().and_then(|g| g.clone());
+                    // Count this joiner. A concurrent/idempotent mount of the
+                    // same workspace is a successful mount and must hold a ref;
+                    // otherwise the first `Workspace.Unmount` drops the store
+                    // out from under the other mounted clients (#150 review).
+                    // Mirrors the `fetch_add` on the full-mount path below.
+                    state.mount_refcount.fetch_add(1, Ordering::Relaxed);
                     return Ok(status_payload(existing, state, store_snapshot.as_deref()));
                 }
                 Ok(_other) => {

--- a/crates/rts-daemon/src/state.rs
+++ b/crates/rts-daemon/src/state.rs
@@ -191,6 +191,16 @@ pub struct DaemonState {
     /// path; nothing waits on `prewarm_done`.
     pub prewarm_in_flight: std::sync::atomic::AtomicBool,
     pub prewarm_done: tokio::sync::Notify,
+    /// Serializes the mount critical section (`workspace::mount_inner`).
+    /// The idempotency check drops the `workspace` lock before
+    /// `Store::open`'s `.await` (the guard is `!Send`), so without this
+    /// the startup prewarm and an explicit `Workspace.Mount` RPC can both
+    /// pass the check and both open the same redb file — redb then refuses
+    /// the second open with "Database already open", wedging the daemon
+    /// (issue #150). Held across the whole check-open-set sequence so
+    /// exactly one mount opens the store; the loser observes `workspace`
+    /// already set and returns the idempotent status.
+    pub mount_serialize: tokio::sync::Mutex<()>,
     /// v0.5.7+ per-session call counters. Bumped in `methods::dispatch`
     /// before each handler fires (so even errored calls count — they
     /// still represent agent intent). Surfaced via `Daemon.Stats`.
@@ -658,6 +668,7 @@ impl DaemonState {
             content_version_cache: ContentVersionCache::new(),
             prewarm_in_flight: std::sync::atomic::AtomicBool::new(false),
             prewarm_done: tokio::sync::Notify::new(),
+            mount_serialize: tokio::sync::Mutex::new(()),
             call_counters: CallCounters::default(),
             query_cache: crate::methods::grep_v2::query_cache::QueryCache::new(),
             mount_source: Mutex::new(None),

--- a/crates/rts-daemon/tests/mount_race_round_trip.rs
+++ b/crates/rts-daemon/tests/mount_race_round_trip.rs
@@ -1,0 +1,175 @@
+//! Regression for issue #150: concurrent mounts must not double-open redb.
+//!
+//! `mount_inner`'s idempotency check drops the `workspace` lock before
+//! `Store::open`'s `.await`, so without serialization two concurrent
+//! mounts (the startup prewarm + an explicit `Workspace.Mount` RPC, or
+//! two explicit RPCs) could both pass the check and both call
+//! `Store::open` on the same redb file. redb refuses the second open with
+//! "Database already open" and the daemon wedges — returning
+//! `STORAGE_FULL` on every later request.
+//!
+//! The fix serializes the check-open-register critical section
+//! (`state.mount_serialize`). This test forces the race deterministically
+//! via the `RTS_TEST_MOUNT_OPEN_DELAY_MS` seam (which widens the window
+//! between the idempotency check and `Store::open`) and fires several
+//! concurrent `Workspace.Mount` RPCs. With the guard, exactly one opens
+//! the store and the rest take the idempotent path; without it, the
+//! losers come back `STORAGE_FULL`.
+
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+struct KillOnDrop(Child);
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while !path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "socket {} did not appear within {timeout:?}",
+            path.display()
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// One `Workspace.Mount` on a fresh connection. Returns the parsed
+/// response (which may carry an `error`).
+async fn mount_once(socket: PathBuf, root: PathBuf, id: String) -> anyhow::Result<Value> {
+    let mut stream = UnixStream::connect(&socket).await?;
+    let req = json!({ "id": id, "method": "Workspace.Mount", "params": { "root": root } });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(20), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for Mount response"))??;
+    anyhow::ensure!(n > 0, "EOF before Mount response");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_mounts_never_double_open() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    std::fs::write(
+        workspace.path().join("hub.rs"),
+        "pub fn hub_compute(x: u32) -> u32 { x + 1 }\n",
+    )?;
+
+    // No `--workspace` → no prewarm; the daemon binds `default.sock` and
+    // waits for explicit Mounts. We drive the race purely through
+    // concurrent Mount RPCs + the delay seam.
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        // Widen the check→open window so the concurrent mounts below
+        // deterministically overlap there (no-op in production).
+        .env("RTS_TEST_MOUNT_OPEN_DELAY_MS", "300")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let child = cmd.spawn()?;
+    let _kill = KillOnDrop(child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await;
+
+    // Fire several concurrent Mounts for the same workspace. Pre-fix,
+    // they all pass the idempotency check (workspace empty), sleep in the
+    // widened window together, then all call Store::open → the losers get
+    // STORAGE_FULL. Post-fix, the serialize guard lets exactly one open;
+    // the rest take the idempotent path.
+    let root: PathBuf = workspace.path().to_path_buf();
+    let mut handles = Vec::new();
+    for i in 0..6 {
+        handles.push(tokio::spawn(mount_once(
+            socket_path.clone(),
+            root.clone(),
+            format!("mount-{i}"),
+        )));
+    }
+    for h in handles {
+        let resp = h.await??;
+        assert!(
+            resp["error"].is_null(),
+            "concurrent Mount must not error (issue #150); got {resp:?}"
+        );
+    }
+
+    // Daemon must still be healthy (a wedged daemon returns STORAGE_FULL
+    // on every request). A follow-up query resolves the seeded symbol.
+    let mut stream = UnixStream::connect(&socket_path).await?;
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let req =
+            json!({ "id": "q", "method": "Index.FindSymbol", "params": { "name": "hub_compute" } });
+        let mut bytes = serde_json::to_vec(&req)?;
+        bytes.push(b'\n');
+        stream.write_all(&bytes).await?;
+        stream.flush().await?;
+        let mut buf = Vec::new();
+        let (rd, _wr) = stream.split();
+        let mut reader = BufReader::new(rd);
+        let n = tokio::time::timeout(Duration::from_secs(10), reader.read_until(b'\n', &mut buf))
+            .await??;
+        anyhow::ensure!(n > 0, "EOF before FindSymbol response");
+        let resp: Value = serde_json::from_slice(&buf)?;
+        assert!(
+            resp["error"].is_null(),
+            "daemon wedged after the mount race; got {resp:?}"
+        );
+        let found = resp["result"]["matches"]
+            .as_array()
+            .map(|a| !a.is_empty())
+            .unwrap_or(false);
+        if found {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "symbol never indexed; daemon may be unhealthy"
+        );
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #150.

## Problem
On a cold start, an explicit `Workspace.Mount` arriving while the startup **prewarm** mount is in flight (or two concurrent Mounts) caused both paths to call `Store::open` on the same redb file. redb refuses the second open with `Database already open` (surfaced as `STORAGE_FULL`), and the daemon **wedged** — every later request failed until the process was killed. This is the root cause of the recurring "Database already open" wedges when driving the daemon via the CLI.

## Root cause
`mount_inner` reads `state.workspace` for its idempotency check, then **drops that lock before** `Store::open`'s `.await` (the `MutexGuard` is `!Send`). So check → open → register isn't atomic; two concurrent mounts both pass the check and both open redb.

## Fix
Add `DaemonState::mount_serialize` (async mutex) held across the whole `mount_inner` critical section. Concurrent mounts serialize: the first opens + registers; the rest take the idempotent path. Read RPCs don't go through `mount_inner`, so they're unaffected. This makes the existing `prewarm_in_flight`/`Notify` coordination robust rather than racy.

## Testing
- New `mount_race_round_trip` test: a test-only `RTS_TEST_MOUNT_OPEN_DELAY_MS` seam (no-op in production) widens the check→open window; the test fires 6 concurrent Mounts. **Verified it fails without the guard** (`STORAGE_FULL` on mount-0) **and passes with it.**
- `find_callers_round_trip`, `persisted_cold_mount_round_trip`, `grep_v2_structural_intersection` still pass — normal mount/query flows unaffected.
- Manually verified end-to-end: the prewarm-vs-Mount repro that deterministically wedged the daemon now leaves it healthy.
- `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)