### PR TITLE
fix(daemon): apply structural-grep combine filter inline, not after the row cap

### DIFF
--- a/changelog.d/152-fix-structural-inline-combine.md
+++ b/changelog.d/152-fix-structural-inline-combine.md
@@ -1,0 +1,10 @@
+### Fix: structural grep + text/regex no longer truncates on large scopes
+
+`rts grep --structural-query … <text>` applied the literal/regex
+intersection filter *after* the structural scan was capped at
+`STRUCTURAL_MAX_ROWS` (4096), so on a large scope the cap consumed raw
+structural nodes before the filter ran and real matches past the first
+4096 nodes were silently dropped. The filter now runs **inline** during
+the scan, so the cap counts only matches that satisfy both the structural
+query and the text/regex filter. Regex compile errors fail fast before the
+scan; the per-file post-pass (and its extra file reads) is gone.

--- a/crates/rts-daemon/src/methods/grep_v2/structural.rs
+++ b/crates/rts-daemon/src/methods/grep_v2/structural.rs
@@ -69,6 +69,49 @@ use super::limits::{
 /// this are skipped (counted toward `files_scanned`, no matches).
 const MAX_FILE_BYTES: usize = 4 * 1024 * 1024;
 
+/// Intersection filter applied **inline** during the structural scan so
+/// the row cap counts only matches that satisfy BOTH the structural query
+/// and the literal/regex filter (issue #152). Built by the caller from
+/// the validated `combine` (regex compiled up-front so a bad pattern
+/// fails before the scan).
+pub enum CombineFilter {
+    /// Literal substring over the match's bytes (ASCII case-fold when
+    /// `case_insensitive`). Mirrors v1 grep literal semantics.
+    Literal {
+        needle: Vec<u8>,
+        case_insensitive: bool,
+    },
+    /// Pre-compiled byte regex.
+    Regex(regex::bytes::Regex),
+}
+
+impl CombineFilter {
+    /// Does the match's byte slice satisfy the filter?
+    fn matches(&self, slice: &[u8]) -> bool {
+        match self {
+            CombineFilter::Literal {
+                needle,
+                case_insensitive,
+            } => {
+                if needle.is_empty() {
+                    return true;
+                }
+                if needle.len() > slice.len() {
+                    return false;
+                }
+                if *case_insensitive {
+                    slice
+                        .windows(needle.len())
+                        .any(|w| w.eq_ignore_ascii_case(needle))
+                } else {
+                    slice.windows(needle.len()).any(|w| w == needle.as_slice())
+                }
+            }
+            CombineFilter::Regex(re) => re.is_match(slice),
+        }
+    }
+}
+
 /// One capture in a structural match.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CapturePayload {
@@ -168,6 +211,7 @@ pub fn run(
     languages: &[String],
     glob: Option<&GlobMatcher>,
     row_limit: usize,
+    combine: Option<&CombineFilter>,
     cancel: &CancelToken,
 ) -> Result<StructuralResult, StructuralError> {
     // Resolve language whitelist + compile queries per language.
@@ -319,14 +363,6 @@ pub fn run(
                 return Err(StructuralError::Cancelled);
             }
             result.rows_seen += 1;
-            if result.matches.len() >= cap {
-                row_truncated = true;
-                // Skip the rest of this file's matches but keep
-                // counting rows_seen so the caller sees the real
-                // candidate count. To stay under wall-clock budget,
-                // break out entirely.
-                break 'files;
-            }
 
             // Find the "primary" capture: the one with the widest
             // byte range (typically the `@whole` capture per
@@ -349,6 +385,29 @@ pub fn run(
                 .fold((u32::MAX, 0u32), |(s, e), (cs, ce)| {
                     (s.min(cs as u32), e.max(ce as u32))
                 });
+
+            // Intersection (`combine`) filter, applied INLINE so the row
+            // cap counts only matches that satisfy both the structural
+            // query and the literal/regex filter (issue #152). Without
+            // this, a large scope hits the cap on raw structural nodes
+            // before the post-pass filter runs, silently dropping real
+            // matches. `source` is already in hand — no extra file read.
+            if let Some(filter) = combine {
+                let (lo, hi) = (start_byte as usize, end_byte as usize);
+                let bytes = source.as_bytes();
+                if hi > bytes.len() || lo > hi || !filter.matches(&bytes[lo..hi]) {
+                    continue;
+                }
+            }
+
+            if result.matches.len() >= cap {
+                row_truncated = true;
+                // Skip the rest of this file's matches but keep
+                // counting rows_seen so the caller sees the real
+                // candidate count. To stay under wall-clock budget,
+                // break out entirely.
+                break 'files;
+            }
             // Re-fetch start position from the *primary* (widest)
             // capture for line/col.
             let primary = captures_vec

--- a/crates/rts-daemon/src/methods/grep_v2/structural.rs
+++ b/crates/rts-daemon/src/methods/grep_v2/structural.rs
@@ -364,6 +364,18 @@ pub fn run(
             }
             result.rows_seen += 1;
 
+            // Per-match wall-clock check (#152 review). With an inline
+            // `combine` filter, filtered-out candidates `continue` before
+            // the row cap, so a single huge file with many non-matching
+            // nodes (e.g. `(identifier) @i` + a rare text) could otherwise
+            // monopolize the blocking thread well past the budget — the
+            // between-files check below never fires mid-file. Sample the
+            // clock every 1024 candidates to keep `Instant::now()` off the
+            // hottest path while still bounding it.
+            if result.rows_seen % 1024 == 0 && started.elapsed() > budget {
+                return Err(StructuralError::Timeout);
+            }
+
             // Find the "primary" capture: the one with the widest
             // byte range (typically the `@whole` capture per
             // tree-sitter convention). If the match has no captures

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -1316,20 +1316,50 @@ pub async fn grep(
             // their CPU-bound compute) — see the v0.3.x comments
             // around `read_symbol_body`'s closure walk for the
             // rationale.
-            // The user's `limit` bounds RETURNED matches. When a
-            // post-scan filter follows (combine literal/regex, or
-            // within_symbol), the scanner must NOT stop at `limit` raw
-            // structural matches — otherwise filtering can shrink the
-            // result below `limit` (often to zero) while matching nodes
-            // remain unscanned (issue #147: `(identifier) @i` + text was
-            // returning empty under a small limit). In that case scan up
-            // to the hard cap and truncate the filtered set to `limit`
-            // below; bounded by STRUCTURAL_MAX_ROWS + the wall-clock
-            // budget. Structural-only queries keep capping at `limit`.
-            let has_post_filter =
-                !matches!(combine, super::grep_v2::compose::StructuralCombine::None)
-                    || shared_filters.within_symbol.is_some();
-            let scan_limit = if has_post_filter {
+            // Build the intersection (`combine`) filter once, up-front, so
+            // a bad regex fails before the scan. It is applied INLINE in
+            // `structural::run` (issue #152) so the row cap counts only
+            // matches that satisfy BOTH the structural query and the
+            // literal/regex filter — a post-pass let the cap truncate raw
+            // structural nodes before filtering on large scopes (#147 fixed
+            // the user-`limit` case; this fixes the hard-cap case).
+            use super::grep_v2::compose::StructuralCombine;
+            use super::grep_v2::structural::CombineFilter;
+            let combine_filter: Option<CombineFilter> = match &combine {
+                StructuralCombine::None => None,
+                StructuralCombine::Literal {
+                    text,
+                    case_insensitive,
+                } => Some(CombineFilter::Literal {
+                    needle: text.clone().into_bytes(),
+                    case_insensitive: *case_insensitive,
+                }),
+                StructuralCombine::Regex {
+                    pattern,
+                    case_insensitive,
+                    multiline,
+                } => {
+                    let mut builder = regex::bytes::RegexBuilder::new(pattern);
+                    builder.case_insensitive(*case_insensitive);
+                    if *multiline {
+                        builder.dot_matches_new_line(true).multi_line(true);
+                    }
+                    let re = builder.build().map_err(|e| {
+                        ProtocolError::new(
+                            ErrorCode::InvalidParams,
+                            format!("`text` failed to compile as regex: {e}"),
+                        )
+                    })?;
+                    Some(CombineFilter::Regex(re))
+                }
+            };
+
+            // The user's `limit` bounds RETURNED matches. `combine` now
+            // runs inline, so the only remaining post-scan filter is
+            // `within_symbol`: give the scan headroom (the hard cap,
+            // wall-clock bounded) when it's present and truncate to `limit`
+            // afterward. Otherwise cap directly at `limit`.
+            let scan_limit = if shared_filters.within_symbol.is_some() {
                 super::grep_v2::limits::STRUCTURAL_MAX_ROWS
             } else {
                 limit
@@ -1342,6 +1372,7 @@ pub async fn grep(
             let glob_owned = glob.clone();
             let files_owned = files.clone();
             let token_owned = token.clone();
+            let combine_owned = combine_filter;
             let result = tokio::task::spawn_blocking(move || {
                 super::grep_v2::structural::run(
                     &state_clone,
@@ -1351,6 +1382,7 @@ pub async fn grep(
                     &languages_owned,
                     glob_owned.as_ref(),
                     scan_limit,
+                    combine_owned.as_ref(),
                     &token_owned,
                 )
             })
@@ -1398,40 +1430,11 @@ pub async fn grep(
                 })),
             })?;
 
-            // Apply the `combine` (literal/regex) intersection filter
-            // post-scan. The protocol matrix defines `structural + text`
-            // and `structural + regex` as intersection: a returned
-            // match must satisfy BOTH filters. Without this filter
-            // calls that combine `structural_query` with `text`/`regex`
-            // would return false-positives (structural-only matches),
-            // breaking the documented composition contract — this is
-            // exactly the bug Codex flagged on PR #110 review.
-            //
-            // Implementation: group matches by file → read each file
-            // once → slice the byte range for each match → check the
-            // literal substring (case-insensitive by default) or run
-            // the regex against the slice. Reading bytes per file is
-            // unavoidable because StructuralMatch carries byte ranges,
-            // not the matched text.
-            use super::grep_v2::compose::StructuralCombine;
-            let combine_filtered: Vec<_> = match &combine {
-                StructuralCombine::None => result.matches,
-                StructuralCombine::Literal {
-                    text,
-                    case_insensitive,
-                } => filter_structural_by_literal(&root, result.matches, text, *case_insensitive),
-                StructuralCombine::Regex {
-                    pattern,
-                    case_insensitive,
-                    multiline,
-                } => filter_structural_by_regex(
-                    &root,
-                    result.matches,
-                    pattern,
-                    *case_insensitive,
-                    *multiline,
-                )?,
-            };
+            // The `combine` (literal/regex) intersection filter is applied
+            // inline during the scan (see `combine_filter` above and
+            // issue #152), so `result.matches` already satisfies both the
+            // structural query and the filter — no post-pass needed.
+            let combine_filtered: Vec<_> = result.matches;
 
             // Apply within_symbol filter post-scan if requested.
             // Mirrors the literal/regex path's filter ordering.
@@ -1899,174 +1902,6 @@ pub async fn grep(
 // matches as byte-range coordinates; intersection with the literal
 // or regex filter requires reading the file bytes at each match's
 // range and testing the substring/pattern against that slice.
-
-/// Filter structural matches by literal-substring intersection.
-/// Matches whose `[start_byte..end_byte]` slice contains `needle`
-/// (case-insensitive when `case_insensitive`) are kept.
-///
-/// Files are read once per file to amortize I/O. A match in a file
-/// that fails to read is silently dropped (already-present matches
-/// for other files survive); this mirrors the v1 grep handler's
-/// "log + continue" file-error policy.
-fn filter_structural_by_literal(
-    root: &std::path::Path,
-    matches: Vec<super::grep_v2::structural::StructuralMatch>,
-    needle: &str,
-    case_insensitive: bool,
-) -> Vec<super::grep_v2::structural::StructuralMatch> {
-    use std::collections::HashMap;
-    if matches.is_empty() || needle.is_empty() {
-        // Empty needle would tautologically match every slice; the
-        // validator already rejects empty `text`, but be defensive.
-        return matches;
-    }
-    let mut by_file: HashMap<&str, Vec<usize>> = HashMap::new();
-    for (i, m) in matches.iter().enumerate() {
-        by_file.entry(m.file.as_str()).or_default().push(i);
-    }
-    let mut keep = vec![false; matches.len()];
-    let needle_bytes = needle.as_bytes();
-    for (file, indices) in by_file {
-        let path = root.join(file);
-        let bytes = match std::fs::read(&path) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::debug!(
-                    target: "rts_daemon::grep_v2",
-                    error = %e,
-                    file = %file,
-                    "structural-intersection: file read failed; dropping its matches"
-                );
-                continue;
-            }
-        };
-        for &i in &indices {
-            let m = &matches[i];
-            let lo = m.start_byte as usize;
-            let hi = m.end_byte as usize;
-            if hi > bytes.len() || lo > hi {
-                continue;
-            }
-            let slice = &bytes[lo..hi];
-            let matched = if case_insensitive {
-                slice_contains_case_insensitive(slice, needle_bytes)
-            } else {
-                slice_contains_exact(slice, needle_bytes)
-            };
-            if matched {
-                keep[i] = true;
-            }
-        }
-    }
-    matches
-        .into_iter()
-        .enumerate()
-        .filter(|(i, _)| keep[*i])
-        .map(|(_, m)| m)
-        .collect()
-}
-
-/// Exact byte-level substring check via windowed scan. The std
-/// library doesn't expose a `bytes.find(needle)` for arbitrary
-/// byte slices; this is a small O(n*m) helper that's fine for
-/// intersection scans where the match slices are bounded by the
-/// structural query's typical node sizes (kilobytes, not megabytes).
-fn slice_contains_exact(haystack: &[u8], needle: &[u8]) -> bool {
-    if needle.is_empty() {
-        return true;
-    }
-    if needle.len() > haystack.len() {
-        return false;
-    }
-    haystack.windows(needle.len()).any(|w| w == needle)
-}
-
-/// Case-insensitive byte-level substring check. Works over ASCII
-/// case; non-ASCII bytes match only their exact value. This mirrors
-/// the v1 grep's literal-mode behavior, which uses the same
-/// case-fold-ASCII semantic.
-fn slice_contains_case_insensitive(haystack: &[u8], needle: &[u8]) -> bool {
-    if needle.is_empty() {
-        return true;
-    }
-    if needle.len() > haystack.len() {
-        return false;
-    }
-    'outer: for start in 0..=haystack.len() - needle.len() {
-        for j in 0..needle.len() {
-            if haystack[start + j].to_ascii_lowercase() != needle[j].to_ascii_lowercase() {
-                continue 'outer;
-            }
-        }
-        return true;
-    }
-    false
-}
-
-/// Filter structural matches by regex intersection. Same file-once-
-/// read pattern as `filter_structural_by_literal`. Compile failures
-/// here are bubbled up as `INVALID_PARAMS` so the caller can
-/// self-correct the regex.
-fn filter_structural_by_regex(
-    root: &std::path::Path,
-    matches: Vec<super::grep_v2::structural::StructuralMatch>,
-    pattern: &str,
-    case_insensitive: bool,
-    multiline: bool,
-) -> Result<Vec<super::grep_v2::structural::StructuralMatch>, ProtocolError> {
-    use std::collections::HashMap;
-    if matches.is_empty() {
-        return Ok(matches);
-    }
-    let mut builder = regex::bytes::RegexBuilder::new(pattern);
-    builder.case_insensitive(case_insensitive);
-    if multiline {
-        builder.dot_matches_new_line(true).multi_line(true);
-    }
-    let re = builder.build().map_err(|e| {
-        ProtocolError::new(
-            ErrorCode::InvalidParams,
-            format!("`text` failed to compile as regex: {e}"),
-        )
-    })?;
-    let mut by_file: HashMap<&str, Vec<usize>> = HashMap::new();
-    for (i, m) in matches.iter().enumerate() {
-        by_file.entry(m.file.as_str()).or_default().push(i);
-    }
-    let mut keep = vec![false; matches.len()];
-    for (file, indices) in by_file {
-        let path = root.join(file);
-        let bytes = match std::fs::read(&path) {
-            Ok(b) => b,
-            Err(e) => {
-                tracing::debug!(
-                    target: "rts_daemon::grep_v2",
-                    error = %e,
-                    file = %file,
-                    "structural-intersection: file read failed; dropping its matches"
-                );
-                continue;
-            }
-        };
-        for &i in &indices {
-            let m = &matches[i];
-            let lo = m.start_byte as usize;
-            let hi = m.end_byte as usize;
-            if hi > bytes.len() || lo > hi {
-                continue;
-            }
-            if re.is_match(&bytes[lo..hi]) {
-                keep[i] = true;
-            }
-        }
-    }
-    Ok(matches
-        .into_iter()
-        .enumerate()
-        .filter(|(i, _)| keep[*i])
-        .map(|(_, m)| m)
-        .collect())
-}
 
 /// Helper: given byte offset `pos` into `bytes`, return
 /// `(line_index_0_based, line_start_byte, line_end_byte_exclusive)`.

--- a/crates/rts-mcp/tests/cli_grep.rs
+++ b/crates/rts-mcp/tests/cli_grep.rs
@@ -248,6 +248,61 @@ async fn grep_structural_without_language_errors() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn grep_structural_combine_scans_past_the_row_cap() {
+    // Regression for #152. With more than STRUCTURAL_MAX_ROWS (4096)
+    // structural nodes before the match, the combine (text) filter must
+    // still find it: the filter runs INLINE so the cap counts post-filter
+    // matches, not raw nodes. The old post-pass capped 4096 raw
+    // identifiers first (none matching), then filtered → empty.
+    let env = TestEnv::new();
+    std::fs::write(
+        env.workspace_path().join("Cargo.toml"),
+        "[package]\nname = \"fixture\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    // 5000 padding fn-name identifiers, then the unique target LAST — so
+    // it sits past the 4096 cap in document scan order.
+    let mut src = String::with_capacity(120_000);
+    for i in 0..5000 {
+        src.push_str(&format!("pub fn pad_{i}() {{}}\n"));
+    }
+    src.push_str("pub fn zzz_unique_target() {}\n");
+    std::fs::write(env.workspace_path().join("big.rs"), src).unwrap();
+
+    // Structural grep scans the committed file set; on a debug daemon
+    // indexing 5k fns can lag the first call. Poll until ready (or the
+    // deadline) so the test asserts the cap behavior, not a cold-index
+    // race. The target is past the 4096-node cap, so finding it at all is
+    // the regression signal.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let mut last = String::new();
+    loop {
+        let out = env
+            .run(&[
+                "--no-color",
+                "grep",
+                "zzz_unique_target",
+                "--structural-query",
+                "(identifier) @i",
+                "--language",
+                "rust",
+            ])
+            .await;
+        let (stdout, _stderr, _code) = parts(&out);
+        if stdout.lines().any(|l| l.contains("zzz_unique_target")) {
+            return; // found past the cap → fix works
+        }
+        last = stdout;
+        assert!(
+            std::time::Instant::now() < deadline,
+            "target identifier past the 4096-node cap was never found \
+             (issue #152); last stdout={last:?}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn grep_no_match_exits_one_with_no_output() {
     let env = TestEnv::new();
     seed_minimal_rust_workspace(env.workspace_path());


### PR DESCRIPTION
Fixes #152. Follows #149 (which fixed the user-`limit` truncation; this fixes the residual hard-cap interaction).

## Problem
`rts grep --structural-query … <text>` applied the literal/regex intersection filter as a **post-pass** over `structural::run`'s output. But `run` caps the scan at `STRUCTURAL_MAX_ROWS` (4096), so on a large scope the cap consumed raw structural nodes *before* the filter ran — matches past the first 4096 nodes were silently dropped:

```
rts grep extract_references --structural-query '(identifier) @i' --language rust --glob 'crates/rts-daemon/**' --limit 3
# → matches: [], rows_seen: 4097, truncated: true   (symbol exists in refs.rs, beyond node 4096)
```

## Fix
Apply the combine filter **inline** in `structural::run` (`CombineFilter`): each match is tested against the literal/regex filter using the file bytes the scanner already holds, and only passing matches count toward the cap. So the cap now bounds *returned* matches and the scan continues until it has enough real ones (still wall-clock bounded). Regex is compiled up-front (fail-fast). The dead post-pass helpers are removed.

## Testing
- New `grep_structural_combine_scans_past_the_row_cap`: a fixture with >4096 identifier nodes before the target — the old post-pass returned empty; inline filtering finds it (match at line 5001, past the 4096 cap). Polls for index readiness so it tests the cap behavior, not a cold-index race.
- `grep_v2_structural_intersection`, `grep_v2_capabilities`, `grep_within_symbol_round_trip`, and all `cli_grep` tests still pass.
- `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)