### PR TITLE
fix(daemon): drop watcher file-ID cache to stop cold-mount tree scan

### DIFF
--- a/changelog.d/153-fix-watcher-nocache.md
+++ b/changelog.d/153-fix-watcher-nocache.md
@@ -1,0 +1,11 @@
+### Fix: cold mount no longer scans gitignored dirs (target/, node_modules)
+
+The file watcher's debouncer used `RecommendedCache` (a file-ID map),
+which scans the **entire watched tree** on startup to seed rename
+detection. `notify` watches the whole workspace recursively and is not
+gitignore-aware, so that scan walked `target/`, `node_modules`, etc. —
+dominating cold mount (≈100 s on a workspace with a multi-GB `target/`,
+despite only ~380 files being indexed). The debouncer now uses `NoCache`:
+the indexer doesn't need precise rename tracking (a rename surfaces as
+remove+create, already handled), so the scan is pure overhead. Cold mount
+on this repo dropped from ~104 s to ~5 s.

--- a/crates/rts-daemon/src/watcher.rs
+++ b/crates/rts-daemon/src/watcher.rs
@@ -33,9 +33,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use notify::{Config as NotifyConfig, EventKind, PollWatcher, RecommendedWatcher, RecursiveMode};
-use notify_debouncer_full::{
-    DebounceEventResult, Debouncer, RecommendedCache, new_debouncer, new_debouncer_opt,
-};
+use notify_debouncer_full::{DebounceEventResult, Debouncer, NoCache, new_debouncer_opt};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
@@ -109,8 +107,8 @@ pub enum WatchEvent {
 /// lifecycle.
 #[allow(dead_code)]
 enum DebouncerHandle {
-    Recommended(Debouncer<RecommendedWatcher, RecommendedCache>),
-    Polling(Debouncer<PollWatcher, RecommendedCache>),
+    Recommended(Debouncer<RecommendedWatcher, NoCache>),
+    Polling(Debouncer<PollWatcher, NoCache>),
 }
 
 /// Running watcher handle. Drop it to stop watching.
@@ -223,7 +221,7 @@ impl Watcher {
                 DEBOUNCE_WINDOW,
                 None,
                 event_handler,
-                RecommendedCache::new(),
+                NoCache::new(),
                 NotifyConfig::default().with_poll_interval(POLL_INTERVAL),
             )
             .map_err(|e| std::io::Error::other(format!("new_debouncer_opt(poll): {e}")))?;
@@ -231,8 +229,22 @@ impl Watcher {
                 .map_err(|e| std::io::Error::other(format!("debouncer.watch(poll): {e}")))?;
             DebouncerHandle::Polling(deb)
         } else {
-            let mut deb = new_debouncer(DEBOUNCE_WINDOW, None, event_handler)
-                .map_err(|e| std::io::Error::other(format!("new_debouncer: {e}")))?;
+            // Use `NoCache` (not the default `RecommendedCache`): the
+            // recommended `FileIdMap` cache scans the entire watched tree
+            // on `watch()` to seed file-IDs for rename detection — and the
+            // watch is whole-tree (notify is not gitignore-aware), so it
+            // walks `target/`, `node_modules`, etc. and dominates cold
+            // mount (issue #153). The indexer doesn't need precise rename
+            // tracking — a rename surfaces as remove+create, which the
+            // writer already handles — so the cache scan is pure overhead.
+            let mut deb = new_debouncer_opt::<_, RecommendedWatcher, _>(
+                DEBOUNCE_WINDOW,
+                None,
+                event_handler,
+                NoCache::new(),
+                NotifyConfig::default(),
+            )
+            .map_err(|e| std::io::Error::other(format!("new_debouncer_opt: {e}")))?;
             deb.watch(root, RecursiveMode::Recursive)
                 .map_err(|e| std::io::Error::other(format!("debouncer.watch: {e}")))?;
             // Only flip to Ok on the recommended path — the polling path


### PR DESCRIPTION
Fixes #153.

## Problem
Cold mount of a normal dev workspace was pathologically slow — **~104s** here for only **~380 indexed files** — because the file watcher scans gitignored dirs the index walk correctly prunes.

## Root cause (profiled)
The notify debouncer used `RecommendedCache` (a `FileIdMap`), which scans the **entire watched tree** on `watch()` to seed file-IDs for rename detection. `notify` watches the workspace recursively and is **not** gitignore-aware, so that scan walks `target/` (gigabytes), `node_modules`, etc.

Evidence:
- `sample` during the walk: indexing threads idle; the hot thread is the debouncer building its path map (`notify::fsevent::callback` → `Mutex::lock`, path parsing).
- Decisive experiment: moving root `target/` out dropped cold mount **104s → 55s**.

## Fix
Switch the debouncer to `NoCache`. The indexer doesn't need precise rename tracking — a rename surfaces as remove+create, which the writer already handles — so the cache scan was pure overhead.

**Result: cold mount ~104s → ~5s (20×)** on this repo (measured).

## Testing
- `p6_watcher_hardening`, `reconciliation_round_trip`, `find_symbol_round_trip`, and the `watcher::tests` unit tests all pass — incremental change detection is unaffected.
- `cargo fmt --all --check` clean.
- A deterministic CI *timing* test would be flaky (machine-dependent), so the perf win is validated empirically (above) and guarded by the correctness tests; the regression would require re-introducing the whole-tree cache scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)