### PR TITLE
feat: verify_impact + verification loop hook (verify-v0 P2)

### DIFF
--- a/.claude/hooks/rts-verify.sh
+++ b/.claude/hooks/rts-verify.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# version: 0.8.0
+# rts-verify.sh — Claude Code PostToolUse hook (verify-v0 P2.U2, this repo).
+#
+# Fires AFTER a Write/Edit/MultiEdit tool runs (so the file is on disk),
+# runs `rts verify <file>`, and — when the file references symbols/imports
+# that don't exist in the index — feeds those hallucinated references back
+# into the model's next-turn context via hookSpecificOutput.additionalContext
+# so the agent can correct them.
+#
+# Annotate-only: NEVER blocks an edit (PostToolUse can't anyway — the tool
+# already ran). The blocking edit gate is a later phase.
+#
+# Contract (see https://code.claude.com/docs/en/hooks):
+#   - Stdin: PostToolUse JSON payload from Claude Code.
+#   - Stdout (on findings): JSON envelope with hookEventName=PostToolUse
+#     + additionalContext. Visible to the model on next turn. PostToolUse
+#     CANNOT set permissionDecision (it's after the fact).
+#   - Stdout (silent): empty. Nothing enters the agent's context.
+#   - Exit 0 ALWAYS. We never block — soft enforcement. Errors during
+#     hook execution degrade to silent.
+#
+# Environment knobs (mirror rts-nudge.sh):
+#   RTS_HOOK_DISABLED=1            — opt out; hook is silent for the session.
+#   RTS_BIN                        — path to the `rts` binary (else $PATH).
+#   RTS_NUDGE_FORCE_DAEMON_UP=1    — test-only: skip the probe, assume up.
+#   RTS_NUDGE_FORCE_DAEMON_DOWN=1  — test-only: skip the probe, assume down.
+#   XDG_RUNTIME_DIR                — daemon-health probe cache location.
+
+set +e  # NEVER let an error bubble up — soft enforcement.
+
+# ---------- 1. Fast early bails ----------
+
+# Opt-out: any non-empty, non-"0" value disables the hook.
+if [[ -n "${RTS_HOOK_DISABLED:-}" && "${RTS_HOOK_DISABLED}" != "0" ]]; then
+    exit 0
+fi
+
+# Read the entire payload. Bail silently on read failure.
+payload="$(cat 2>/dev/null)"
+if [[ -z "$payload" ]]; then
+    exit 0
+fi
+
+# ---------- 2. Parse with jq (ONE shell-out, all fields batched) ----------
+
+# Single jq invocation extracts tool_name + the edited file path. PostToolUse
+# carries the path under tool_input.file_path (Write/Edit/MultiEdit all use
+# file_path).
+read_jq=$(printf '%s' "$payload" | jq -r '
+    [
+      (.tool_name             // ""),
+      (.tool_input.file_path  // "")
+    ] | @tsv
+' 2>/dev/null)
+
+if [[ -z "$read_jq" ]]; then
+    exit 0
+fi
+
+IFS=$'\t' read -r tool_name file_path <<<"$read_jq"
+
+# Only file-mutating tools get verified. Everything else is silent.
+case "$tool_name" in
+    Write|Edit|MultiEdit) ;;
+    *) exit 0 ;;
+esac
+
+# Need a real, existing file path to verify.
+if [[ -z "$file_path" || ! -f "$file_path" ]]; then
+    exit 0
+fi
+
+# ---------- 3. Daemon-health probe (cached) ----------
+#
+# Only verify if rts is actually available. A down daemon → silent (the
+# `rts verify` call would just error with exit 3). Reuses rts-nudge's
+# probe approach + force-knobs so the two hooks share behavior.
+if [[ -n "${RTS_NUDGE_FORCE_DAEMON_DOWN:-}" ]]; then
+    exit 0
+fi
+if [[ -z "${RTS_NUDGE_FORCE_DAEMON_UP:-}" ]]; then
+    runtime_dir="${XDG_RUNTIME_DIR:-/tmp}"
+    probe_file="${runtime_dir}/rts-up.${PPID:-$$}"
+    if [[ -e "$probe_file" ]]; then
+        :  # Cached "up".
+    else
+        if pgrep -x rts-daemon >/dev/null 2>&1; then
+            mkdir -p "$runtime_dir" 2>/dev/null
+            : >"$probe_file" 2>/dev/null
+        else
+            exit 0  # rts not running — silent.
+        fi
+    fi
+fi
+
+# ---------- 4. Locate the `rts` binary ----------
+#
+# $RTS_BIN wins (tests / non-PATH installs); else fall back to $PATH.
+rts_bin="${RTS_BIN:-}"
+if [[ -z "$rts_bin" ]]; then
+    rts_bin="$(command -v rts 2>/dev/null)"
+fi
+if [[ -z "$rts_bin" || ! -x "$rts_bin" ]]; then
+    exit 0  # No rts binary — silent.
+fi
+
+# ---------- 5. Run `rts verify <file>` ----------
+#
+# --no-color so the captured output is escape-free when re-emitted into
+# JSON. RTS_NO_AUTOSPAWN is intentionally NOT set: if the daemon is up
+# (probe passed) the call connects; if a race took it down, the call
+# exits 3 → we stay silent below.
+verify_out="$("$rts_bin" --no-color verify "$file_path" 2>/dev/null)"
+verify_code=$?
+
+# Exit-code contract from `rts verify`:
+#   0 → clean / unsupported language / nothing to check → silent.
+#   1 → ≥1 hallucinated reference → emit nudge.
+#   3 → daemon error / unreachable → silent.
+# Only act on exit 1 WITH output.
+if [[ "$verify_code" -ne 1 || -z "$verify_out" ]]; then
+    exit 0
+fi
+
+# ---------- 6. Emit the nudge ----------
+#
+# Bash-native JSON string escape (no jq fork on the output path). The
+# verify output is workspace-controlled symbol names + our nudge line —
+# ASCII-safe in practice; the escape covers \, ", and newlines. A broken
+# envelope (exotic chars) degrades to a logged hook-output error, never
+# silent corruption.
+context="rts verify found references in ${file_path} that don't resolve against the index (possible hallucinations):
+${verify_out}
+Verify these symbols/imports actually exist before relying on them — use mcp__rts__find_symbol / mcp__rts__verify_symbol to confirm, or fix the names."
+
+escape_for_json() {
+    local s="$1"
+    s="${s//\\/\\\\}"   # \  → \\
+    s="${s//\"/\\\"}"   # "  → \"
+    s="${s//$'\n'/\\n}" # newline → \n
+    printf '"%s"' "$s"
+}
+
+escaped=$(escape_for_json "$context")
+
+printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":%s}}\n' "$escaped"
+exit 0

--- a/.claude/hooks/tests/run-verify-tests.sh
+++ b/.claude/hooks/tests/run-verify-tests.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Pure-bash test runner for .claude/hooks/rts-verify.sh — the PostToolUse
+# hook that runs `rts verify <file>` after Write/Edit/MultiEdit and feeds
+# hallucinated references back to the agent. No bats, no external test
+# framework. Runs anywhere bash + jq exist.
+#
+# The real `rts verify` needs a daemon + index, which we don't spin up in
+# a hook unit test. Instead we stub the `rts` binary via $RTS_BIN: a tiny
+# script whose exit code + stdout are driven by env vars, so each case can
+# exercise the hook's branch logic deterministically. The daemon-health
+# probe is bypassed with the same RTS_NUDGE_FORCE_DAEMON_UP/DOWN knobs the
+# nudge hook uses.
+#
+# Output: one line per test (PASS/FAIL); non-zero exit if any test fails.
+
+set -uo pipefail  # NOT -e: we want all tests to run.
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HOOK="$REPO_ROOT/.claude/hooks/rts-verify.sh"
+if [[ ! -x "$HOOK" ]]; then
+    echo "ERROR: $HOOK is not executable" >&2
+    exit 1
+fi
+
+# Scratch dir for the stub `rts` binary + the file paths we "verify".
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# A stub `rts` that mimics `rts verify`'s exit-code + output contract.
+# Driven by env: STUB_EXIT (default 0) and STUB_OUT (stdout to emit).
+STUB_RTS="$WORK/rts"
+cat >"$STUB_RTS" <<'STUB'
+#!/usr/bin/env bash
+# Stub `rts` for hook tests. Only handles `--no-color verify <file>`.
+printf '%s' "${STUB_OUT:-}"
+exit "${STUB_EXIT:-0}"
+STUB
+chmod +x "$STUB_RTS"
+
+# A real file on disk for the hook's `-f` check.
+TARGET_FILE="$WORK/edited.rs"
+: >"$TARGET_FILE"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+FAILED_TESTS=()
+
+# Run one test.
+#   $1 name
+#   $2 tool_name
+#   $3 file_path (use "$TARGET_FILE" for an existing file, or a bogus path)
+#   $4 expected: "nudge" | "silent"
+#   $5 (optional) substring that MUST appear in nudge output
+# Honors env: STUB_EXIT, STUB_OUT, RTS_HOOK_DISABLED,
+# RTS_NUDGE_FORCE_DAEMON_UP / RTS_NUDGE_FORCE_DAEMON_DOWN.
+run_test() {
+    local name="$1" tool="$2" fpath="$3" expect="$4" must_have="${5:-}"
+    local payload
+    payload=$(jq -nc \
+        --arg t "$tool" \
+        --arg f "$fpath" \
+        '{tool_name:$t, tool_input:{file_path:$f}, hook_event_name:"PostToolUse"}')
+    local out
+    out=$(printf '%s' "$payload" | RTS_BIN="$STUB_RTS" "$HOOK" 2>&1)
+    local status=$?
+
+    local fail_reason=""
+    if [[ $status -ne 0 ]]; then
+        fail_reason="exit $status (expected 0; hook must NEVER block)"
+    elif [[ "$expect" == "nudge" ]]; then
+        if [[ -z "$out" ]]; then
+            fail_reason="expected nudge, got empty stdout"
+        elif [[ -n "$must_have" && "$out" != *"$must_have"* ]]; then
+            fail_reason="expected substring '$must_have' missing from: $out"
+        fi
+    elif [[ "$expect" == "silent" ]]; then
+        if [[ -n "$out" ]]; then
+            fail_reason="expected silent, got stdout: $out"
+        fi
+    fi
+
+    if [[ -z "$fail_reason" ]]; then
+        printf 'PASS  %s\n' "$name"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        printf 'FAIL  %s  — %s\n' "$name" "$fail_reason"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        FAILED_TESTS+=("$name")
+    fi
+}
+
+reset_env() {
+    unset RTS_HOOK_DISABLED RTS_NUDGE_FORCE_DAEMON_DOWN STUB_EXIT STUB_OUT
+    export RTS_NUDGE_FORCE_DAEMON_UP=1
+}
+
+# ============================================================
+# Test cases
+# ============================================================
+
+# 1. Write referencing an invented symbol → hook emits a nudge naming it.
+reset_env
+export STUB_EXIT=1
+export STUB_OUT="$TARGET_FILE:1  totally_invented_symbol  (did you mean: real_thing?)"
+run_test "write_invented_symbol_nudges"   "Write" "$TARGET_FILE" "nudge"  "totally_invented_symbol"
+
+# The nudge must carry the PostToolUse envelope + the "verify these" line.
+reset_env
+export STUB_EXIT=1
+export STUB_OUT="$TARGET_FILE:1  bogus_sym"
+run_test "nudge_envelope_hookSpecificOutput"  "Write" "$TARGET_FILE" "nudge"  "hookSpecificOutput"
+reset_env
+export STUB_EXIT=1
+export STUB_OUT="$TARGET_FILE:1  bogus_sym"
+run_test "nudge_envelope_hookEventName_post"  "Write" "$TARGET_FILE" "nudge"  '"hookEventName":"PostToolUse"'
+reset_env
+export STUB_EXIT=1
+export STUB_OUT="$TARGET_FILE:1  bogus_sym"
+run_test "nudge_has_verify_instruction"       "Edit"  "$TARGET_FILE" "nudge"  "Verify these symbols"
+
+# 2. Write referencing only real symbols (verify exit 0, no output) → silent.
+reset_env
+export STUB_EXIT=0
+export STUB_OUT=""
+run_test "write_clean_file_silent"        "Write" "$TARGET_FILE" "silent"
+
+# Exit 1 but EMPTY output (shouldn't happen, but be defensive) → silent.
+reset_env
+export STUB_EXIT=1
+export STUB_OUT=""
+run_test "exit1_no_output_silent"         "Write" "$TARGET_FILE" "silent"
+
+# 3. RTS_HOOK_DISABLED=1 → silent.
+reset_env
+export STUB_EXIT=1
+export STUB_OUT="$TARGET_FILE:1  bogus_sym"
+export RTS_HOOK_DISABLED=1
+run_test "hook_disabled_silent"           "Write" "$TARGET_FILE" "silent"
+
+reset_env
+export STUB_EXIT=1
+export STUB_OUT="$TARGET_FILE:1  bogus_sym"
+export RTS_HOOK_DISABLED=true
+run_test "hook_disabled_true_silent"      "Write" "$TARGET_FILE" "silent"
+
+# 4. Daemon down (forced) → silent (never even runs verify).
+reset_env
+unset RTS_NUDGE_FORCE_DAEMON_UP
+export RTS_NUDGE_FORCE_DAEMON_DOWN=1
+export STUB_EXIT=1
+export STUB_OUT="$TARGET_FILE:1  bogus_sym"
+run_test "daemon_down_silent"             "Write" "$TARGET_FILE" "silent"
+
+# verify exit 3 (daemon error mid-run) → silent.
+reset_env
+export STUB_EXIT=3
+export STUB_OUT=""
+run_test "verify_daemon_error_silent"     "Write" "$TARGET_FILE" "silent"
+
+# 5. Non-mutating tool (Read) → silent.
+reset_env
+export STUB_EXIT=1
+export STUB_OUT="$TARGET_FILE:1  bogus_sym"
+run_test "read_tool_silent"               "Read"  "$TARGET_FILE" "silent"
+
+reset_env
+export STUB_EXIT=1
+export STUB_OUT="$TARGET_FILE:1  bogus_sym"
+run_test "bash_tool_silent"               "Bash"  "$TARGET_FILE" "silent"
+
+# MultiEdit IS a verified tool.
+reset_env
+export STUB_EXIT=1
+export STUB_OUT="$TARGET_FILE:1  multi_bogus"
+run_test "multiedit_invented_symbol_nudges" "MultiEdit" "$TARGET_FILE" "nudge" "multi_bogus"
+
+# 6. Nonexistent / empty file path → silent.
+reset_env
+export STUB_EXIT=1
+export STUB_OUT="x:1  bogus"
+run_test "missing_file_path_silent"       "Write" "$WORK/does-not-exist.rs" "silent"
+reset_env
+export STUB_EXIT=1
+export STUB_OUT="x:1  bogus"
+run_test "empty_file_path_silent"         "Write" "" "silent"
+
+# 7. Robustness: malformed / empty stdin → silent.
+reset_env
+out=$(printf 'not json' | RTS_BIN="$STUB_RTS" "$HOOK" 2>&1)
+if [[ -z "$out" && $? -eq 0 ]]; then
+    printf 'PASS  %s\n' "malformed_json_silent"
+    PASS_COUNT=$((PASS_COUNT + 1))
+else
+    printf 'FAIL  %s  — got: %s\n' "malformed_json_silent" "$out"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("malformed_json_silent")
+fi
+
+out=$(printf '' | RTS_BIN="$STUB_RTS" "$HOOK" 2>&1)
+if [[ -z "$out" && $? -eq 0 ]]; then
+    printf 'PASS  %s\n' "empty_stdin_silent"
+    PASS_COUNT=$((PASS_COUNT + 1))
+else
+    printf 'FAIL  %s  — got: %s\n' "empty_stdin_silent" "$out"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAILED_TESTS+=("empty_stdin_silent")
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+echo "---"
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+if [[ $FAIL_COUNT -eq 0 ]]; then
+    printf '%d/%d tests passed.\n' "$PASS_COUNT" "$TOTAL"
+    exit 0
+else
+    printf '%d/%d tests passed; %d FAILED:\n' "$PASS_COUNT" "$TOTAL" "$FAIL_COUNT"
+    for t in "${FAILED_TESTS[@]}"; do
+        printf '  - %s\n' "$t"
+    done
+    exit 1
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
 
-  "_comment": "Project-scoped Claude Code settings, committed to repo (vs settings.local.json which is per-user). Configures the rts-nudge PreToolUse hook that intercepts Bash grep/rg/find calls on workspace paths and suggests the AST-precise mcp__rts__* equivalent. The 'if' clause is the load-bearing optimization: Claude Code evaluates it BEFORE forking the hook process, so the script doesn't run for cargo/git/etc. Disable via env: RTS_HOOK_DISABLED=1.",
+  "_comment": "Project-scoped Claude Code settings, committed to repo (vs settings.local.json which is per-user). Configures two rts hooks: (1) the rts-nudge PreToolUse hook intercepts Bash grep/rg/find calls on workspace paths and suggests the AST-precise mcp__rts__* equivalent — its 'if' clause is the load-bearing optimization (Claude Code evaluates it BEFORE forking the hook, so it doesn't run for cargo/git/etc.); (2) the rts-verify PostToolUse hook runs `rts verify` after each Write/Edit/MultiEdit and feeds any hallucinated symbol/import references back to the agent (annotate-only, never blocks). Disable both via env: RTS_HOOK_DISABLED=1.",
 
   "hooks": {
     "PreToolUse": [
@@ -13,6 +13,18 @@
             "type": "command",
             "command": ".claude/hooks/rts-nudge.sh",
             "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/rts-verify.sh",
+            "timeout": 10
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,33 @@ nags users without rts installed.
 Test the hook locally with `.claude/hooks/tests/run-tests.sh` (pure
 bash, no `bats` or other deps required; needs `jq` + `python3`).
 
+### Edit-verification nudge (verify-v0)
+
+This repo also ships a project-local Claude Code `PostToolUse` hook at
+`.claude/hooks/rts-verify.sh` (registered via `.claude/settings.json`,
+matcher `Write|Edit|MultiEdit`). After each `Write`/`Edit`/`MultiEdit`
+the hook runs `rts verify <file>` on the just-written file: it extracts
+the file's use-site references (calls, types, imports, qualified paths)
+and checks each one against the index. Any reference that **provably has
+no matching definition** (a hallucination) is fed back into the agent's
+next-turn context via `additionalContext`, as
+`FILE:LINE  NAME  (did you mean: …?)` plus a one-line "verify these
+symbols exist" nudge.
+
+It is **annotate-only**: it never edits and never blocks the write (a
+`PostToolUse` hook fires after the tool already ran, so blocking is not
+even possible — the blocking edit gate is a later phase). It is silent
+when the file is clean, when the file's language has no reference
+extraction (anything but Rust / TypeScript / Python), and when the rts
+daemon isn't running.
+
+Opt out for a session with the same `RTS_HOOK_DISABLED=1` env var that
+disables the nudge hook. The hook locates the `rts` binary via `$RTS_BIN`
+(if set) or `$PATH`.
+
+Test it locally with `.claude/hooks/tests/run-verify-tests.sh` (pure
+bash; needs `jq`; stubs the `rts` binary so it needs no daemon).
+
 ### Where shell `grep` / `rg` is still the right tool
 
 - Searching files outside the indexed workspace (vendored deps,

--- a/changelog.d/164-feat-verify-impact-and-loop-hook.md
+++ b/changelog.d/164-feat-verify-impact-and-loop-hook.md
@@ -1,0 +1,26 @@
+### Feat: `verify_impact` pre-edit gate + a verification loop hook
+
+Extends the verification layer (verify-v0 P2) from checking *claims* to gating
+*edits* and wiring verification into the live agent loop.
+
+- **`verify_impact` / `Index.VerifyImpact`** — declare an intended change to a
+  symbol (`signature` | `remove` | `rename`) and get the blast radius as a
+  pass/fail `verdict` (`would_break` | `safe`). Wraps the reverse-call-graph
+  walk: lists `affected_callers[]` with a per-caller `reason`, and for a
+  `signature` change compares the proposed arity to the real one (pass
+  `new_signature`). Conservative — `safe` means no *arity* break (v0 checks
+  arity only). Honors qualified names (`Foo::method`); unknown symbol →
+  `not_found` + ranked candidates. Available as the `rts impact` CLI too.
+
+- **`rts verify <file>`** — check a file's symbol/import references against the
+  index and report hallucinated (not_found) ones as `FILE:LINE  name  (did you
+  mean: …?)`. Exit 0 clean, 1 hallucinations found, 3/4 daemon error.
+
+- **PostToolUse loop hook** (`.claude/hooks/rts-verify.sh`) — after each
+  Write/Edit, runs `rts verify` on the changed file and feeds any hallucinated
+  references back to the agent so it self-corrects next turn. Annotate-only
+  (never blocks), silent when the daemon is down, opt out with
+  `RTS_HOOK_DISABLED=1`.
+
+Deferred: the `uncovered_after_change` coverage field (needs test-reachability
+edges) and a *blocking* pre-edit gate both land with `verify_edit` (P3).

--- a/crates/rts-daemon/src/methods/daemon.rs
+++ b/crates/rts-daemon/src/methods/daemon.rs
@@ -201,6 +201,11 @@ const DAEMON_CAPABILITIES: &[&str] = &[
     // grounding-rate summary that excludes indeterminate claims from
     // the denominator. Additive.
     "verify_claims",
+    // verify-v0 P2.U1 — `Index.VerifyImpact`: declare an intended change
+    // to a symbol (signature/remove/rename) and get the blast radius as a
+    // pass/fail `verdict` (would_break | safe) so an edit can be gated.
+    // A verification-framed wrapper over `impact_of`. Additive.
+    "verify_impact",
 ];
 
 /// `Daemon.Ping` — heartbeat + capability advertisement (protocol-v0 §4.1, §7.1).

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -3555,10 +3555,15 @@ fn new_signature_shape(
 ///   iff any callers (indeterminate, `reason:"undecidable_signature"`).
 /// - Unknown symbol → `not_found`, `exists:false`, ranked `candidates[]`,
 ///   NO `verdict`.
+/// - Ambiguous name (resolves to >1 def) → `indeterminate`,
+///   `reason:"ambiguous_overload"`, the defs listed in `matches[]`, NO
+///   `verdict` — the agent should qualify (picking one could falsely read
+///   `safe` while another overload has callers).
 ///
-/// Default `depth` is 1 (direct callers) — a gate wants immediate
-/// breakage. `INVALID_PARAMS` on empty/oversize `symbol`. Walks the
-/// reverse call graph → cancellable.
+/// Default `depth` is 1 (direct callers) — a gate wants immediate breakage.
+/// Test callers are INCLUDED (unlike `impact_of`): breaking a test is not
+/// `safe`. `INVALID_PARAMS` on empty/oversize `symbol`. Walks the reverse
+/// call graph → cancellable.
 pub async fn verify_impact(
     params: serde_json::Value,
     state: &Arc<DaemonState>,
@@ -3625,6 +3630,33 @@ pub async fn verify_impact(
     if let Some(q) = &qualifier {
         hits.retain(|h| h.parent.as_deref() == Some(q.as_str()));
     }
+    // Ambiguous: the name resolves to MULTIPLE defs and we can't tell which
+    // one the agent means. Computing impact for an arbitrary overload could
+    // report `safe` while a different overload has callers, so return
+    // `indeterminate` (the agent should qualify the name) — same honesty rule
+    // as verify_symbol. List the candidates so the agent can disambiguate.
+    if hits.len() > 1 {
+        if token.is_cancelled() {
+            return Err(cancelled());
+        }
+        let matches: Vec<serde_json::Value> = hits
+            .iter()
+            .map(|h| {
+                let qn = match &h.parent {
+                    Some(parent) => format!("{parent}::{}", h.name),
+                    None => h.name.clone(),
+                };
+                serde_json::json!({ "qualified_name": qn, "file": h.file, "line": h.start_line })
+            })
+            .collect();
+        return Ok(serde_json::json!({
+            "resolution": rust_tree_sitter::Resolution::Indeterminate,
+            "reason":     rust_tree_sitter::IndeterminateReason::AmbiguousOverload,
+            "change":     p.change.as_wire_str(),
+            "symbol":     p.symbol,
+            "matches":    matches,
+        }));
+    }
     let anchor = match hits.into_iter().next() {
         Some(a) => a,
         None => {
@@ -3659,11 +3691,14 @@ pub async fn verify_impact(
 
     // Run the impact BFS — direct callers by default (depth 1). Reuse
     // ImpactBounds; CPU-bound BFS runs on a blocking thread like impact_of.
+    // Unlike `impact_of` (a refactoring-exploration tool that hides test
+    // noise), this is a BREAK GATE: a change that breaks a test caller is NOT
+    // `safe`, so test callers are INCLUDED.
     let bounds = crate::impact::ImpactBounds {
         max_depth: p.depth.unwrap_or(1),
         max_nodes: crate::impact::DEFAULT_MAX_NODES,
         token_budget: crate::impact::DEFAULT_TOKEN_BUDGET,
-        exclude_test_paths: true,
+        exclude_test_paths: false,
     };
     let store_clone = store_arc.clone();
     let ranks_clone = ranks.clone();

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -419,6 +419,50 @@ struct VerifyClaimsParams {
     claims: Vec<ClaimItem>,
 }
 
+/// `Index.VerifyImpact` params (verify-v0 P2.U1). "Will this change to a
+/// symbol break its callers?" — resolves the def, runs the impact BFS,
+/// and reports the blast radius as a pass/fail `verdict`.
+#[derive(Debug, Deserialize)]
+struct VerifyImpactParams {
+    /// Symbol whose change we want to gate. 1..=256 chars. Bare or
+    /// qualified, same resolution as `Index.ImpactOf`/`Index.VerifySymbol`.
+    symbol: String,
+    /// The kind of change being declared: `signature`, `remove`, `rename`.
+    change: VerifyImpactChange,
+    /// For `change: signature` — the proposed new signature, e.g.
+    /// `commit_batch(entries: &[Entry], flush: bool) -> Result<()>`. When
+    /// present and parseable we compute the new arity; when absent or
+    /// undecidable the verdict falls back to `would_break` iff there are
+    /// any callers, with `resolution:"indeterminate"`.
+    #[serde(default)]
+    new_signature: Option<String>,
+    /// BFS depth for the blast radius. DEFAULT 1 for verify_impact (direct
+    /// callers only) — a gate wants the immediate breakage, not the full
+    /// transitive closure. Clamped to [1, 4] by `ImpactBounds`.
+    #[serde(default)]
+    depth: Option<u32>,
+}
+
+/// The declared change kind for `Index.VerifyImpact`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum VerifyImpactChange {
+    Signature,
+    Remove,
+    Rename,
+}
+
+impl VerifyImpactChange {
+    /// Wire string echoed back in the `change` response field.
+    fn as_wire_str(self) -> &'static str {
+        match self {
+            VerifyImpactChange::Signature => "signature",
+            VerifyImpactChange::Remove => "remove",
+            VerifyImpactChange::Rename => "rename",
+        }
+    }
+}
+
 /// One claim in a `Index.VerifyClaims` batch. Tagged by `type`.
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -3433,6 +3477,302 @@ pub async fn impact_of(
         "tokens_returned":      walk.tokens_used,
         "token_counter":        TOKEN_COUNTER,
     }))
+}
+
+/// Compute the `SignatureShape` of a proposed `new_signature` string by
+/// wrapping it into a parseable function definition for the def's language
+/// and running the same `signature_shape` extractor `verify_signature`
+/// uses on the indexed def.
+///
+/// The parse trick: `signature_shape` needs a *function-definition node*,
+/// but `new_signature` is just the header (`name(params) -> ret`). We
+/// reconstruct a minimal valid definition per language —
+/// `fn <sig> {}` (Rust), `function <sig> {}` (TS), `def <sig>: pass`
+/// (Python) — parse it, locate the def node (`find_def_node`), and extract
+/// the shape. Returns `None` (→ undecidable) when the language is
+/// unsupported, the reconstructed source doesn't parse into a def node, or
+/// the shape itself is undecidable (variadics).
+fn new_signature_shape(
+    file: &str,
+    new_signature: &str,
+) -> Option<rust_tree_sitter::SignatureShape> {
+    use rust_tree_sitter::Parser;
+    use rust_tree_sitter::languages::Language;
+
+    let info = crate::language::info_for_path(file)?;
+    let lang = info.language;
+
+    let sig = new_signature.trim();
+    if sig.is_empty() {
+        return None;
+    }
+    // Wrap the bare header into a minimal valid definition for `lang`.
+    let wrapped = match lang {
+        Language::Rust => format!("fn {sig} {{}}"),
+        Language::TypeScript | Language::JavaScript => format!("function {sig} {{}}"),
+        Language::Python => format!("def {sig}: pass"),
+        // Other languages: signature_shape returns None for them anyway.
+        _ => return None,
+    };
+
+    let parser = Parser::new(lang).ok()?;
+    let tree = parser.parse(&wrapped, None).ok()?;
+    let root_node = tree.root_node().inner();
+    // The reconstructed def starts at byte 0-ish; the first recognised def
+    // node covers the wrapper. Anchor on a byte inside the header.
+    let anchor = wrapped.find(sig).unwrap_or(0);
+    let def_node = find_def_node(root_node, anchor)?;
+    rust_tree_sitter::signature_shape(def_node, wrapped.as_bytes(), lang)
+}
+
+/// Resolve the `FoundSymbol` (file + byte range) for a name whose `sid`
+/// we already know. Uses the same bare/qualified batch lookup
+/// `verify_signature` uses, then picks the def row whose `sid` matches
+/// `anchor_sid`. Returns `None` on a storage error or when no def row
+/// carries that sid (torn read). Best-effort: the caller treats `None` as
+/// an undecidable signature shape.
+fn resolve_found_for_sid(store: &Arc<Store>, name: &str, anchor_sid: u32) -> Option<FoundSymbol> {
+    let bare = name.rsplit("::").next().unwrap_or(name).to_string();
+    let mut lookup_names: Vec<String> = vec![name.to_string()];
+    if bare != name {
+        lookup_names.push(bare);
+    }
+    let mut batched = store.find_symbols_batch_with_sids(&lookup_names).ok()?;
+    for n in &lookup_names {
+        if let Some((_sid, hits)) = batched.remove(n) {
+            if let Some(found) = hits.into_iter().find(|h| h.sid == anchor_sid) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// `Index.VerifyImpact(symbol, change, new_signature?, depth?)` —
+/// verify-v0 P2.U1, capability `verify_impact`.
+///
+/// A verification-framed wrapper over `Index.ImpactOf`: the agent declares
+/// an intended change to `symbol` and gets the blast radius as a pass/fail
+/// `verdict` so it can gate an edit before making it.
+///
+/// Wire shape:
+/// ```jsonc
+/// { "resolution": "exact",          // exact | not_found | indeterminate
+///   "verdict": "would_break",       // would_break | safe (OMITTED on not_found)
+///   "change": "signature",
+///   "affected_count": 5,
+///   "affected_callers": [ { "file": "...", "line": 1532,
+///                           "enclosing": "<qualified_name>", "depth": 1,
+///                           "reason": "arity 1 -> 2" } ],
+///   "symbol": "store::Store::commit_batch",
+///   "truncated": false,             // true → affected_count is a lower bound
+///   "candidates": [] }              // populated only on not_found
+/// ```
+///
+/// Verdict logic (conservative — a false `would_break` only costs a
+/// review; a false `safe` ships a break):
+/// - `remove`/`rename`: `would_break` iff any callers, else `safe`.
+/// - `signature`: decidable old+new shape with differing arity →
+///   `would_break` (exact); equal arity → `safe` (exact, still lists
+///   callers); undecidable shape OR no `new_signature` → `would_break`
+///   iff any callers (indeterminate, `reason:"undecidable_signature"`).
+/// - Unknown symbol → `not_found`, `exists:false`, ranked `candidates[]`,
+///   NO `verdict`.
+///
+/// Default `depth` is 1 (direct callers) — a gate wants immediate
+/// breakage. `INVALID_PARAMS` on empty/oversize `symbol`. Walks the
+/// reverse call graph → cancellable.
+pub async fn verify_impact(
+    params: serde_json::Value,
+    state: &Arc<DaemonState>,
+    token: CancelToken,
+) -> Result<serde_json::Value, ProtocolError> {
+    if token.is_cancelled() {
+        return Err(cancelled());
+    }
+    let p: VerifyImpactParams = parse_params(params)?;
+    if p.symbol.is_empty() || p.symbol.len() > 256 {
+        return Err(ProtocolError::new(
+            ErrorCode::InvalidParams,
+            "`symbol` must be 1..=256 characters",
+        ));
+    }
+
+    let (root, store_arc) = snapshot(state)?;
+    // Read generation BEFORE any read txn (Deepening §C cache invariant).
+    let generation = state.index_generation.load(Ordering::Relaxed);
+    let ranks = symbol_ranks_lazy(state, &store_arc, generation)?;
+
+    // Resolve the def's sid. A miss is a RESULT (not an error): return
+    // not_found + a ranked candidate shortlist so the agent self-corrects.
+    let anchor_sid = match store_arc.sid_for_name(&p.symbol).map_err(|e| {
+        ProtocolError::new(
+            ErrorCode::InternalError,
+            format!("sid_for_name storage error: {e:#}"),
+        )
+    })? {
+        Some(s) => s,
+        None => {
+            if token.is_cancelled() {
+                return Err(cancelled());
+            }
+            /// Near-miss candidate count surfaced on a `not_found`.
+            const CANDIDATE_LIMIT: usize = 5;
+            let bare = p.symbol.rsplit("::").next().unwrap_or(&p.symbol);
+            let pool = verify_candidate_pool(&store_arc, ranks.as_ref())?;
+            let candidates =
+                rust_tree_sitter::rank_candidates(bare, pool.into_iter(), CANDIDATE_LIMIT);
+            let candidates_json: Vec<serde_json::Value> = candidates
+                .into_iter()
+                .map(|c| {
+                    serde_json::json!({
+                        "qualified_name": c.qualified_name,
+                        "edit_distance":  c.edit_distance,
+                        "pagerank":       c.pagerank,
+                    })
+                })
+                .collect();
+            return Ok(serde_json::json!({
+                "resolution": rust_tree_sitter::Resolution::NotFound,
+                "exists":     false,
+                "change":     p.change.as_wire_str(),
+                "symbol":     p.symbol,
+                "candidates": candidates_json,
+            }));
+        }
+    };
+
+    // Run the impact BFS — direct callers by default (depth 1). Reuse
+    // ImpactBounds; CPU-bound BFS runs on a blocking thread like impact_of.
+    let bounds = crate::impact::ImpactBounds {
+        max_depth: p.depth.unwrap_or(1),
+        max_nodes: crate::impact::DEFAULT_MAX_NODES,
+        token_budget: crate::impact::DEFAULT_TOKEN_BUDGET,
+        exclude_test_paths: true,
+    };
+    let store_clone = store_arc.clone();
+    let ranks_clone = ranks.clone();
+    let token_clone = token.clone();
+    let walk = tokio::task::spawn_blocking(move || {
+        crate::impact::compute(
+            &store_clone,
+            anchor_sid,
+            bounds,
+            ranks_clone.as_deref(),
+            &token_clone,
+        )
+    })
+    .await
+    .map_err(|e| ProtocolError::new(ErrorCode::InternalError, format!("impact join error: {e}")))?
+    .map_err(|e| {
+        ProtocolError::new(
+            ErrorCode::InternalError,
+            format!("impact compute error: {e:#}"),
+        )
+    })?;
+    if token.is_cancelled() {
+        return Err(cancelled());
+    }
+
+    let affected_count = walk.impact.len();
+    // `affected_count` respects impact truncation: if ANY bound fired the
+    // BFS stopped early, so the count is a LOWER BOUND. Surface that so a
+    // gate doesn't read a partial `safe`-ish count as authoritative.
+    let truncated = walk.closure_truncated
+        || walk.wall_clock_truncated
+        || walk.depth_truncated
+        || walk.node_count_truncated;
+
+    // Decide the verdict + per-caller reason.
+    let (resolution, verdict, reason, per_caller_reason): (
+        rust_tree_sitter::Resolution,
+        bool, // would_break
+        Option<rust_tree_sitter::IndeterminateReason>,
+        String,
+    ) = match p.change {
+        VerifyImpactChange::Remove => (
+            rust_tree_sitter::Resolution::Exact,
+            affected_count > 0,
+            None,
+            "references removed symbol".to_string(),
+        ),
+        VerifyImpactChange::Rename => (
+            rust_tree_sitter::Resolution::Exact,
+            affected_count > 0,
+            None,
+            "references old name".to_string(),
+        ),
+        VerifyImpactChange::Signature => {
+            // Resolve the def's FoundSymbol (file + byte range) so we can
+            // read its ACTUAL shape and pick the right language for the
+            // proposed new_signature. Reuse the same bare/qualified name
+            // lookup verify_signature uses, then pick the def whose sid
+            // matches the anchor we already resolved.
+            let def = resolve_found_for_sid(&store_arc, &p.symbol, anchor_sid);
+            // OLD shape: from the indexed def (reuse verify_signature's helper).
+            let old_shape = def
+                .as_ref()
+                .and_then(|found| actual_signature_shape(&root, found));
+            // NEW shape: from the proposed new_signature string, parsed for
+            // the def's language.
+            let new_shape = match (&def, p.new_signature.as_deref()) {
+                (Some(found), Some(sig)) => new_signature_shape(&found.file, sig),
+                _ => None,
+            };
+            match (old_shape, new_shape) {
+                (Some(old), Some(new)) if old.arity != new.arity => (
+                    rust_tree_sitter::Resolution::Exact,
+                    true,
+                    None,
+                    format!("arity {} -> {}", old.arity, new.arity),
+                ),
+                (Some(_), Some(_)) => (
+                    // Arity-compatible: provably no arity break. Still list
+                    // callers for review, but verdict is safe.
+                    rust_tree_sitter::Resolution::Exact,
+                    false,
+                    None,
+                    "arity unchanged".to_string(),
+                ),
+                _ => (
+                    // Can't prove safe → conservative would_break iff callers.
+                    rust_tree_sitter::Resolution::Indeterminate,
+                    affected_count > 0,
+                    Some(rust_tree_sitter::IndeterminateReason::UndecidableSignature),
+                    "signature change, impact undecidable".to_string(),
+                ),
+            }
+        }
+    };
+
+    let affected_callers: Vec<serde_json::Value> = walk
+        .impact
+        .iter()
+        .map(|e| {
+            serde_json::json!({
+                "file":      e.file,
+                "line":      e.start_line,
+                "enclosing": e.qualified_name,
+                "depth":     e.depth,
+                "reason":    per_caller_reason,
+            })
+        })
+        .collect();
+
+    let mut out = serde_json::json!({
+        "resolution":       resolution,
+        "verdict":          if verdict { "would_break" } else { "safe" },
+        "change":           p.change.as_wire_str(),
+        "affected_count":   affected_count,
+        "affected_callers": affected_callers,
+        "symbol":           p.symbol,
+        "truncated":        truncated,
+        "candidates":       [],
+    });
+    if let Some(r) = reason {
+        out["reason"] = serde_json::json!(r);
+    }
+    Ok(out)
 }
 
 /// Internal struct used by `find_callers` (and U2's `read_symbol`

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -3525,29 +3525,6 @@ fn new_signature_shape(
     rust_tree_sitter::signature_shape(def_node, wrapped.as_bytes(), lang)
 }
 
-/// Resolve the `FoundSymbol` (file + byte range) for a name whose `sid`
-/// we already know. Uses the same bare/qualified batch lookup
-/// `verify_signature` uses, then picks the def row whose `sid` matches
-/// `anchor_sid`. Returns `None` on a storage error or when no def row
-/// carries that sid (torn read). Best-effort: the caller treats `None` as
-/// an undecidable signature shape.
-fn resolve_found_for_sid(store: &Arc<Store>, name: &str, anchor_sid: u32) -> Option<FoundSymbol> {
-    let bare = name.rsplit("::").next().unwrap_or(name).to_string();
-    let mut lookup_names: Vec<String> = vec![name.to_string()];
-    if bare != name {
-        lookup_names.push(bare);
-    }
-    let mut batched = store.find_symbols_batch_with_sids(&lookup_names).ok()?;
-    for n in &lookup_names {
-        if let Some((_sid, hits)) = batched.remove(n) {
-            if let Some(found) = hits.into_iter().find(|h| h.sid == anchor_sid) {
-                return Some(found);
-            }
-        }
-    }
-    None
-}
-
 /// `Index.VerifyImpact(symbol, change, new_signature?, depth?)` —
 /// verify-v0 P2.U1, capability `verify_impact`.
 ///
@@ -3603,25 +3580,62 @@ pub async fn verify_impact(
     let generation = state.index_generation.load(Ordering::Relaxed);
     let ranks = symbol_ranks_lazy(state, &store_arc, generation)?;
 
-    // Resolve the def's sid. A miss is a RESULT (not an error): return
-    // not_found + a ranked candidate shortlist so the agent self-corrects.
-    let anchor_sid = match store_arc.sid_for_name(&p.symbol).map_err(|e| {
-        ProtocolError::new(
-            ErrorCode::InternalError,
-            format!("sid_for_name storage error: {e:#}"),
-        )
-    })? {
-        Some(s) => s,
+    // Resolve the anchor def. Honor a QUALIFIED input (`Foo::method`) the
+    // way `verify_symbol` does: resolve the bare final segment, then narrow
+    // to the def whose immediate container matches the qualifier — so a
+    // qualified claim never resolves to a same-named method on another type.
+    // A miss is a RESULT (not an error): return not_found + ranked candidates.
+    let bare = p
+        .symbol
+        .rsplit("::")
+        .next()
+        .unwrap_or(&p.symbol)
+        .to_string();
+    let qualifier: Option<String> = if p.symbol.contains("::") {
+        let mut segs: Vec<&str> = p.symbol.split("::").collect();
+        segs.pop(); // drop the final (bare) segment
+        segs.into_iter()
+            .rev()
+            .find(|s| !s.is_empty())
+            .map(str::to_string)
+    } else {
+        None
+    };
+    let mut lookup_names: Vec<String> = vec![p.symbol.clone()];
+    if bare != p.symbol {
+        lookup_names.push(bare.clone());
+    }
+    let mut batched = store_arc
+        .find_symbols_batch_with_sids(&lookup_names)
+        .map_err(|e| {
+            ProtocolError::new(
+                ErrorCode::InternalError,
+                format!("find_symbols_batch_with_sids storage error: {e:#}"),
+            )
+        })?;
+    let mut hits: Vec<FoundSymbol> = Vec::new();
+    for n in &lookup_names {
+        if let Some((_sid, found)) = batched.remove(n) {
+            if !found.is_empty() {
+                hits = found;
+                break;
+            }
+        }
+    }
+    if let Some(q) = &qualifier {
+        hits.retain(|h| h.parent.as_deref() == Some(q.as_str()));
+    }
+    let anchor = match hits.into_iter().next() {
+        Some(a) => a,
         None => {
             if token.is_cancelled() {
                 return Err(cancelled());
             }
             /// Near-miss candidate count surfaced on a `not_found`.
             const CANDIDATE_LIMIT: usize = 5;
-            let bare = p.symbol.rsplit("::").next().unwrap_or(&p.symbol);
             let pool = verify_candidate_pool(&store_arc, ranks.as_ref())?;
             let candidates =
-                rust_tree_sitter::rank_candidates(bare, pool.into_iter(), CANDIDATE_LIMIT);
+                rust_tree_sitter::rank_candidates(&bare, pool.into_iter(), CANDIDATE_LIMIT);
             let candidates_json: Vec<serde_json::Value> = candidates
                 .into_iter()
                 .map(|c| {
@@ -3641,6 +3655,7 @@ pub async fn verify_impact(
             }));
         }
     };
+    let anchor_sid = anchor.sid;
 
     // Run the impact BFS — direct callers by default (depth 1). Reuse
     // ImpactBounds; CPU-bound BFS runs on a blocking thread like impact_of.
@@ -3703,22 +3718,14 @@ pub async fn verify_impact(
             "references old name".to_string(),
         ),
         VerifyImpactChange::Signature => {
-            // Resolve the def's FoundSymbol (file + byte range) so we can
-            // read its ACTUAL shape and pick the right language for the
-            // proposed new_signature. Reuse the same bare/qualified name
-            // lookup verify_signature uses, then pick the def whose sid
-            // matches the anchor we already resolved.
-            let def = resolve_found_for_sid(&store_arc, &p.symbol, anchor_sid);
-            // OLD shape: from the indexed def (reuse verify_signature's helper).
-            let old_shape = def
-                .as_ref()
-                .and_then(|found| actual_signature_shape(&root, found));
-            // NEW shape: from the proposed new_signature string, parsed for
-            // the def's language.
-            let new_shape = match (&def, p.new_signature.as_deref()) {
-                (Some(found), Some(sig)) => new_signature_shape(&found.file, sig),
-                _ => None,
-            };
+            // OLD shape: from the resolved anchor def (reuse verify_signature's
+            // helper). NEW shape: from the proposed new_signature string,
+            // parsed for the anchor's language.
+            let old_shape = actual_signature_shape(&root, &anchor);
+            let new_shape = p
+                .new_signature
+                .as_deref()
+                .and_then(|sig| new_signature_shape(&anchor.file, sig));
             match (old_shape, new_shape) {
                 (Some(old), Some(new)) if old.arity != new.arity => (
                     rust_tree_sitter::Resolution::Exact,

--- a/crates/rts-daemon/src/methods/mod.rs
+++ b/crates/rts-daemon/src/methods/mod.rs
@@ -191,6 +191,10 @@ pub async fn dispatch(
             counters.index_impact_of.fetch_add(1, Relaxed);
             index::impact_of(params, state, token).await
         }
+        "Index.VerifyImpact" => {
+            counters.index_verify_impact.fetch_add(1, Relaxed);
+            index::verify_impact(params, state, token).await
+        }
         "Index.ReadRange" => {
             counters.index_read_range.fetch_add(1, Relaxed);
             index::read_range(params, state).await
@@ -269,6 +273,7 @@ fn is_cancellable_method(method: &str) -> bool {
             | "Index.VerifyImport"
             | "Index.VerifyClaims"
             | "Index.ImpactOf"
+            | "Index.VerifyImpact"
             | "Index.ReadSymbol"
             | "Index.Outline"
             | "Workspace.Mount"

--- a/crates/rts-daemon/src/state.rs
+++ b/crates/rts-daemon/src/state.rs
@@ -381,6 +381,7 @@ pub struct CallCounters {
     /// verify-v0 P1.U4: `Index.VerifyClaims` calls.
     pub index_verify_claims: AtomicU64,
     pub index_impact_of: AtomicU64,
+    pub index_verify_impact: AtomicU64,
     pub index_read_range: AtomicU64,
     pub index_read_symbol: AtomicU64,
     pub index_read_symbol_at: AtomicU64,
@@ -430,6 +431,7 @@ impl CallCounters {
             "Index.VerifyImport":  self.index_verify_import.load(Relaxed),
             "Index.VerifyClaims":  self.index_verify_claims.load(Relaxed),
             "Index.ImpactOf":      self.index_impact_of.load(Relaxed),
+            "Index.VerifyImpact":  self.index_verify_impact.load(Relaxed),
             "Index.ReadRange":     self.index_read_range.load(Relaxed),
             "Index.ReadSymbol":    self.index_read_symbol.load(Relaxed),
             "Index.ReadSymbolAt":  self.index_read_symbol_at.load(Relaxed),
@@ -465,6 +467,7 @@ impl CallCounters {
             + self.index_verify_import.load(Relaxed)
             + self.index_verify_claims.load(Relaxed)
             + self.index_impact_of.load(Relaxed)
+            + self.index_verify_impact.load(Relaxed)
             + self.index_read_range.load(Relaxed)
             + self.index_read_symbol.load(Relaxed)
             + self.index_read_symbol_at.load(Relaxed)

--- a/crates/rts-daemon/tests/protocol_schemas.rs
+++ b/crates/rts-daemon/tests/protocol_schemas.rs
@@ -48,6 +48,7 @@ const PROTOCOL_METHODS: &[&str] = &[
     "Index.VerifyImport",
     "Index.VerifyClaims",
     "Index.ImpactOf",
+    "Index.VerifyImpact",
     "Index.ReadRange",
     "Index.ReadSymbol",
     "Index.ReadSymbolAt",
@@ -309,6 +310,10 @@ async fn response_matches_schema_for_each_method() -> anyhow::Result<()> {
             ]}),
         ),
         ("Index.ImpactOf", json!({"name": "answer"})),
+        (
+            "Index.VerifyImpact",
+            json!({"symbol": "answer", "change": "remove"}),
+        ),
         ("Index.Outline", json!({"token_budget": 4096})),
         ("Index.Grep", json!({"text": "answer"})),
         (
@@ -402,6 +407,7 @@ const EXPECTED_CAPABILITIES: &[&str] = &[
     "verify_signature",
     "verify_import",
     "verify_claims",
+    "verify_impact",
 ];
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/rts-daemon/tests/verify_impact_round_trip.rs
+++ b/crates/rts-daemon/tests/verify_impact_round_trip.rs
@@ -160,6 +160,7 @@ async fn verify_impact_round_trip() -> anyhow::Result<()> {
         workspace.path().join("hub.rs"),
         "pub fn target(x: u32) -> u32 { x + 1 }\n\
          pub fn orphan(y: u32) -> u32 { y + 2 }\n\
+         pub fn tested_only(z: u32) -> u32 { z }\n\
          pub struct Hub;\n\
          impl Hub { pub fn ping(&self) -> u32 { 0 } }\n",
     )?;
@@ -167,6 +168,22 @@ async fn verify_impact_round_trip() -> anyhow::Result<()> {
         workspace.path().join("caller_a.rs"),
         "use crate::target;\n\
          pub fn caller_a() { let _ = target(1); }\n",
+    )?;
+    // The ONLY caller of `tested_only` lives in a test-path file — an edit
+    // gate must still report would_break (breaking a test is not `safe`).
+    std::fs::write(
+        workspace.path().join("probe_test.rs"),
+        "use crate::tested_only;\n\
+         pub fn probe() { let _ = tested_only(1); }\n",
+    )?;
+    // Two defs of the same bare name `dup` → an ambiguous impact target.
+    std::fs::write(
+        workspace.path().join("dup_x.rs"),
+        "pub fn dup() -> u32 { 1 }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("dup_y.rs"),
+        "pub fn dup() -> u32 { 2 }\n",
     )?;
 
     let socket_path = if cfg!(target_os = "macos") {
@@ -208,7 +225,16 @@ async fn verify_impact_round_trip() -> anyhow::Result<()> {
     wait_for_symbol(&mut stream, "orphan", Duration::from_secs(5)).await?;
     wait_for_symbol(&mut stream, "caller_a", Duration::from_secs(5)).await?;
     wait_for_symbol(&mut stream, "ping", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "tested_only", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "dup", Duration::from_secs(5)).await?;
     wait_for_refs(&mut stream, "target", &["caller_a"], Duration::from_secs(5)).await?;
+    wait_for_refs(
+        &mut stream,
+        "tested_only",
+        &["probe"],
+        Duration::from_secs(5),
+    )
+    .await?;
 
     // 1. remove of a called fn → would_break + caller listed.
     let rm = round_trip(
@@ -355,6 +381,51 @@ async fn verify_impact_round_trip() -> anyhow::Result<()> {
         qbad["resolution"], "not_found",
         "Other::ping must NOT match the bare `ping` under Hub; got {qbad:?}"
     );
+
+    // 8. A symbol called ONLY from a test-path file → would_break. An edit
+    //    gate must count test callers (breaking a test is not `safe`).
+    let tested = round_trip(
+        &mut stream,
+        "17",
+        "Index.VerifyImpact",
+        json!({ "symbol": "tested_only", "change": "remove" }),
+    )
+    .await?;
+    let tr = &tested["result"];
+    assert_eq!(
+        tr["verdict"], "would_break",
+        "a test-only caller must still trip the gate; got {tr:?}"
+    );
+    let tcallers = tr["affected_callers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        tcallers.iter().any(|c| c["file"] == "probe_test.rs"),
+        "the test-path caller must be listed; got {tr:?}"
+    );
+
+    // 9. An overloaded name (two defs of `dup`) → indeterminate, not an
+    //    arbitrary pick. The agent should qualify it.
+    let ambiguous = round_trip(
+        &mut stream,
+        "18",
+        "Index.VerifyImpact",
+        json!({ "symbol": "dup", "change": "remove" }),
+    )
+    .await?;
+    let am = &ambiguous["result"];
+    assert_eq!(
+        am["resolution"], "indeterminate",
+        "an overloaded impact target must be indeterminate; got {am:?}"
+    );
+    assert_eq!(am["reason"], "ambiguous_overload");
+    assert!(
+        am["verdict"].is_null(),
+        "indeterminate must not carry a verdict; got {am:?}"
+    );
+    let ms = am["matches"].as_array().cloned().unwrap_or_default();
+    assert_eq!(ms.len(), 2, "both `dup` defs should be listed; got {am:?}");
 
     Ok(())
 }

--- a/crates/rts-daemon/tests/verify_impact_round_trip.rs
+++ b/crates/rts-daemon/tests/verify_impact_round_trip.rs
@@ -1,0 +1,331 @@
+//! End-to-end test for verify-v0 P2.U1: `Index.VerifyImpact`.
+//!
+//! `Index.VerifyImpact` is a verification-framed wrapper over the impact
+//! analysis: the agent declares an intended change to a symbol and gets the
+//! blast radius as a pass/fail verdict so it can gate an edit before making
+//! it.
+//!
+//! Fixture:
+//!   `hub.rs`      defines `target` (called) and `orphan` (uncalled).
+//!   `caller_a.rs` calls `target`.
+//!
+//! Cases:
+//!   1. `remove` of a called fn  → would_break + the caller listed.
+//!   2. `remove` of an uncalled fn → safe.
+//!   3. `signature` arity 1→2 on a called fn → would_break + per-caller
+//!      `reason` "arity 1 -> 2".
+//!   4. `signature` arity-preserving rename of a param → safe.
+//!   5. unknown symbol → not_found + non-empty candidates.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+/// Poll `Index.FindCallers(target)` until every name in `expected_callers`
+/// is present — the REFS edges `Index.VerifyImpact`'s BFS depends on are
+/// committed in a separate writer batch from the DEF rows. Mirrors
+/// `impact_of_round_trip.rs::wait_for_refs`.
+async fn wait_for_refs(
+    stream: &mut UnixStream,
+    target: &str,
+    expected_callers: &[&str],
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 200;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindCallers",
+            json!({ "name": target }),
+        )
+        .await?;
+        let callers = resp["result"]["callers"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        let caller_names: Vec<&str> = callers
+            .iter()
+            .filter_map(|c| c["enclosing_qualified_name"].as_str())
+            .collect();
+        let all_present = expected_callers
+            .iter()
+            .all(|expected| caller_names.contains(expected));
+        if all_present {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "REFS to `{target}` never fully settled within {:?} — expected {:?}, got {:?}",
+                timeout,
+                expected_callers,
+                caller_names
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn verify_impact_round_trip() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // `target` is called by caller_a; `orphan` is defined but never called.
+    std::fs::write(
+        workspace.path().join("hub.rs"),
+        "pub fn target(x: u32) -> u32 { x + 1 }\n\
+         pub fn orphan(y: u32) -> u32 { y + 2 }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("caller_a.rs"),
+        "use crate::target;\n\
+         pub fn caller_a() { let _ = target(1); }\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+
+    wait_for_symbol(&mut stream, "target", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "orphan", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "caller_a", Duration::from_secs(5)).await?;
+    wait_for_refs(&mut stream, "target", &["caller_a"], Duration::from_secs(5)).await?;
+
+    // 1. remove of a called fn → would_break + caller listed.
+    let rm = round_trip(
+        &mut stream,
+        "10",
+        "Index.VerifyImpact",
+        json!({ "symbol": "target", "change": "remove" }),
+    )
+    .await?;
+    assert!(rm["error"].is_null(), "verify_impact remove failed: {rm:?}");
+    let r = &rm["result"];
+    assert_eq!(r["resolution"], "exact");
+    assert_eq!(r["verdict"], "would_break", "remove of a called fn: {r:?}");
+    assert_eq!(r["change"], "remove");
+    assert!(
+        r["affected_count"].as_u64().unwrap_or(0) >= 1,
+        "expected >=1 affected caller; got {r:?}"
+    );
+    let callers = r["affected_callers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        callers
+            .iter()
+            .any(|c| c["enclosing"].as_str() == Some("caller_a")),
+        "caller_a should be listed; got {callers:?}"
+    );
+    assert_eq!(
+        callers[0]["reason"], "references removed symbol",
+        "remove reason; got {callers:?}"
+    );
+
+    // 2. remove of an uncalled fn → safe.
+    let rm_orphan = round_trip(
+        &mut stream,
+        "11",
+        "Index.VerifyImpact",
+        json!({ "symbol": "orphan", "change": "remove" }),
+    )
+    .await?;
+    let ro = &rm_orphan["result"];
+    assert_eq!(ro["resolution"], "exact");
+    assert_eq!(ro["verdict"], "safe", "remove of an uncalled fn: {ro:?}");
+    assert_eq!(ro["affected_count"], 0);
+
+    // 3. signature arity 1 -> 2 on a called fn → would_break + per-caller reason.
+    let sig = round_trip(
+        &mut stream,
+        "12",
+        "Index.VerifyImpact",
+        json!({
+            "symbol": "target",
+            "change": "signature",
+            "new_signature": "target(x: u32, y: u32) -> u32"
+        }),
+    )
+    .await?;
+    assert!(
+        sig["error"].is_null(),
+        "verify_impact signature failed: {sig:?}"
+    );
+    let s = &sig["result"];
+    assert_eq!(s["resolution"], "exact", "decidable arity change: {s:?}");
+    assert_eq!(s["verdict"], "would_break", "arity 1 -> 2: {s:?}");
+    let scallers = s["affected_callers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        scallers
+            .iter()
+            .any(|c| c["reason"].as_str() == Some("arity 1 -> 2")),
+        "per-caller arity reason; got {scallers:?}"
+    );
+
+    // 4. signature arity-preserving param rename → safe.
+    let sig_ok = round_trip(
+        &mut stream,
+        "13",
+        "Index.VerifyImpact",
+        json!({
+            "symbol": "target",
+            "change": "signature",
+            "new_signature": "target(renamed: u32) -> u32"
+        }),
+    )
+    .await?;
+    let so = &sig_ok["result"];
+    assert_eq!(so["resolution"], "exact", "arity-preserving: {so:?}");
+    assert_eq!(so["verdict"], "safe", "arity unchanged is safe: {so:?}");
+
+    // 5. unknown symbol → not_found + non-empty candidates, no verdict.
+    let miss = round_trip(
+        &mut stream,
+        "14",
+        "Index.VerifyImpact",
+        json!({ "symbol": "targett", "change": "remove" }),
+    )
+    .await?;
+    let mr = &miss["result"];
+    assert_eq!(mr["resolution"], "not_found");
+    assert_eq!(mr["exists"], false);
+    assert!(
+        mr["verdict"].is_null(),
+        "not_found must not carry a verdict; got {mr:?}"
+    );
+    let cands = mr["candidates"].as_array().cloned().unwrap_or_default();
+    assert!(
+        !cands.is_empty(),
+        "expected candidates on a miss; got {mr:?}"
+    );
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}

--- a/crates/rts-daemon/tests/verify_impact_round_trip.rs
+++ b/crates/rts-daemon/tests/verify_impact_round_trip.rs
@@ -159,7 +159,9 @@ async fn verify_impact_round_trip() -> anyhow::Result<()> {
     std::fs::write(
         workspace.path().join("hub.rs"),
         "pub fn target(x: u32) -> u32 { x + 1 }\n\
-         pub fn orphan(y: u32) -> u32 { y + 2 }\n",
+         pub fn orphan(y: u32) -> u32 { y + 2 }\n\
+         pub struct Hub;\n\
+         impl Hub { pub fn ping(&self) -> u32 { 0 } }\n",
     )?;
     std::fs::write(
         workspace.path().join("caller_a.rs"),
@@ -205,6 +207,7 @@ async fn verify_impact_round_trip() -> anyhow::Result<()> {
     wait_for_symbol(&mut stream, "target", Duration::from_secs(5)).await?;
     wait_for_symbol(&mut stream, "orphan", Duration::from_secs(5)).await?;
     wait_for_symbol(&mut stream, "caller_a", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "ping", Duration::from_secs(5)).await?;
     wait_for_refs(&mut stream, "target", &["caller_a"], Duration::from_secs(5)).await?;
 
     // 1. remove of a called fn → would_break + caller listed.
@@ -317,6 +320,40 @@ async fn verify_impact_round_trip() -> anyhow::Result<()> {
     assert!(
         !cands.is_empty(),
         "expected candidates on a miss; got {mr:?}"
+    );
+
+    // 6. Qualified name whose container matches → resolves (verdict present,
+    //    not not_found). `Hub::ping` is a method of `Hub`.
+    let q_ok = round_trip(
+        &mut stream,
+        "15",
+        "Index.VerifyImpact",
+        json!({ "symbol": "Hub::ping", "change": "remove" }),
+    )
+    .await?;
+    let qok = &q_ok["result"];
+    assert_ne!(
+        qok["resolution"], "not_found",
+        "Hub::ping should resolve to the method; got {qok:?}"
+    );
+    assert!(
+        qok["verdict"].is_string(),
+        "a resolved verify_impact must carry a verdict; got {qok:?}"
+    );
+
+    // 7. Qualified name whose container does NOT match → not_found, even
+    //    though a bare `ping` exists under `Hub` (the false-positive fix).
+    let q_bad = round_trip(
+        &mut stream,
+        "16",
+        "Index.VerifyImpact",
+        json!({ "symbol": "Other::ping", "change": "remove" }),
+    )
+    .await?;
+    let qbad = &q_bad["result"];
+    assert_eq!(
+        qbad["resolution"], "not_found",
+        "Other::ping must NOT match the bare `ping` under Hub; got {qbad:?}"
     );
 
     Ok(())

--- a/crates/rts-mcp/Cargo.toml
+++ b/crates/rts-mcp/Cargo.toml
@@ -58,6 +58,11 @@ serde_json = "1"
 # Errors
 anyhow = "1"
 
+# Use-site reference extraction (F3) + language detection for the
+# `rts verify` subcommand. `rust_tree_sitter` is the rts-core lib name;
+# already in the workspace via rts-bench, so no new transitive deps.
+rust_tree_sitter = { path = "../rts-core" }
+
 # Logging — stderr-only per stdio MCP discipline.
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/crates/rts-mcp/src/bin/rts.rs
+++ b/crates/rts-mcp/src/bin/rts.rs
@@ -134,6 +134,25 @@ enum Cmd {
         #[arg(long)]
         file: Option<String>,
     },
+    /// Verify the blast radius of an intended change to a symbol.
+    ///
+    /// Declares a change (`signature`, `remove`, `rename`) and prints a
+    /// pass/fail verdict (`would_break` | `safe`) plus the affected
+    /// callers, so an edit can be gated before it's made.
+    Impact {
+        /// Exact symbol name (bare or qualified).
+        symbol: String,
+        /// The change kind: `signature`, `remove`, or `rename`.
+        #[arg(long, default_value = "signature")]
+        change: String,
+        /// For `--change signature`: the proposed new signature header,
+        /// e.g. `commit_batch(entries: &[Entry], flush: bool) -> Result<()>`.
+        #[arg(long)]
+        new_signature: Option<String>,
+        /// Blast-radius depth (default 1, direct callers; hard cap 4).
+        #[arg(long)]
+        depth: Option<u32>,
+    },
     /// Print the workspace outline (token-budgeted tree).
     Outline {
         /// Optional glob to restrict the outline.
@@ -514,6 +533,56 @@ async fn run_command(
             let n = cli::render_callers_tree(&body, &mut stdout, style).map_err(io_to_anyhow)?;
             stdout.flush().map_err(io_to_anyhow)?;
             Ok(if n == 0 { exit::NO_RESULTS } else { exit::OK })
+        }
+        Cmd::Impact {
+            symbol,
+            change,
+            new_signature,
+            depth,
+        } => {
+            let mut params = serde_json::Map::new();
+            params.insert("symbol".into(), Value::String(symbol.clone()));
+            params.insert("change".into(), Value::String(change.clone()));
+            if let Some(s) = new_signature {
+                params.insert("new_signature".into(), Value::String(s.clone()));
+            }
+            if let Some(d) = depth {
+                params.insert("depth".into(), Value::Number((*d).into()));
+            }
+            let body = match cli::call_method(
+                &client,
+                workspace,
+                "Index.VerifyImpact",
+                Value::Object(params),
+            )
+            .await
+            {
+                Ok(v) => v,
+                Err(e) => return Ok(cli::render_connection_error(&e, style)),
+            };
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&body).unwrap_or_default()
+                );
+                // Exit OK on a verdict (would_break or safe); NO_RESULTS
+                // only when the symbol wasn't found.
+                let resolved = body
+                    .get("resolution")
+                    .and_then(|v| v.as_str())
+                    .map(|r| r != "not_found")
+                    .unwrap_or(false);
+                return Ok(if resolved { exit::OK } else { exit::NO_RESULTS });
+            }
+            let mut stdout = std::io::stdout().lock();
+            cli::render_impact_verdict(&body, &mut stdout, style).map_err(io_to_anyhow)?;
+            stdout.flush().map_err(io_to_anyhow)?;
+            let resolved = body
+                .get("resolution")
+                .and_then(|v| v.as_str())
+                .map(|r| r != "not_found")
+                .unwrap_or(false);
+            Ok(if resolved { exit::OK } else { exit::NO_RESULTS })
         }
         Cmd::Outline { glob, token_budget } => {
             let mut params = serde_json::Map::new();

--- a/crates/rts-mcp/src/bin/rts.rs
+++ b/crates/rts-mcp/src/bin/rts.rs
@@ -153,6 +153,20 @@ enum Cmd {
         #[arg(long)]
         depth: Option<u32>,
     },
+    /// Verify a file's symbol/import references against the index.
+    ///
+    /// Extracts the use-site references from FILE (calls, types, imports,
+    /// qualified paths), checks each decidable one against the daemon, and
+    /// prints any reference that provably has no matching definition (a
+    /// hallucination) as `FILE:LINE  NAME  (did you mean: …?)`.
+    ///
+    /// Annotate-only — never edits, never blocks. Exit 0 = clean (or the
+    /// file's language has no reference extraction), 1 = ≥1 hallucinated
+    /// reference, 3 = daemon error.
+    Verify {
+        /// Path to the file to verify.
+        path: PathBuf,
+    },
     /// Print the workspace outline (token-budgeted tree).
     Outline {
         /// Optional glob to restrict the outline.
@@ -584,6 +598,7 @@ async fn run_command(
                 .unwrap_or(false);
             Ok(if resolved { exit::OK } else { exit::NO_RESULTS })
         }
+        Cmd::Verify { path } => run_verify(&client, workspace, cli.json, path, style).await,
         Cmd::Outline { glob, token_budget } => {
             let mut params = serde_json::Map::new();
             if let Some(g) = glob {
@@ -675,6 +690,99 @@ async fn run_command(
 
 fn io_to_anyhow(e: std::io::Error) -> CmdError {
     CmdError::Setup(anyhow::anyhow!("stdout write: {e}"))
+}
+
+/// `rts verify <FILE>` — check a file's symbol/import references against
+/// the index and report the hallucinated (`not_found`) ones.
+///
+/// Pipeline (mirrors `rts-bench`'s `verify_metrics` routing):
+///   1. Detect FILE's language from its extension. Unsupported / unknown
+///      language → print nothing, exit OK ("nothing checkable").
+///   2. `extract_references` (F3) → the use-site references.
+///   3. For each DECIDABLE ref, call the daemon: `Import` →
+///      `Index.VerifyImport`, `Call`/`Type`/`Path` → `Index.VerifySymbol`.
+///      Collect the ones whose `resolution == "not_found"`; skip `exact`
+///      and `indeterminate`.
+///   4. Print each hallucination + (optional) top candidate.
+///
+/// Exit codes: OK (clean / unsupported / nothing to check), NO_RESULTS
+/// (≥1 hallucination — repurposed as the hook's "found something" signal),
+/// DAEMON_ERROR (any daemon contact failure).
+async fn run_verify(
+    client: &rts_mcp::connection::ConnectionManager,
+    workspace: &std::path::Path,
+    json: bool,
+    path: &std::path::Path,
+    style: &Style,
+) -> Result<i32, CmdError> {
+    // 1. Read the file. A missing/unreadable file is a setup error
+    // (exit 3) — the hook only ever calls us on a path the tool just
+    // wrote, but a CLI user deserves a clear message.
+    let bytes = std::fs::read(path).map_err(|e| anyhow::anyhow!("read {}: {e}", path.display()))?;
+
+    // Detect language from the path's extension (same table the daemon
+    // and indexer use). Unsupported / unknown → nothing checkable.
+    let path_str = path.to_string_lossy();
+    let lang = match rust_tree_sitter::detect_language_from_path(&path_str) {
+        Some(l) if rust_tree_sitter::supports_references(l) => l,
+        _ => return Ok(cli::exit::OK),
+    };
+
+    // 2. Extract references (F3).
+    let refs = rust_tree_sitter::extract_references(&bytes, lang);
+
+    // 3. Check each decidable reference against the daemon.
+    let mut halls: Vec<cli::Hallucination> = Vec::new();
+    for r in &refs {
+        let (method, params, name) = cli::verify_route(r);
+        let body = match cli::call_method(client, workspace, method, params).await {
+            Ok(v) => v,
+            Err(e) => return Ok(cli::render_connection_error(&e, style)),
+        };
+        let resolution = body
+            .get("resolution")
+            .and_then(|v| v.as_str())
+            .unwrap_or("indeterminate");
+        // Only `not_found` is a hallucination. `exact` and
+        // `indeterminate` are not surfaced (annotate-only, honest:
+        // never flag an undecidable reference).
+        if resolution == "not_found" {
+            halls.push(cli::Hallucination {
+                name,
+                line: r.line,
+                did_you_mean: cli::top_candidate(&body),
+            });
+        }
+    }
+
+    // 4. Emit.
+    if json {
+        let body = serde_json::json!({
+            "file": path_str,
+            "hallucinations": halls
+                .iter()
+                .map(|h| serde_json::json!({
+                    "name": h.name,
+                    "line": h.line,
+                    "did_you_mean": h.did_you_mean,
+                }))
+                .collect::<Vec<_>>(),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&body).unwrap_or_default()
+        );
+    } else {
+        let mut stdout = std::io::stdout().lock();
+        cli::render_verify(&path_str, &halls, &mut stdout, style).map_err(io_to_anyhow)?;
+        stdout.flush().map_err(io_to_anyhow)?;
+    }
+
+    Ok(if halls.is_empty() {
+        cli::exit::OK
+    } else {
+        cli::exit::NO_RESULTS
+    })
 }
 
 /// `rts telemetry {status,preview,enable,disable,flush}` dispatch.

--- a/crates/rts-mcp/src/bin/rts.rs
+++ b/crates/rts-mcp/src/bin/rts.rs
@@ -705,9 +705,10 @@ fn io_to_anyhow(e: std::io::Error) -> CmdError {
 ///      and `indeterminate`.
 ///   4. Print each hallucination + (optional) top candidate.
 ///
-/// Exit codes: OK (clean / unsupported / nothing to check), NO_RESULTS
+/// Exit codes: OK=0 (clean / unsupported / nothing to check), NO_RESULTS=1
 /// (≥1 hallucination — repurposed as the hook's "found something" signal),
-/// DAEMON_ERROR (any daemon contact failure).
+/// DAEMON_ERROR=3 / TIMEOUT=4 (any daemon contact failure — the hook treats
+/// every non-1 exit as "nothing to surface", so 3 and 4 are both silent).
 async fn run_verify(
     client: &rts_mcp::connection::ConnectionManager,
     workspace: &std::path::Path,

--- a/crates/rts-mcp/src/cli.rs
+++ b/crates/rts-mcp/src/cli.rs
@@ -710,6 +710,84 @@ pub fn render_stats<W: Write>(body: &Value, w: &mut W, style: &Style) -> std::io
     Ok(pairs.len().max(1))
 }
 
+// ── verify (file-reference check) ─────────────────────────────────────
+
+/// One hallucinated reference discovered by `rts verify`: a decidable
+/// symbol/import reference whose `resolution == "not_found"`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Hallucination {
+    /// The referenced name (final segment for qualified refs / imports).
+    pub name: String,
+    /// 1-based line of the reference in the verified file.
+    pub line: usize,
+    /// The top "did you mean" candidate's qualified name, if any.
+    pub did_you_mean: Option<String>,
+}
+
+/// Route one reference to its verify method + params, mirroring the
+/// routing in `rts-bench`'s `verify_metrics.rs`:
+/// - `Import` → `Index.VerifyImport { path }`
+/// - `Call` / `Type` / `Path` → `Index.VerifySymbol { name }`
+///
+/// Returns `(method, params, name)` where `name` is the human-facing
+/// label for the reference. Kept a tight local helper (not shared with
+/// the bench crate) on purpose.
+pub fn verify_route(r: &rust_tree_sitter::Reference) -> (&'static str, Value, String) {
+    use rust_tree_sitter::RefKind;
+    match r.kind {
+        RefKind::Import => {
+            let path = r.qualified.as_deref().unwrap_or(&r.name).to_string();
+            (
+                "Index.VerifyImport",
+                serde_json::json!({ "path": path }),
+                r.name.clone(),
+            )
+        }
+        RefKind::Call | RefKind::Type | RefKind::Path => (
+            "Index.VerifySymbol",
+            serde_json::json!({ "name": r.name }),
+            r.name.clone(),
+        ),
+    }
+}
+
+/// Pull the top candidate's `qualified_name` from a verify response
+/// body's `candidates[0]`, when present.
+pub fn top_candidate(body: &Value) -> Option<String> {
+    body.get("candidates")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .and_then(|c| c.get("qualified_name"))
+        .and_then(|q| q.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Render the collected hallucinations as `<file>:<line>  <name>
+/// (did you mean: <top candidate>?)` lines. Returns the number of
+/// lines written (== hallucination count). `rel` is the file label
+/// (typically the path as the user passed it).
+pub fn render_verify<W: Write>(
+    rel: &str,
+    halls: &[Hallucination],
+    w: &mut W,
+    style: &Style,
+) -> std::io::Result<usize> {
+    for h in halls {
+        let loc = format!("{rel}:{}", h.line);
+        match &h.did_you_mean {
+            Some(cand) => writeln!(
+                w,
+                "{}  {}  {}",
+                style.magenta(&loc),
+                style.yellow(&h.name),
+                style.dim(&format!("(did you mean: {cand}?)")),
+            )?,
+            None => writeln!(w, "{}  {}", style.magenta(&loc), style.yellow(&h.name),)?,
+        }
+    }
+    Ok(halls.len())
+}
+
 /// Truncate a string to `max` characters, suffixing `…` when the
 /// original was longer. Operates on chars, not bytes, so multi-byte
 /// identifiers don't split mid-codepoint.

--- a/crates/rts-mcp/src/cli.rs
+++ b/crates/rts-mcp/src/cli.rs
@@ -500,6 +500,112 @@ pub fn render_callers_tree<W: Write>(
     Ok(callers.len())
 }
 
+/// Render an `Index.VerifyImpact` verdict: a one-line headline
+/// (`would_break` / `safe` / `not_found`) followed by the affected
+/// callers grouped by file (mirrors `render_callers_tree`). Returns the
+/// number of affected callers so the binary can pick an exit code.
+pub fn render_impact_verdict<W: Write>(
+    body: &Value,
+    w: &mut W,
+    style: &Style,
+) -> std::io::Result<usize> {
+    let resolution = body
+        .get("resolution")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?");
+    let symbol = body.get("symbol").and_then(|v| v.as_str()).unwrap_or("?");
+    let change = body.get("change").and_then(|v| v.as_str()).unwrap_or("?");
+
+    // Miss: not_found + did-you-mean candidates, no verdict.
+    if resolution == "not_found" {
+        writeln!(
+            w,
+            "{} {} ({})",
+            style.red("not found"),
+            style.bold(symbol),
+            change
+        )?;
+        let cands = body
+            .get("candidates")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        if !cands.is_empty() {
+            writeln!(w, "{}", style.dim("did you mean:"))?;
+            for c in &cands {
+                let qn = c
+                    .get("qualified_name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                writeln!(w, "  {}", style.cyan(qn))?;
+            }
+        }
+        return Ok(0);
+    }
+
+    let verdict = body.get("verdict").and_then(|v| v.as_str()).unwrap_or("?");
+    let count = body
+        .get("affected_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let headline = if verdict == "would_break" {
+        style.red("WOULD BREAK")
+    } else {
+        style.green("SAFE")
+    };
+    let mut line = format!("{headline} {} ({change})", style.bold(symbol));
+    if resolution == "indeterminate" {
+        let reason = body.get("reason").and_then(|v| v.as_str()).unwrap_or("");
+        line.push_str(&format!(
+            " {}",
+            style.dim(&format!("[indeterminate: {reason}]"))
+        ));
+    }
+    writeln!(w, "{line}")?;
+    let truncated = body
+        .get("truncated")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let count_note = if truncated {
+        format!("{count}+ affected caller(s) (truncated — lower bound)")
+    } else {
+        format!("{count} affected caller(s)")
+    };
+    writeln!(w, "{}", style.dim(&count_note))?;
+
+    let callers = body
+        .get("affected_callers")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let mut grouped: std::collections::BTreeMap<&str, Vec<&Value>> =
+        std::collections::BTreeMap::new();
+    for c in &callers {
+        let file = c.get("file").and_then(|v| v.as_str()).unwrap_or("?");
+        grouped.entry(file).or_default().push(c);
+    }
+    for (file, entries) in grouped {
+        writeln!(w, "{}", style.magenta(file))?;
+        for c in entries {
+            let cline = c.get("line").and_then(|v| v.as_u64()).unwrap_or(0);
+            let enclosing = c
+                .get("enclosing")
+                .and_then(|v| v.as_str())
+                .unwrap_or("<file-scope>");
+            let reason = c.get("reason").and_then(|v| v.as_str()).unwrap_or("");
+            writeln!(
+                w,
+                "  {}:{}  {} {}",
+                style.dim("L"),
+                style.green(&cline.to_string()),
+                style.bold(enclosing),
+                style.cyan(&format!("({reason})")),
+            )?;
+        }
+    }
+    Ok(callers.len())
+}
+
 /// Render the daemon's `outline_text` directly. The daemon already
 /// produces a dotted-indent tree-style hierarchy (protocol-v0 §7.5);
 /// we just pass it through (with a header) so the CLI shape stays

--- a/crates/rts-mcp/src/server.rs
+++ b/crates/rts-mcp/src/server.rs
@@ -254,6 +254,26 @@ pub struct ImpactOfArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct VerifyImpactArgs {
+    /// Symbol whose change you want to gate — bare (`commit_batch`) or
+    /// qualified (`Store::commit_batch`). 1..=256 chars.
+    pub symbol: String,
+    /// The kind of change you intend: `signature`, `remove`, or `rename`.
+    pub change: String,
+    /// For `change: signature` — the proposed new signature header, e.g.
+    /// `commit_batch(entries: &[Entry], flush: bool) -> Result<()>`. When
+    /// present and parseable, the arity is compared against the indexed
+    /// def; absent or undecidable → conservative `would_break` if there
+    /// are any callers, with `resolution: indeterminate`.
+    #[serde(default)]
+    pub new_signature: Option<String>,
+    /// Blast-radius depth. Default 1 (direct callers only) — a gate wants
+    /// immediate breakage. Hard cap 4.
+    #[serde(default)]
+    pub depth: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct ReadSymbolAtArgs {
     /// Workspace-relative file path.
     pub file: String,
@@ -681,6 +701,31 @@ impl RtsServer {
         }
         match self
             .call_daemon("Index.ImpactOf", Value::Object(params))
+            .await
+        {
+            Ok(v) => Ok(success_json(&v)),
+            Err(e) => Ok(connection_error_to_call_result(&e)),
+        }
+    }
+
+    #[tool(
+        description = "Gate an edit before you make it: declare a change to a symbol (`signature`, `remove`, `rename`) and get the blast radius as a pass/fail `verdict` (would_break | safe). Prefer this over a manual `impact_of` plus eyeballing, or `Bash(grep 'name(')` to guess callers, before you rename or change the arity of a function: it resolves the def, walks the indexed reverse-reference graph for direct callers, and for `signature` compares the new arity to the real one (pass `new_signature`). Use when the task includes 'is it safe to change', 'will this break callers', or you're about to edit a public symbol. `would_break` lists `affected_callers[]` with a per-caller `reason`; `safe` means no arity break; `not_found` returns ranked `candidates[]`."
+    )]
+    async fn verify_impact(
+        &self,
+        Parameters(args): Parameters<VerifyImpactArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut params = serde_json::Map::new();
+        params.insert("symbol".into(), Value::String(args.symbol));
+        params.insert("change".into(), Value::String(args.change));
+        if let Some(s) = args.new_signature {
+            params.insert("new_signature".into(), Value::String(s));
+        }
+        if let Some(d) = args.depth {
+            params.insert("depth".into(), Value::Number(d.into()));
+        }
+        match self
+            .call_daemon("Index.VerifyImpact", Value::Object(params))
             .await
         {
             Ok(v) => Ok(success_json(&v)),

--- a/crates/rts-mcp/src/server.rs
+++ b/crates/rts-mcp/src/server.rs
@@ -709,7 +709,7 @@ impl RtsServer {
     }
 
     #[tool(
-        description = "Gate an edit before you make it: declare a change to a symbol (`signature`, `remove`, `rename`) and get the blast radius as a pass/fail `verdict` (would_break | safe). Prefer this over a manual `impact_of` plus eyeballing, or `Bash(grep 'name(')` to guess callers, before you rename or change the arity of a function: it resolves the def, walks the indexed reverse-reference graph for direct callers, and for `signature` compares the new arity to the real one (pass `new_signature`). Use when the task includes 'is it safe to change', 'will this break callers', or you're about to edit a public symbol. `would_break` lists `affected_callers[]` with a per-caller `reason`; `safe` means no arity break; `not_found` returns ranked `candidates[]`."
+        description = "Gate an edit before you make it: declare a change to a symbol (`signature`, `remove`, `rename`) and get the blast radius as a pass/fail `verdict` (would_break | safe). Prefer this over a manual `impact_of` plus eyeballing, or `Bash(grep 'name(')`, before you rename or change a function's arity: it resolves the def, walks the reverse-reference graph for direct callers, and for `signature` compares the new arity to the real one (pass `new_signature`). Use when the task says 'is it safe to change' or 'will this break callers'. `would_break` lists `affected_callers[]` with a per-caller `reason`; `safe` means no *arity* break only — a same-arity param-type change isn't detected, so still skim the callers; `not_found` returns ranked `candidates[]`."
     )]
     async fn verify_impact(
         &self,

--- a/crates/rts-mcp/tests/cli_impact.rs
+++ b/crates/rts-mcp/tests/cli_impact.rs
@@ -1,0 +1,67 @@
+//! `rts impact <SYMBOL> --change <C>` — verify a change's blast radius
+//! and render the pass/fail verdict + affected callers.
+
+mod cli_common;
+
+use cli_common::{TestEnv, parts, seed_minimal_rust_workspace};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn impact_remove_of_called_fn_is_would_break() {
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    let out = env
+        .run(&["--no-color", "impact", "make_widget", "--change", "remove"])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 0,
+        "a resolved verdict exits 0; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains("WOULD BREAK"),
+        "remove of a called fn should be WOULD BREAK; got {stdout:?}"
+    );
+    assert!(
+        stdout.contains("caller_a") || stdout.contains("caller_b"),
+        "expected an affected caller listed; got {stdout:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn impact_remove_of_uncalled_fn_is_safe() {
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    let out = env
+        .run(&["--no-color", "impact", "make_circle", "--change", "remove"])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 0,
+        "a resolved verdict exits 0; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains("SAFE"),
+        "remove of an uncalled fn should be SAFE; got {stdout:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn impact_unknown_symbol_exits_no_results() {
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    let out = env
+        .run(&["--no-color", "impact", "make_widgett", "--change", "remove"])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 1,
+        "unknown symbol → not_found → NO_RESULTS exit; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains("not found"),
+        "expected a not-found headline; got {stdout:?}"
+    );
+}

--- a/crates/rts-mcp/tests/cli_verify.rs
+++ b/crates/rts-mcp/tests/cli_verify.rs
@@ -1,0 +1,123 @@
+//! `rts verify <FILE>` — check a file's symbol/import references against
+//! the index and report hallucinated (not_found) references.
+//!
+//! Exit-code contract (mirrors the rg-style convention in `rts.rs`):
+//!   0 — clean (or unsupported language / nothing to check)
+//!   1 — ≥1 hallucinated reference found
+//!   3 — daemon error / not reachable
+
+mod cli_common;
+
+use cli_common::{TestEnv, parts, seed_minimal_rust_workspace};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn verify_real_symbol_file_is_clean() {
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    // A file that only references symbols that exist in the index
+    // (`make_widget` is defined in the seeded `hub.rs`).
+    let file = env.workspace_path().join("good.rs");
+    std::fs::write(&file, "pub fn use_it() { let _ = make_widget(7); }\n").unwrap();
+
+    let out = env
+        .run(&["--no-color", "verify", file.to_str().unwrap()])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 0,
+        "all references resolve → clean exit 0; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "clean file emits no hallucination lines; got {stdout:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn verify_invented_symbol_file_exits_one_and_names_it() {
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    // References a symbol that does NOT exist anywhere in the index.
+    let file = env.workspace_path().join("bad.rs");
+    std::fs::write(
+        &file,
+        "pub fn use_it() { let _ = totally_invented_symbol(1, 2); }\n",
+    )
+    .unwrap();
+
+    let out = env
+        .run(&["--no-color", "verify", file.to_str().unwrap()])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 1,
+        "a hallucinated reference → exit 1; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains("totally_invented_symbol"),
+        "expected the invented symbol named in output; got {stdout:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn verify_unsupported_language_is_clean_silent() {
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    // Go has no F3 reference extraction → "nothing checkable" → exit 0.
+    let file = env.workspace_path().join("main.go");
+    std::fs::write(
+        &file,
+        "package main\nfunc main() { totally_invented_symbol() }\n",
+    )
+    .unwrap();
+
+    let out = env
+        .run(&["--no-color", "verify", file.to_str().unwrap()])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 0,
+        "unsupported language → exit 0; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "unsupported language emits nothing; got {stdout:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn verify_json_flag_emits_structured_hallucinations() {
+    let env = TestEnv::new();
+    seed_minimal_rust_workspace(env.workspace_path());
+
+    let file = env.workspace_path().join("bad_json.rs");
+    std::fs::write(
+        &file,
+        "pub fn use_it() { let _ = totally_invented_symbol(1); }\n",
+    )
+    .unwrap();
+
+    let out = env
+        .run(&["--no-color", "--json", "verify", file.to_str().unwrap()])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 1,
+        "hallucination present → exit 1; stdout={stdout:?} stderr={stderr:?}"
+    );
+    let body: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("json parse {e}: {stdout:?}"));
+    let halls = body
+        .get("hallucinations")
+        .and_then(|v| v.as_array())
+        .expect("hallucinations array present");
+    assert!(
+        halls
+            .iter()
+            .any(|h| h.get("name").and_then(|n| n.as_str()) == Some("totally_invented_symbol")),
+        "expected the invented symbol in the json hallucinations; got {stdout:?}"
+    );
+}

--- a/crates/rts-mcp/tests/cli_verify.rs
+++ b/crates/rts-mcp/tests/cli_verify.rs
@@ -4,7 +4,7 @@
 //! Exit-code contract (mirrors the rg-style convention in `rts.rs`):
 //!   0 — clean (or unsupported language / nothing to check)
 //!   1 — ≥1 hallucinated reference found
-//!   3 — daemon error / not reachable
+//!   3 (or 4 on timeout) — daemon error / not reachable
 
 mod cli_common;
 

--- a/crates/rts-mcp/tests/snapshots/public-api.txt
+++ b/crates/rts-mcp/tests/snapshots/public-api.txt
@@ -6,6 +6,47 @@ pub const rts_mcp::cli::exit::NO_RESULTS: i32
 pub const rts_mcp::cli::exit::OK: i32
 pub const rts_mcp::cli::exit::TIMEOUT: i32
 pub const rts_mcp::cli::exit::WORKSPACE_ERROR: i32
+pub struct rts_mcp::cli::Hallucination
+pub rts_mcp::cli::Hallucination::did_you_mean: core::option::Option<alloc::string::String>
+pub rts_mcp::cli::Hallucination::line: usize
+pub rts_mcp::cli::Hallucination::name: alloc::string::String
+impl core::clone::Clone for rts_mcp::cli::Hallucination
+pub fn rts_mcp::cli::Hallucination::clone(&self) -> rts_mcp::cli::Hallucination
+impl core::cmp::PartialEq for rts_mcp::cli::Hallucination
+pub fn rts_mcp::cli::Hallucination::eq(&self, other: &rts_mcp::cli::Hallucination) -> bool
+impl core::fmt::Debug for rts_mcp::cli::Hallucination
+pub fn rts_mcp::cli::Hallucination::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for rts_mcp::cli::Hallucination
+impl core::marker::Freeze for rts_mcp::cli::Hallucination
+impl core::marker::Send for rts_mcp::cli::Hallucination
+impl core::marker::Sync for rts_mcp::cli::Hallucination
+impl core::marker::Unpin for rts_mcp::cli::Hallucination
+impl core::panic::unwind_safe::RefUnwindSafe for rts_mcp::cli::Hallucination
+impl core::panic::unwind_safe::UnwindSafe for rts_mcp::cli::Hallucination
+impl<T, U> core::convert::Into<U> for rts_mcp::cli::Hallucination where U: core::convert::From<T>
+pub fn rts_mcp::cli::Hallucination::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for rts_mcp::cli::Hallucination where U: core::convert::Into<T>
+pub type rts_mcp::cli::Hallucination::Error = core::convert::Infallible
+pub fn rts_mcp::cli::Hallucination::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for rts_mcp::cli::Hallucination where U: core::convert::TryFrom<T>
+pub type rts_mcp::cli::Hallucination::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn rts_mcp::cli::Hallucination::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for rts_mcp::cli::Hallucination where T: core::clone::Clone
+pub type rts_mcp::cli::Hallucination::Owned = T
+pub fn rts_mcp::cli::Hallucination::clone_into(&self, target: &mut T)
+pub fn rts_mcp::cli::Hallucination::to_owned(&self) -> T
+impl<T> core::any::Any for rts_mcp::cli::Hallucination where T: 'static + ?core::marker::Sized
+pub fn rts_mcp::cli::Hallucination::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for rts_mcp::cli::Hallucination where T: ?core::marker::Sized
+pub fn rts_mcp::cli::Hallucination::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for rts_mcp::cli::Hallucination where T: ?core::marker::Sized
+pub fn rts_mcp::cli::Hallucination::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for rts_mcp::cli::Hallucination where T: core::clone::Clone
+pub unsafe fn rts_mcp::cli::Hallucination::clone_to_uninit(&self, dest: *mut u8)
+impl<T> core::convert::From<T> for rts_mcp::cli::Hallucination
+pub fn rts_mcp::cli::Hallucination::from(t: T) -> T
+impl<T> tracing::instrument::Instrument for rts_mcp::cli::Hallucination
+impl<T> tracing::instrument::WithSubscriber for rts_mcp::cli::Hallucination
 pub struct rts_mcp::cli::Style
 pub rts_mcp::cli::Style::enabled: bool
 impl rts_mcp::cli::Style
@@ -53,7 +94,10 @@ pub fn rts_mcp::cli::render_impact_verdict<W: std::io::Write>(body: &serde_json:
 pub fn rts_mcp::cli::render_outline<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
 pub fn rts_mcp::cli::render_read<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
 pub fn rts_mcp::cli::render_stats<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
+pub fn rts_mcp::cli::render_verify<W: std::io::Write>(rel: &str, halls: &[rts_mcp::cli::Hallucination], w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
 pub fn rts_mcp::cli::resolve_workspace(override_path: core::option::Option<&std::path::Path>) -> anyhow::Result<std::path::PathBuf>
+pub fn rts_mcp::cli::top_candidate(body: &serde_json::value::Value) -> core::option::Option<alloc::string::String>
+pub fn rts_mcp::cli::verify_route(r: &rust_tree_sitter::verify::references::Reference) -> (&'static str, serde_json::value::Value, alloc::string::String)
 pub mod rts_mcp::connection
 pub enum rts_mcp::connection::ConnectionError
 pub rts_mcp::connection::ConnectionError::Daemon(rts_mcp::daemon_client::DaemonError)

--- a/crates/rts-mcp/tests/snapshots/public-api.txt
+++ b/crates/rts-mcp/tests/snapshots/public-api.txt
@@ -49,6 +49,7 @@ pub fn rts_mcp::cli::render_callers_tree<W: std::io::Write>(body: &serde_json::v
 pub fn rts_mcp::cli::render_connection_error(e: &rts_mcp::connection::ConnectionError, style: &rts_mcp::cli::Style) -> i32
 pub fn rts_mcp::cli::render_find_table<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
 pub fn rts_mcp::cli::render_grep_lines<W: std::io::Write>(body: &serde_json::value::Value, pattern: &str, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
+pub fn rts_mcp::cli::render_impact_verdict<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
 pub fn rts_mcp::cli::render_outline<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
 pub fn rts_mcp::cli::render_read<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
 pub fn rts_mcp::cli::render_stats<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>

--- a/crates/rts-mcp/tests/tool_descriptions.rs
+++ b/crates/rts-mcp/tests/tool_descriptions.rs
@@ -65,6 +65,7 @@ const AUDITED_TOOLS: &[&str] = &[
     "verify_import",
     "verify_claims",
     "impact_of",
+    "verify_impact",
     "grep",
     "daemon_telemetry",
 ];

--- a/docs/plans/2026-06-19-001-feat-verify-impact-and-loop-hooks-plan.md
+++ b/docs/plans/2026-06-19-001-feat-verify-impact-and-loop-hooks-plan.md
@@ -1,0 +1,88 @@
+---
+title: "feat: verify_impact + verification loop hooks (verify-v0 P2)"
+type: feat
+status: draft
+date: 2026-06-19
+origin: docs/plans/2026-06-18-001-feat-verification-anti-hallucination-layer-plan.md
+---
+
+# feat: verify_impact + verification loop hooks (verify-v0 P2)
+
+**Goal:** Add the pre-edit blast-radius gate (`verify_impact`) and wire verification into the agent's live edit loop via a Claude Code hook, so the agent catches breaking changes and hallucinated references as it writes — not at compile time.
+
+**Architecture:** `Index.VerifyImpact` wraps the existing `impact_of` reverse-call-graph walk with a pass/fail verdict; a new `rts verify` CLI makes single-file reference-checking scriptable; a PostToolUse hook calls it on each Write/Edit and feeds hallucinated symbols back to the agent.
+
+**Grounding (from exploration):** `impact_of` = `crate::impact::compute` (`crates/rts-daemon/src/impact.rs:242`) → `ImpactResult{ impact: Vec<ImpactEntry{qualified_name,kind,file,start_line,...,depth,rank_score}> }`; anchor resolved via `Store::sid_for_name` (`store/mod.rs:938`). Handler exemplar `impact_of` at `methods/index.rs:3345`. CLI = `crates/rts-mcp/src/bin/rts.rs` (`Cmd` enum + `run_command`), daemon calls via `cli::call_method`. Hooks = `.claude/hooks/rts-nudge.sh` (+ `.claude/hooks/tests/run-tests.sh`, `.claude/settings.json`). **No** test-coverage tracking and **no** PostToolUse hook exist yet.
+
+---
+
+## Scope decisions
+
+- **`uncovered_after_change` is DEFERRED.** The index has no test-reachability edges (would need a new `TEST_EDGES` table + writer work). `verify_impact` ships the caller blast-radius + verdict; the coverage field lands with P3's `verify_edit`/coverage checks.
+- **CER (correction-efficiency) is a P4 benchmark metric**, not a standalone P2 build — it only means something measured over a task corpus with the loop wired. P2 makes the loop *exist and observable*; P4 measures it.
+- **Hook target = Claude Code** (the repo's existing hook stack). The `rts verify` CLI is the harness-agnostic core, so the same capability is reusable from the pi stack's `tool_call` hook later.
+
+---
+
+## Implementation Units
+
+### U1 — `Index.VerifyImpact` / `verify_impact`
+
+**Files:** `crates/rts-daemon/src/methods/index.rs` (handler), `methods/mod.rs` (dispatch+cancellable), `state.rs` (counter), `schemas/v0/methods/Index.VerifyImpact.{req,resp}.schema.json`, `crates/rts-mcp/src/server.rs` (tool), `crates/rts-mcp/src/bin/rts.rs` (`rts impact` CLI subcommand), tests.
+
+A verification-framed wrapper over `impact_of`: the agent declares an intended change and gets the blast radius **as a verdict**.
+
+**Input:** `{ symbol, change: "signature"|"remove"|"rename", new_signature?, depth? }`.
+
+**Output:**
+```
+{ "resolution": "exact",                 // exact | not_found | indeterminate
+  "verdict": "would_break",              // would_break | safe
+  "change": "signature",
+  "affected_count": 5,
+  "affected_callers": [
+    { "file": "src/store/mod.rs", "line": 1532, "enclosing": "commit_round_trips",
+      "depth": 1, "reason": "arity 1 -> 2" } ],
+  "symbol": "store::Store::commit_batch" }
+```
+
+**Verdict logic (conservative — a false "would_break" only costs a review; a false "safe" ships a break):**
+- Resolve `symbol` via `sid_for_name`. Not indexed → `{resolution:"not_found", exists:false, candidates:[…]}` (reuse P1's `verify_candidate_pool` + `rank_candidates`); no verdict.
+- Found → run `impact::compute` (direct callers; `depth` default 1, reuse `ImpactBounds`). Build `affected_callers` from `ImpactEntry` (file, start_line→`line`, qualified_name→`enclosing`, depth).
+- `remove` / `rename`: `would_break` iff `affected_count > 0`, else `safe`. `reason` = "references removed symbol" / "references old name".
+- `signature`: extract old shape (F4 `signature_shape` on the indexed def — reuse U2's `actual_signature_shape` helper from P1) and, if `new_signature` is given, the new shape (parse the string as a fn, F4). Both decidable + **arity differs** → `would_break`, `reason` = "arity N -> M". Both decidable + arity equal → `safe` (arity-compatible; callers still listed for review). `new_signature` absent or shape undecidable → `would_break` when callers exist (can't prove safe), `resolution:"indeterminate"`, else `safe`.
+
+Register `"Index.VerifyImpact"` (dispatch + counter + `is_cancellable_method`). MCP tool `verify_impact`. CLI `rts impact <symbol> --change <c> [--new-signature S]` rendering callers like `render_callers_tree`.
+
+**Tests:** remove with callers → `would_break`; remove of an uncalled symbol → `safe`; signature arity 1→2 with callers → `would_break` + per-caller "arity 1 -> 2"; signature arity-preserving → `safe`; unknown symbol → `not_found` + candidates; schema round-trip in `protocol_schemas.rs`; MCP `tool_descriptions` audit.
+
+### U2 — `rts verify` CLI + PostToolUse loop hook
+
+**Files:** `crates/rts-mcp/src/bin/rts.rs` (+ `cli.rs` render) for `rts verify`; `.claude/hooks/rts-verify.sh` (new); `.claude/settings.json` (register PostToolUse on Write|Edit); `.claude/hooks/tests/` (new cases); `AGENTS.md` (document the hook + opt-out).
+
+**`rts verify <path>` (or `--stdin --lang <l>`):** read the file, `extract_references` (F3), call `verify_symbol`/`verify_import` on each decidable reference via the daemon, print the `not_found` ones (`file:line  symbol  (did you mean: <candidate>?)`). Exit code: `0` clean, `1` hallucinations found, `3` daemon error (so a hook can branch). Skips unsupported languages cleanly. Reuses the F3→verify routing from `rts-bench`'s `verify_metrics` (factor the shared bit if clean; else mirror it — keep it small).
+
+**`.claude/hooks/rts-verify.sh` (PostToolUse, matcher `Write`/`Edit`):** soft-enforcement contract identical to `rts-nudge.sh` (exit 0 always; `RTS_HOOK_DISABLED` opt-out; daemon-down → silent; cached health probe). On a Write/Edit to a source file, run `rts verify <tool_input.file_path>`; if it reports hallucinations, emit them via `hookSpecificOutput.additionalContext` so the agent self-corrects next turn. Never block (P2 is annotate-only; the blocking PreToolUse-on-edit gate is P3, gated on `verify_edit`).
+
+**Tests:** extend `.claude/hooks/tests/run-tests.sh` — a Write of a file referencing a real symbol → silent; a Write referencing an invented symbol → nudge naming it; `RTS_HOOK_DISABLED=1` → silent; daemon-down → silent. Plus Rust CLI tests for `rts verify` exit codes.
+
+---
+
+## Acceptance criteria
+
+- `verify_impact` returns `would_break` with the affected-caller list for remove/rename/arity-changing-signature on a called symbol, and `safe` when there are no callers or the change is arity-preserving; unknown symbol → `not_found` + candidates. Schema-validated; CLI parity (`rts impact`).
+- `rts verify <file>` exits non-zero and names hallucinated references on a file with an invented symbol; exits 0 on a clean file; degrades cleanly when the daemon is down or the language is unsupported.
+- The PostToolUse hook surfaces hallucinations after a Write/Edit, is silent on clean writes, and honors `RTS_HOOK_DISABLED`; covered by the bash hook-test harness.
+- Read-only throughout; `cargo test --workspace` green; `cargo fmt --check` clean; no new plain-clippy warnings.
+
+## Deferred / follow-ups
+- `uncovered_after_change` (needs test-reachability edges) → P3.
+- PreToolUse **blocking** edit gate → P3 (needs `verify_edit`'s shadow-index patch verdict).
+- CER (correction-efficiency) measurement → P4 benchmark.
+
+## Requirements trace
+| Spec § | Covered by |
+| :-- | :-- |
+| §3.4 verify_impact | U1 (minus `uncovered_after_change`, deferred) |
+| §6.2 hooks (push, loop-breaker) | U2 (PostToolUse annotate; PreToolUse-block deferred to P3) |
+| §5 CER | deferred to P4 (documented) |

--- a/schemas/v0/methods/Index.VerifyImpact.req.schema.json
+++ b/schemas/v0/methods/Index.VerifyImpact.req.schema.json
@@ -8,7 +8,7 @@
     "symbol":        { "type": "string", "minLength": 1, "maxLength": 256 },
     "change":        { "type": "string", "enum": ["signature", "remove", "rename"] },
     "new_signature": { "type": "string" },
-    "depth":         { "type": "integer", "minimum": 1, "maximum": 4 }
+    "depth":         { "type": "integer" }
   },
   "required": ["symbol", "change"],
   "additionalProperties": false

--- a/schemas/v0/methods/Index.VerifyImpact.req.schema.json
+++ b/schemas/v0/methods/Index.VerifyImpact.req.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.VerifyImpact.req.schema.json",
+  "title": "Index.VerifyImpact request params",
+  "description": "verify-v0 P2.U1, capability `verify_impact`. Declares an intended change to `symbol` and returns the blast radius as a pass/fail verdict so an agent can gate an edit. `new_signature` is consulted only for `change: signature`. `depth` defaults to 1 (direct callers); out-of-window values are clamped, not rejected.",
+  "type": "object",
+  "properties": {
+    "symbol":        { "type": "string", "minLength": 1, "maxLength": 256 },
+    "change":        { "type": "string", "enum": ["signature", "remove", "rename"] },
+    "new_signature": { "type": "string" },
+    "depth":         { "type": "integer", "minimum": 1, "maximum": 4 }
+  },
+  "required": ["symbol", "change"],
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Index.VerifyImpact.resp.schema.json
+++ b/schemas/v0/methods/Index.VerifyImpact.resp.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.VerifyImpact.resp.schema.json",
+  "title": "Index.VerifyImpact result",
+  "description": "verify-v0 P2.U1. On a hit: `verdict` (would_break | safe), echoed `change`, `affected_count`, `affected_callers[]`, and `truncated` (true → affected_count is a lower bound). `resolution` is `exact` for remove/rename and for a decidable signature arity comparison; `indeterminate` (with `reason`) when the signature shape is undecidable. On a miss: `resolution: not_found`, `exists: false`, ranked `candidates[]`, and NO `verdict`.",
+  "type": "object",
+  "properties": {
+    "resolution": {
+      "type": "string",
+      "enum": ["exact", "not_found", "indeterminate"]
+    },
+    "verdict": {
+      "description": "Pass/fail gate. Present on a hit; OMITTED on not_found.",
+      "type": "string",
+      "enum": ["would_break", "safe"]
+    },
+    "reason": {
+      "description": "IndeterminateReason wire string. Present only when resolution is `indeterminate`.",
+      "type": "string",
+      "enum": ["dynamic_dispatch", "macro_generated", "ffi", "unresolved_ref", "reflection", "ambiguous_overload", "undecidable_signature"]
+    },
+    "change": { "type": "string", "enum": ["signature", "remove", "rename"] },
+    "exists": { "type": "boolean" },
+    "symbol": { "type": "string" },
+    "affected_count": { "type": "integer", "minimum": 0 },
+    "truncated": {
+      "description": "True when an impact bound fired (closure / wall-clock / depth / node-count) and `affected_count` is therefore a lower bound.",
+      "type": "boolean"
+    },
+    "affected_callers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "file":      { "type": "string" },
+          "line":      { "type": "integer", "minimum": 0 },
+          "enclosing": { "type": "string" },
+          "depth":     { "type": "integer", "minimum": 0 },
+          "reason":    { "type": "string" }
+        },
+        "required": ["file", "line", "enclosing", "depth", "reason"]
+      }
+    },
+    "candidates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "qualified_name": { "type": "string" },
+          "edit_distance":  { "type": "integer", "minimum": 0 },
+          "pagerank":       { "type": "number" }
+        },
+        "required": ["qualified_name", "edit_distance", "pagerank"]
+      }
+    }
+  },
+  "required": ["resolution"]
+}

--- a/schemas/v0/methods/Index.VerifyImpact.resp.schema.json
+++ b/schemas/v0/methods/Index.VerifyImpact.resp.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://rts.local/schemas/v0/methods/Index.VerifyImpact.resp.schema.json",
   "title": "Index.VerifyImpact result",
-  "description": "verify-v0 P2.U1. On a hit: `verdict` (would_break | safe), echoed `change`, `affected_count`, `affected_callers[]`, and `truncated` (true → affected_count is a lower bound). `resolution` is `exact` for remove/rename and for a decidable signature arity comparison; `indeterminate` (with `reason`) when the signature shape is undecidable. On a miss: `resolution: not_found`, `exists: false`, ranked `candidates[]`, and NO `verdict`.",
+  "description": "verify-v0 P2.U1. On a hit: `verdict` (would_break | safe), echoed `change`, `affected_count`, `affected_callers[]`, and `truncated` (true → affected_count is a lower bound). `resolution` is `exact` for remove/rename and for a decidable signature arity comparison; `indeterminate` (with `reason`) when the signature shape is undecidable, or `ambiguous_overload` when the name resolves to multiple defs (the agent should qualify it — the candidate defs are listed in `matches[]`). On a miss: `resolution: not_found`, `exists: false`, ranked `candidates[]`, and NO `verdict`.",
   "type": "object",
   "properties": {
     "resolution": {
@@ -51,6 +51,19 @@
           "pagerank":       { "type": "number" }
         },
         "required": ["qualified_name", "edit_distance", "pagerank"]
+      }
+    },
+    "matches": {
+      "description": "The ambiguous defs to disambiguate between. Present only when resolution is `indeterminate` with reason `ambiguous_overload`.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "qualified_name": { "type": "string" },
+          "file":           { "type": "string" },
+          "line":           { "type": "integer", "minimum": 0 }
+        },
+        "required": ["qualified_name", "file", "line"]
       }
     }
   },


### PR DESCRIPTION
## Summary

verify-v0 **Phase 2**: extends verification from checking *claims* (P1) to **gating edits** and **wiring verification into the live agent loop**.

Plan: `docs/plans/2026-06-19-001-feat-verify-impact-and-loop-hooks-plan.md`.

## What's in it

**U1 — `verify_impact` / `Index.VerifyImpact` (+ `rts impact` CLI)**
Declare an intended change to a symbol (`signature` | `remove` | `rename`) → get the blast radius as a pass/fail `verdict` (`would_break` | `safe`). Wraps the existing reverse-call-graph walk (`impact::compute`); lists `affected_callers[]` with a per-caller `reason`; for a `signature` change compares the proposed arity (`new_signature`) to the real one via F4. Conservative (`safe` = no *arity* break; v0 is arity-only). Honors qualified names (`Foo::method`) like `verify_symbol`; unknown symbol → `not_found` + ranked candidates. Read-only.

**U2 — `rts verify <file>` CLI + PostToolUse loop hook**
`rts verify` parses a file with rts's own tree-sitter extractor (F3), checks each symbol/import reference via the verify tools, and reports the hallucinated (`not_found`) ones as `FILE:LINE  name  (did you mean: …?)` (exit 0 clean / 1 found / 3–4 daemon error). The PostToolUse hook (`.claude/hooks/rts-verify.sh`) runs it after each Write/Edit/MultiEdit and feeds hallucinations back to the agent — **annotate-only (never blocks)**, silent when the daemon is down, opt out with `RTS_HOOK_DISABLED=1`.

## Scope decisions (per plan)
- **`uncovered_after_change` deferred** — the index has no test-reachability edges; lands with P3's `verify_edit`/coverage.
- **Blocking pre-edit gate deferred to P3** (needs `verify_edit`'s shadow-index verdict). P2 is annotate-only.
- **CER (correction-efficiency) is a P4 benchmark metric**, not built standalone.

## Process
Subagent-driven: implementer + spec/quality review per unit. Review findings fixed in-branch — notably making `verify_impact` honor qualified names (was bare-only, contradicting its own docs), the `safe`-is-arity-only tool-description note, and schema/depth-clamp alignment. The hook was reviewed specifically for safety (runs on every edit): exits 0 on every path, daemon-down silent, quoting/injection-safe (tested with a hostile filename).

## Test plan
- [x] `cargo test --workspace` — green
- [x] `protocol_schemas` live round-trip validates `Index.VerifyImpact`
- [x] `cli_impact` (3) + `cli_verify` (4) CLI tests
- [x] hook harnesses: `run-verify-tests.sh` 17/17, existing `run-tests.sh` 24/24
- [x] `cargo fmt --check` clean; no new clippy warnings (pre-existing local-toolchain warnings are non-blocking in CI)