### PR TITLE
feat: verify_edit (scoped delta) + edit-quality metrics & CI gate (verify-v0 P3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,39 @@ disables the nudge hook. The hook locates the `rts` binary via `$RTS_BIN`
 Test it locally with `.claude/hooks/tests/run-verify-tests.sh` (pure
 bash; needs `jq`; stubs the `rts` binary so it needs no daemon).
 
+### `rts verify-edit` — the CI / pre-merge gate (verify-v0 P3)
+
+Where `rts verify <file>` annotates and never blocks, **`rts verify-edit`**
+is the *blocking* gate: it validates a whole proposed patch *before it is
+written* and fails the build by exit code on a caller-breaking change.
+
+```
+rts verify-edit --edits pr-edits.json --fail-on critical
+```
+
+`--edits` takes a path or `-` (stdin) to an edits JSON —
+`[{ "file": "...", "content": "..." }]`, where each `content` is the FULL
+post-edit content of that file. It calls `Index.VerifyEdit`, prints the
+pass/warn/fail verdict + findings (`SEVERITY  kind  symbol  site  — detail`;
+`--json` passes the daemon response straight through), and maps the verdict
+to an exit code via **`--fail-on <none|warn|critical>`** (default
+`critical`):
+
+| `--fail-on` | pass | warn | fail | daemon error / bad input |
+|-------------|------|------|------|--------------------------|
+| `critical`  | 0    | 0    | 2    | 3                        |
+| `warn`      | 0    | 2    | 2    | 3                        |
+| `none`      | 0    | 0    | 0    | 3                        |
+
+So `--fail-on critical` (the default) fails the build only on a real break
+(`broken_caller` / `signature_break`); `--fail-on warn` is stricter; and
+`--fail-on none` is report-only (always exits 0). A malformed/empty edits
+JSON errors cleanly with exit 3, never a panic.
+
+The same EVR/BCIR numbers this gate is built on are measured in bulk by
+`rts-bench verify-edit --corpus … --workspace …` (Edit Validity Rate and
+Broken-Caller Introduction Rate over a corpus of edit-sets).
+
 ### Where shell `grep` / `rg` is still the right tool
 
 - Searching files outside the indexed workspace (vendored deps,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = [
     "spikes/p0-1-rmcp-hello",
     "spikes/p0-2-redb-smoke",
     "spikes/p0-3-notify-smoke",
+    "spikes/p1-1-verify-edit-delta",
     # cargo-fuzz crate: nightly-only (libfuzzer-sys requires sancov
     # passes that aren't available on stable). Built via
     # `cd crates/rts-daemon && cargo +nightly fuzz run <target>` per

--- a/changelog.d/165-feat-verify-edit-metrics-and-cli.md
+++ b/changelog.d/165-feat-verify-edit-metrics-and-cli.md
@@ -1,0 +1,25 @@
+### Feat: EVR/BCIR edit-quality metrics + the `rts verify-edit` CI gate
+
+Completes verify-v0 P3: turns `Index.VerifyEdit` (the scoped pre-edit validator
+landed in P3.U1) into a measurable metric and a build-gating CLI.
+
+- **EVR / BCIR metrics** (`rts-bench verify-edit`) — runs a TOML corpus of
+  proposed edit-sets (`[[edit_set]]`, each a list of `{file, content}` full
+  post-edit contents) through `verify_edit` and reports two deterministic
+  rates: **EVR** (Edit Validity Rate = `pass` verdicts / all edit-sets;
+  `warn`/`fail` count against it) and **BCIR** (Broken-Caller Introduction Rate
+  = edit-sets with a `broken_caller`/`signature_break` finding / all edit-sets).
+  No LLM in the loop. Committed corpora: `corpus/verify-edit-eval-rts-core.toml`
+  and the pinned self-validation fixture `corpus/verify-edit-eval-selftest.toml`
+  (EVR 2/3, BCIR 1/3), asserted by an integration test against a live daemon.
+
+- **`rts verify-edit --edits <path|->`** — the enterprise/CI pre-merge gate.
+  Reads an edits JSON (`[{ "file": "...", "content": "..." }]`, full post-edit
+  content) from a file or stdin (`-`), calls `Index.VerifyEdit`, prints the
+  pass/warn/fail verdict + findings (`--json` passes the daemon response
+  through), and maps the verdict to an exit code via **`--fail-on
+  <none|warn|critical>`** (default `critical`): pass/warn → 0, fail → 2 under
+  `critical`; warn/fail → 2 under `warn`; always 0 under `none` (report-only).
+  Daemon/contact error or malformed edits → 3. CI usage:
+  `rts verify-edit --edits pr-edits.json --fail-on critical` fails the build on
+  a caller-breaking patch.

--- a/corpus/verify-edit-eval-rts-core.toml
+++ b/corpus/verify-edit-eval-rts-core.toml
@@ -1,0 +1,66 @@
+# Edit-quality corpus for `crates/rts-core`
+# (`rts-bench verify-edit`, verify-v0 P3.U2).
+#
+# Each `[[edit_set]]` is a whole PROPOSED patch — a list of
+# `{file, content}` entries where `content` is the COMPLETE new content of
+# `file` after the edit. The harness forwards each edit-set to the daemon's
+# `Index.VerifyEdit` (read-only, never written to disk) and aggregates:
+#
+#   EVR  = Edit Validity Rate           = `pass` verdicts / all edit-sets
+#   BCIR = Broken-Caller Introduction   = edit-sets with a
+#          Rate                           `broken_caller`/`signature_break`
+#                                         finding / all edit-sets
+#
+# `warn`/`fail` count against EVR; every edit-set always yields a verdict,
+# so there is no excluded bucket. No LLM in the loop — the metric is fully
+# deterministic.
+#
+# Run: `rts-bench verify-edit \
+#         --corpus corpus/verify-edit-eval-rts-core.toml \
+#         --workspace crates/rts-core`
+#
+# Grading methodology:
+# - The `expected_verdict` field is advisory: the measured EVR/BCIR come
+#   from the LIVE index, which can shift as rts-core evolves. The PINNED
+#   expected values live in the self-validation fixture
+#   (`corpus/verify-edit-eval-selftest.toml`), which the integration test
+#   asserts on.
+# - "Breaking" edit-sets deliberately remove or change a called public fn
+#   so the metric has a non-zero BCIR to detect (a metric that can only
+#   ever report 0 is untrustworthy).
+# - "Safe" edit-sets add brand-new files / arity-preserving content so
+#   they resolve to a clean `pass`.
+
+version = 1
+
+# --- BREAKING: stub out a file that defines a called public fn ---
+# `signature_shape` is called from `crate::verify::mod` and re-exported in
+# `lib.rs`; rewriting its defining file to a stub drops the def while live
+# callers remain → fail + broken_caller (callers are outside the patch).
+[[edit_set]]
+name = "breaking: drop signature_shape() (called by verify::mod)"
+expected_verdict = "fail"
+edits = [
+  { file = "src/verify/signature_shape.rs", content = "//! stubbed out\n" },
+]
+
+# --- SAFE: add a brand-new standalone file ---
+# A new file with a self-contained fn references nothing existing and is
+# referenced by nothing → pass + new_symbol.
+[[edit_set]]
+name = "safe: add a brand-new standalone helper file"
+expected_verdict = "pass"
+edits = [
+  { file = "src/scratch_new_helper.rs", content = "pub fn scratch_new_helper(x: u32) -> u32 {\n    x.wrapping_add(1)\n}\n" },
+]
+
+# --- SAFE: add two new mutually-consistent files in one patch ---
+# Both files are new; the caller and callee are edited together, so there
+# is no stale-index caller to break → pass.
+[[edit_set]]
+name = "safe: add a new callee + its new caller in one patch"
+expected_verdict = "pass"
+edits = [
+  { file = "src/scratch_callee.rs", content = "pub fn scratch_callee(a: u32, b: u32) -> u32 {\n    a + b\n}\n" },
+  { file = "src/scratch_caller.rs", content = "use crate::scratch_callee;\npub fn scratch_caller() -> u32 {\n    scratch_callee(1, 2)\n}\n" },
+]

--- a/corpus/verify-edit-eval-selftest.toml
+++ b/corpus/verify-edit-eval-selftest.toml
@@ -1,0 +1,54 @@
+# Self-validation fixture for the edit-quality harness
+# (`rts-bench verify-edit`, verify-v0 P3.U2).
+#
+# This corpus has KNOWN expected EVR / BCIR so the metric provably
+# detects what it should. It is checked against the tiny workspace seeded
+# by the `verify_edit_metrics_integration` test
+# (`crates/rts-bench/tests/verify_edit_metrics_integration.rs`), which
+# defines:
+#
+#   hub.rs       — `pub fn target(x: u32) -> u32` (arity 1), called by
+#   caller_a.rs  — `pub fn caller_a()` → `target(1)`
+#
+# Each `[[edit_set]]` is a whole proposed patch (a list of
+# `{file, content}` FULL post-edit contents) with a KNOWN expected
+# verdict.  The measured numbers come from the LIVE daemon — the
+# `expected_verdict` field below is advisory metadata only.
+#
+# Against the seeded workspace, the three edit-sets resolve as:
+#
+#   1. "breaking-remove"     hub.rs no longer defines `target`
+#                            → fail + broken_caller (caller_a)        [BCIR]
+#   2. "safe-add"            keep `target`, add `brand_new`
+#                            → pass + new_symbol
+#   3. "safe-body"           arity-preserving body edit of `target`
+#                            → pass
+#
+#   EVR  = pass / total              = 2 / 3
+#   BCIR = caller-breaking / total   = 1 / 3
+#
+# If these expected values ever drift, either `Index.VerifyEdit` or the
+# extractor changed — investigate before re-baselining.
+
+version = 1
+
+[[edit_set]]
+name = "breaking-remove: drop a called fn → broken_caller"
+expected_verdict = "fail"
+edits = [
+  { file = "hub.rs", content = "pub fn unrelated() -> u32 { 0 }\n" },
+]
+
+[[edit_set]]
+name = "safe-add: add a new fn, keep target intact → pass"
+expected_verdict = "pass"
+edits = [
+  { file = "hub.rs", content = "pub fn target(x: u32) -> u32 { x + 1 }\npub fn brand_new() -> u32 { 9 }\n" },
+]
+
+[[edit_set]]
+name = "safe-body: arity-preserving body edit → pass"
+expected_verdict = "pass"
+edits = [
+  { file = "hub.rs", content = "pub fn target(x: u32) -> u32 { x + 100 }\n" },
+]

--- a/crates/rts-bench/src/main.rs
+++ b/crates/rts-bench/src/main.rs
@@ -246,6 +246,36 @@ enum Cmd {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Edit-quality metric harness (verify-v0 P3.U2). Runs a corpus of
+    /// proposed edit-sets (`[[edit_set]]`, each a list of `{file, content}`
+    /// full post-edit contents) through `Index.VerifyEdit` and reports two
+    /// deterministic rates:
+    ///
+    ///   EVR  = Edit Validity Rate          = `pass` verdicts / all edit-sets
+    ///   BCIR = Broken-Caller Introduction  = edit-sets with a
+    ///          Rate                          `broken_caller`/`signature_break`
+    ///                                        finding / all edit-sets
+    ///
+    /// `warn`/`fail` count against EVR; every edit-set always yields a
+    /// verdict, so there is no excluded bucket. No LLM in the loop.
+    ///
+    /// Corpus format: see `corpus/verify-edit-eval-rts-core.toml` and the
+    /// pinned self-validation fixture `corpus/verify-edit-eval-selftest.toml`.
+    VerifyEdit {
+        /// Path to a TOML verify-edit-eval corpus file.
+        #[arg(long)]
+        corpus: PathBuf,
+        /// Workspace to validate the edits against. Mounted + indexed via
+        /// the same rts-mcp + daemon path the other benches use.
+        #[arg(long)]
+        workspace: PathBuf,
+        /// Where to write the JSON `EditQualityReport`.
+        #[arg(long)]
+        out: Option<PathBuf>,
+        /// Skip writing the report to disk (it's still printed to stdout).
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Self-dogfood telemetry harness. Ingests a Claude Code session
     /// JSONL transcript and reports how often the agent reached for
     /// `Bash(grep|rg|find|cat|ls)` when an `mcp__rts__*` tool would
@@ -683,6 +713,12 @@ async fn main() -> Result<()> {
             out,
             dry_run,
         } => run_verify(corpus, workspace, out, dry_run).await,
+        Cmd::VerifyEdit {
+            corpus,
+            workspace,
+            out,
+            dry_run,
+        } => run_verify_edit(corpus, workspace, out, dry_run).await,
         Cmd::RealRepos { sub } => run_real_repos(sub).await,
         Cmd::Dogfood {
             session,
@@ -935,6 +971,101 @@ async fn run_verify(
             std::env::current_dir()
                 .unwrap_or_else(|_| PathBuf::from("."))
                 .join(format!("bench-verify-{}.json", git_short_sha()))
+        });
+        std::fs::write(&out_path, &json)
+            .with_context(|| format!("write {}", out_path.display()))?;
+        println!("wrote {}", out_path.display());
+    }
+    Ok(())
+}
+
+/// `rts-bench verify-edit` — edit-quality metric harness (verify-v0
+/// P3.U2).
+///
+/// Mounts the workspace via the same rts-mcp + daemon path the other
+/// benches use, runs each corpus edit-set through the `verify_edit` MCP
+/// tool, and prints the JSON `EditQualityReport` (EVR / BCIR).
+async fn run_verify_edit(
+    corpus_path: PathBuf,
+    workspace: PathBuf,
+    out: Option<PathBuf>,
+    dry_run: bool,
+) -> Result<()> {
+    let workspace = workspace
+        .canonicalize()
+        .with_context(|| format!("canonicalize {}", workspace.display()))?;
+    let corpus = verify_metrics::load_edit_corpus(&corpus_path)
+        .with_context(|| format!("load corpus {}", corpus_path.display()))?;
+    println!(
+        "verify-edit: workspace={} corpus={} edit_sets={}",
+        workspace.display(),
+        corpus_path.display(),
+        corpus.edit_sets.len(),
+    );
+
+    let rts_mcp_bin = resolve_bin("rts-mcp")?;
+    let rts_daemon_bin = resolve_bin("rts-daemon")?;
+    let mut session =
+        mcp_runner::McpSession::spawn(&rts_mcp_bin, &rts_daemon_bin, &workspace, &[]).await?;
+
+    // Warm the index before validating edits so cold-mount churn doesn't
+    // masquerade as a caller-breaking finding.
+    let _ = session
+        .tools_call("find_symbol", json!({ "pattern": "*" }), 30)
+        .await?;
+
+    let verdicts = {
+        let mut oracle = verify_metrics::SessionOracle::new(&mut session);
+        verify_metrics::run_edit_corpus(&mut oracle, &corpus).await?
+    };
+    session.close().await?;
+
+    // Per-edit-set line for quick scan: name, measured verdict, and the
+    // advisory expected verdict (flagged with `!=` when they disagree so a
+    // corpus drift is visible at a glance).
+    for (set, v) in corpus.edit_sets.iter().zip(verdicts.iter()) {
+        let expect = set.expected_verdict.as_deref().unwrap_or("?");
+        let mark = if expect == "?" || expect == v.verdict {
+            ""
+        } else {
+            " (!= expected)"
+        };
+        let bc = if v.introduces_broken_caller() {
+            " [broken-caller]"
+        } else {
+            ""
+        };
+        println!(
+            "  [{:>4}{mark}{bc}] {} (expected {expect})",
+            v.verdict, set.name
+        );
+    }
+
+    let report = verify_metrics::build_edit_report(
+        env!("CARGO_PKG_VERSION"),
+        &workspace.display().to_string(),
+        &corpus_path.display().to_string(),
+        verdicts,
+    );
+
+    let fmt_rate = |m: &verify_metrics::EditRate| match m.rate {
+        Some(r) => format!("{:.3} ({}/{})", r, m.numerator, m.denominator),
+        None => "null (0/0)".to_string(),
+    };
+    println!(
+        "verify-edit: EVR={} BCIR={}",
+        fmt_rate(&report.evr),
+        fmt_rate(&report.bcir),
+    );
+
+    let json = serde_json::to_string_pretty(&report).context("encode edit-quality report")?;
+    println!("{json}");
+
+    if !dry_run {
+        let out_path = out.unwrap_or_else(|| {
+            std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(format!("bench-verify-edit-{}.json", git_short_sha()))
         });
         std::fs::write(&out_path, &json)
             .with_context(|| format!("write {}", out_path.display()))?;

--- a/crates/rts-bench/src/verify_metrics.rs
+++ b/crates/rts-bench/src/verify_metrics.rs
@@ -249,14 +249,135 @@ pub fn load_corpus(path: &Path) -> Result<Corpus> {
 }
 
 // ---------------------------------------------------------------------
+// Edit corpus (EVR / BCIR)
+// ---------------------------------------------------------------------
+
+/// Parsed verify-EDIT-eval corpus. Mirrors the snippet-corpus TOML shape:
+/// a pinned `version` plus an `[[edit_set]]` array, where each entry is a
+/// whole proposed patch (a list of `[file, content]` edits) with a KNOWN
+/// expected verdict the self-validation fixture pins.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EditCorpus {
+    #[allow(dead_code)]
+    pub version: u32,
+    #[serde(rename = "edit_set")]
+    pub edit_sets: Vec<CorpusEditSet>,
+}
+
+/// One proposed edit-set: a label, the list of `{file, content}` edits
+/// (full post-edit content), and the verdict the fixture expects. The
+/// expected fields are advisory metadata for the human summary / a future
+/// grader — the measured EVR / BCIR are computed from the LIVE daemon
+/// verdict, never from these.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CorpusEditSet {
+    /// Free-text label for the edit-set (what it exercises).
+    #[serde(default)]
+    pub name: String,
+    /// The proposed edits — each `{file, content}` carries the full
+    /// post-edit content of `file`.
+    pub edits: Vec<CorpusEdit>,
+    /// Expected verdict (`pass` | `warn` | `fail`). Advisory — surfaced
+    /// in the summary so a drift is visible; not used in aggregation.
+    #[serde(default)]
+    pub expected_verdict: Option<String>,
+}
+
+/// One proposed file edit inside a [`CorpusEditSet`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CorpusEdit {
+    /// Workspace-relative file path.
+    pub file: String,
+    /// The COMPLETE new content of `file` after the edit.
+    pub content: String,
+}
+
+impl CorpusEditSet {
+    /// The `edits` array as the JSON the daemon's `Index.VerifyEdit`
+    /// expects: `[{ "file": …, "content": … }]`.
+    pub fn edits_json(&self) -> serde_json::Value {
+        serde_json::to_value(&self.edits).unwrap_or_else(|_| json!([]))
+    }
+}
+
+/// Load and parse a TOML verify-EDIT-eval corpus.
+pub fn load_edit_corpus(path: &Path) -> Result<EditCorpus> {
+    let bytes =
+        std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let parsed: EditCorpus = toml::from_str(&bytes)
+        .with_context(|| format!("parse {} as verify-edit corpus TOML", path.display()))?;
+    Ok(parsed)
+}
+
+// ---------------------------------------------------------------------
 // Verify oracle
 // ---------------------------------------------------------------------
 
-/// Abstracts the three live verify calls so the aggregation pipeline can
-/// run against the real daemon in production and canned answers in tests.
+/// The outcome of one `verify_edit` call: the verdict string plus the
+/// distinct finding kinds the daemon reported. Kept deliberately small —
+/// the edit metrics (EVR / BCIR) only need the verdict and whether a
+/// caller-breaking kind appeared, not the full finding payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditVerdict {
+    /// `pass` | `warn` | `fail` (frozen wire strings). An unknown /
+    /// missing verdict is treated as `fail` by the aggregator (an
+    /// undecodable verdict is never counted as a clean pass).
+    pub verdict: String,
+    /// The distinct `kind` strings across `findings[]`
+    /// (`broken_caller`, `signature_break`, `dangling_ref`,
+    /// `new_symbol`, …). Used to decide BCIR membership.
+    pub finding_kinds: BTreeSet<String>,
+}
+
+impl EditVerdict {
+    /// True when the verdict reads as a clean `pass` (the EVR numerator
+    /// criterion). `warn` and `fail` — and any unknown verdict — count
+    /// AGAINST EVR.
+    pub fn is_pass(&self) -> bool {
+        self.verdict == "pass"
+    }
+
+    /// True when any finding kind is caller-breaking (`broken_caller`
+    /// or `signature_break`) — the BCIR numerator criterion.
+    pub fn introduces_broken_caller(&self) -> bool {
+        self.finding_kinds.contains("broken_caller")
+            || self.finding_kinds.contains("signature_break")
+    }
+
+    /// Build an [`EditVerdict`] from a raw `Index.VerifyEdit` response
+    /// body. Missing `verdict` → `"fail"` (honest default — never read
+    /// an undecodable body as a pass). Missing/empty `findings` → no
+    /// kinds.
+    pub fn from_body(body: &serde_json::Value) -> Self {
+        let verdict = body
+            .get("verdict")
+            .and_then(|v| v.as_str())
+            .unwrap_or("fail")
+            .to_string();
+        let finding_kinds = body
+            .get("findings")
+            .and_then(|f| f.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|f| f.get("kind").and_then(|k| k.as_str()))
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+        EditVerdict {
+            verdict,
+            finding_kinds,
+        }
+    }
+}
+
+/// Abstracts the live verify calls so the aggregation pipeline can run
+/// against the real daemon in production and canned answers in tests.
 ///
-/// Each method returns the [`Resolution`] for one reference. The pure
-/// math never sees the daemon; this trait is the only seam that does.
+/// Each per-reference method returns the [`Resolution`] for one
+/// reference; [`verify_edit`](VerifyOracle::verify_edit) returns the
+/// [`EditVerdict`] for one whole edit-set. The pure math never sees the
+/// daemon; this trait is the only seam that does.
 #[allow(async_fn_in_trait)]
 pub trait VerifyOracle {
     /// `verify_symbol(name)` → resolution.
@@ -272,6 +393,11 @@ pub trait VerifyOracle {
     /// driver (a call site is only decidable when the callee exists), so
     /// this method just reports the signature outcome.
     async fn verify_signature(&mut self, name: &str, arity: u32) -> Result<Resolution>;
+    /// `verify_edit(edits)` → the verdict + finding kinds for one
+    /// proposed edit-set. `edits` is the `[{file, content}]` array
+    /// (full post-edit content) forwarded verbatim to the daemon's
+    /// `Index.VerifyEdit`.
+    async fn verify_edit(&mut self, edits: &serde_json::Value) -> Result<EditVerdict>;
 }
 
 /// Live [`VerifyOracle`] backed by an `McpSession` talking to the real
@@ -346,6 +472,16 @@ impl VerifyOracle for SessionOracle<'_> {
             },
             other => other,
         })
+    }
+
+    async fn verify_edit(&mut self, edits: &serde_json::Value) -> Result<EditVerdict> {
+        let call = self
+            .session
+            .tools_call("verify_edit", json!({ "edits": edits }), self.retries)
+            .await
+            .context("verify_edit call")?;
+        let body = call.result_body.clone().unwrap_or_default();
+        Ok(EditVerdict::from_body(&body))
     }
 }
 
@@ -465,6 +601,115 @@ pub fn report_from_resolutions(
         acc.unsupported_language_refs,
         acc.languages_covered,
     )
+}
+
+// ---------------------------------------------------------------------
+// Edit metrics: EVR / BCIR
+// ---------------------------------------------------------------------
+
+/// A simple fraction over the edit corpus: `numerator / denominator`,
+/// with `rate = None` when the corpus is empty (never `NaN`). Same
+/// honest-denominator convention as [`Metric`], but every edit-set is
+/// always decidable (a verdict always comes back), so there is no
+/// excluded-indeterminate bucket here.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EditRate {
+    /// Edit-sets matching the metric's criterion.
+    pub numerator: u64,
+    /// Total edit-sets considered.
+    pub denominator: u64,
+    /// `numerator / denominator`, or `null` when `denominator == 0`.
+    pub rate: Option<f64>,
+}
+
+impl EditRate {
+    fn new(numerator: u64, denominator: u64) -> Self {
+        let rate = if denominator == 0 {
+            None
+        } else {
+            Some(numerator as f64 / denominator as f64)
+        };
+        EditRate {
+            numerator,
+            denominator,
+            rate,
+        }
+    }
+}
+
+/// Versioned edit-quality report. EVR (Edit Validity Rate) and BCIR
+/// (Broken-Caller Introduction Rate) over a corpus of proposed edit-sets.
+///
+/// - **EVR** = fraction of edit-sets whose `verify_edit` verdict is
+///   `pass`. `warn` / `fail` (and any undecodable verdict) count against
+///   it.
+/// - **BCIR** = fraction of edit-sets whose findings include ≥1
+///   `broken_caller` or `signature_break`. The complement of "clean of
+///   caller breaks" — higher is worse.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EditQualityReport {
+    /// Schema version for this report payload.
+    pub version: u32,
+    /// `rts-bench` package version.
+    pub rts_bench_version: String,
+    /// Workspace the edits were validated against.
+    pub workspace_path: String,
+    /// Corpus file the edit-sets came from.
+    pub corpus_path: String,
+    /// Number of corpus edit-sets processed.
+    pub edit_set_count: usize,
+    /// Edit Validity Rate: `pass` verdicts / all edit-sets.
+    pub evr: EditRate,
+    /// Broken-Caller Introduction Rate: edit-sets with ≥1
+    /// `broken_caller`/`signature_break` finding / all edit-sets.
+    pub bcir: EditRate,
+}
+
+/// Aggregate EVR / BCIR from an iterator of per-edit-set [`EditVerdict`]s.
+/// Pure math — no daemon, no IO.
+pub fn build_edit_report(
+    rts_bench_version: &str,
+    workspace_path: &str,
+    corpus_path: &str,
+    verdicts: impl IntoIterator<Item = EditVerdict>,
+) -> EditQualityReport {
+    let mut total = 0u64;
+    let mut passes = 0u64;
+    let mut broken = 0u64;
+    for v in verdicts {
+        total += 1;
+        if v.is_pass() {
+            passes += 1;
+        }
+        if v.introduces_broken_caller() {
+            broken += 1;
+        }
+    }
+    EditQualityReport {
+        version: 1,
+        rts_bench_version: rts_bench_version.to_string(),
+        workspace_path: workspace_path.to_string(),
+        corpus_path: corpus_path.to_string(),
+        edit_set_count: total as usize,
+        evr: EditRate::new(passes, total),
+        bcir: EditRate::new(broken, total),
+    }
+}
+
+/// Run an edit corpus through the oracle, calling `verify_edit` once per
+/// edit-set and collecting the verdicts. A single failed RPC aborts the
+/// run (unlike snippet metrics, an edit-set has no honest "skip" — a
+/// missing verdict would silently shrink the denominator).
+pub async fn run_edit_corpus<O: VerifyOracle>(
+    oracle: &mut O,
+    corpus: &EditCorpus,
+) -> Result<Vec<EditVerdict>> {
+    let mut out = Vec::with_capacity(corpus.edit_sets.len());
+    for set in &corpus.edit_sets {
+        let edits = set.edits_json();
+        out.push(oracle.verify_edit(&edits).await?);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -603,6 +848,21 @@ mod tests {
         symbols: HashMap<String, Resolution>,
         imports: HashMap<String, Resolution>,
         signatures: HashMap<String, Resolution>,
+        /// Canned `verify_edit` verdicts, returned in order. Each call
+        /// pops the next. A panic on exhaustion makes a miscounted test
+        /// loud instead of silently reusing a stale verdict.
+        edit_verdicts: Vec<EditVerdict>,
+    }
+
+    impl StubOracle {
+        fn empty() -> Self {
+            StubOracle {
+                symbols: HashMap::new(),
+                imports: HashMap::new(),
+                signatures: HashMap::new(),
+                edit_verdicts: Vec::new(),
+            }
+        }
     }
 
     impl VerifyOracle for StubOracle {
@@ -627,6 +887,19 @@ mod tests {
                 .copied()
                 .unwrap_or(Resolution::Indeterminate))
         }
+        async fn verify_edit(&mut self, _edits: &serde_json::Value) -> Result<EditVerdict> {
+            if self.edit_verdicts.is_empty() {
+                anyhow::bail!("StubOracle.verify_edit called more times than canned verdicts");
+            }
+            Ok(self.edit_verdicts.remove(0))
+        }
+    }
+
+    fn verdict(v: &str, kinds: &[&str]) -> EditVerdict {
+        EditVerdict {
+            verdict: v.to_string(),
+            finding_kinds: kinds.iter().map(|s| s.to_string()).collect(),
+        }
     }
 
     fn block_on<F: std::future::Future>(f: F) -> F::Output {
@@ -645,6 +918,7 @@ mod tests {
             symbols: HashMap::from([("make_thing".to_string(), Resolution::Exact)]),
             imports: HashMap::new(),
             signatures: HashMap::from([("make_thing".to_string(), Resolution::NotFound)]),
+            edit_verdicts: Vec::new(),
         };
         let mut acc = Resolutions::default();
         block_on(resolve_snippet(
@@ -671,6 +945,7 @@ mod tests {
             symbols: HashMap::from([("invented".to_string(), Resolution::NotFound)]),
             imports: HashMap::new(),
             signatures: HashMap::from([("invented".to_string(), Resolution::NotFound)]),
+            edit_verdicts: Vec::new(),
         };
         let mut acc = Resolutions::default();
         block_on(resolve_snippet(
@@ -694,6 +969,7 @@ mod tests {
             symbols: HashMap::new(),
             imports: HashMap::from([("std::collections::HashMap".to_string(), Resolution::Exact)]),
             signatures: HashMap::new(),
+            edit_verdicts: Vec::new(),
         };
         let mut acc = Resolutions::default();
         block_on(resolve_snippet(
@@ -721,6 +997,7 @@ mod tests {
             symbols: HashMap::new(),
             imports: HashMap::new(),
             signatures: HashMap::new(),
+            edit_verdicts: Vec::new(),
         };
         let acc = block_on(run_corpus(&mut oracle, &corpus)).unwrap();
         // Go has no F3 support → no decidable refs, 4 non-blank lines
@@ -746,10 +1023,148 @@ mod tests {
             symbols: HashMap::new(),
             imports: HashMap::new(),
             signatures: HashMap::new(),
+            edit_verdicts: Vec::new(),
         };
         let acc =
             block_on(run_corpus(&mut oracle, &corpus)).expect("must not abort on unknown lang");
         assert!(acc.symbol.is_empty());
         assert_eq!(acc.unsupported_language_refs, 2);
+    }
+
+    // ---- EVR / BCIR aggregation (edit metrics) ----
+
+    #[test]
+    fn edit_verdict_from_body_defaults_missing_verdict_to_fail() {
+        // No `verdict` field → fail (never a false pass), no kinds.
+        let v = EditVerdict::from_body(&json!({}));
+        assert_eq!(v.verdict, "fail");
+        assert!(!v.is_pass());
+        assert!(v.finding_kinds.is_empty());
+
+        // A pass with a new_symbol finding: is_pass true, no broken caller.
+        let v = EditVerdict::from_body(&json!({
+            "verdict": "pass",
+            "findings": [{ "kind": "new_symbol", "symbol": "brand_new" }],
+        }));
+        assert!(v.is_pass());
+        assert!(!v.introduces_broken_caller());
+
+        // A fail with a broken_caller: not a pass, IS a broken caller.
+        let v = EditVerdict::from_body(&json!({
+            "verdict": "fail",
+            "findings": [{ "kind": "broken_caller", "symbol": "target" }],
+        }));
+        assert!(!v.is_pass());
+        assert!(v.introduces_broken_caller());
+
+        // signature_break also counts toward BCIR.
+        let v = EditVerdict::from_body(&json!({
+            "verdict": "fail",
+            "findings": [{ "kind": "signature_break", "symbol": "target" }],
+        }));
+        assert!(v.introduces_broken_caller());
+    }
+
+    #[test]
+    fn build_edit_report_evr_bcir_numerator_denominator() {
+        // 4 edit-sets: 2 pass (one with a benign new_symbol), 1 warn,
+        // 1 fail-with-broken_caller.
+        //   EVR  = passes / total      = 2 / 4 = 0.5
+        //   BCIR = caller-breaks / total = 1 / 4 = 0.25
+        let verdicts = vec![
+            verdict("pass", &[]),
+            verdict("pass", &["new_symbol"]),
+            verdict("warn", &["dangling_ref"]),
+            verdict("fail", &["broken_caller"]),
+        ];
+        let report = build_edit_report("0.0.0-test", "/ws", "/c.toml", verdicts);
+        assert_eq!(report.version, 1);
+        assert_eq!(report.edit_set_count, 4);
+        assert_eq!(report.evr.numerator, 2);
+        assert_eq!(report.evr.denominator, 4);
+        assert_eq!(report.evr.rate, Some(0.5));
+        assert_eq!(report.bcir.numerator, 1);
+        assert_eq!(report.bcir.denominator, 4);
+        assert_eq!(report.bcir.rate, Some(0.25));
+    }
+
+    #[test]
+    fn build_edit_report_signature_break_counts_toward_bcir() {
+        // A `fail` driven by a signature_break (not broken_caller) still
+        // lands in BCIR — both kinds are caller-breaking.
+        let verdicts = vec![verdict("fail", &["signature_break"])];
+        let report = build_edit_report("0.0.0-test", "/ws", "/c.toml", verdicts);
+        assert_eq!(report.evr.rate, Some(0.0));
+        assert_eq!(report.bcir.numerator, 1);
+        assert_eq!(report.bcir.rate, Some(1.0));
+    }
+
+    #[test]
+    fn build_edit_report_empty_corpus_is_none_not_nan() {
+        let report = build_edit_report("0.0.0-test", "/ws", "/c.toml", []);
+        assert_eq!(report.edit_set_count, 0);
+        assert_eq!(report.evr.rate, None);
+        assert_eq!(report.bcir.rate, None);
+        // And serializes as JSON null, never NaN.
+        let j = serde_json::to_value(&report).unwrap();
+        assert!(j["evr"]["rate"].is_null());
+        assert!(j["bcir"]["rate"].is_null());
+    }
+
+    #[test]
+    fn run_edit_corpus_calls_verify_edit_per_set_in_order() {
+        // Two edit-sets; the stub returns a canned verdict per call.
+        // run_edit_corpus must preserve order and emit one verdict each.
+        let corpus = EditCorpus {
+            version: 1,
+            edit_sets: vec![
+                CorpusEditSet {
+                    name: "breaking".into(),
+                    edits: vec![CorpusEdit {
+                        file: "hub.rs".into(),
+                        content: "pub fn unrelated() {}\n".into(),
+                    }],
+                    expected_verdict: Some("fail".into()),
+                },
+                CorpusEditSet {
+                    name: "safe".into(),
+                    edits: vec![CorpusEdit {
+                        file: "hub.rs".into(),
+                        content: "pub fn target(x: u32) -> u32 { x }\npub fn extra() {}\n".into(),
+                    }],
+                    expected_verdict: Some("pass".into()),
+                },
+            ],
+        };
+        let mut oracle = StubOracle::empty();
+        oracle.edit_verdicts = vec![
+            verdict("fail", &["broken_caller"]),
+            verdict("pass", &["new_symbol"]),
+        ];
+        let verdicts = block_on(run_edit_corpus(&mut oracle, &corpus)).unwrap();
+        assert_eq!(verdicts.len(), 2);
+        assert_eq!(verdicts[0].verdict, "fail");
+        assert!(verdicts[0].introduces_broken_caller());
+        assert_eq!(verdicts[1].verdict, "pass");
+
+        // And the report over those verdicts: EVR=1/2, BCIR=1/2.
+        let report = build_edit_report("0.0.0-test", "/ws", "/c.toml", verdicts);
+        assert_eq!(report.evr.rate, Some(0.5));
+        assert_eq!(report.bcir.rate, Some(0.5));
+    }
+
+    #[test]
+    fn corpus_edit_set_edits_json_matches_daemon_shape() {
+        let set = CorpusEditSet {
+            name: "x".into(),
+            edits: vec![CorpusEdit {
+                file: "a.rs".into(),
+                content: "fn a() {}\n".into(),
+            }],
+            expected_verdict: None,
+        };
+        let j = set.edits_json();
+        assert_eq!(j[0]["file"], "a.rs");
+        assert_eq!(j[0]["content"], "fn a() {}\n");
     }
 }

--- a/crates/rts-bench/tests/verify_edit_metrics_integration.rs
+++ b/crates/rts-bench/tests/verify_edit_metrics_integration.rs
@@ -1,0 +1,137 @@
+//! Integration test for `rts-bench verify-edit` (verify-v0 P3.U2).
+//!
+//! Runs the REAL `verify-edit` subcommand — spawning rts-mcp + the daemon
+//! and mounting a tiny seeded workspace — against the committed
+//! self-validation fixture (`corpus/verify-edit-eval-selftest.toml`) and
+//! asserts the KNOWN EVR / BCIR.
+//!
+//! The fixture has three edit-sets over a workspace where `hub.rs` defines
+//! `target(x)` (arity 1) and `caller_a.rs` calls it:
+//!   1. remove `target`          → fail + broken_caller   (counts toward BCIR)
+//!   2. add a fn, keep `target`  → pass + new_symbol
+//!   3. arity-preserving edit    → pass
+//!
+//! So EVR = 2/3 and BCIR = 1/3. If these drift, either `Index.VerifyEdit`
+//! or the extractor changed — investigate before re-baselining.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use tokio::process::Command;
+
+fn rts_bench_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-bench"))
+}
+
+fn sibling(name: &str) -> PathBuf {
+    let me = rts_bench_bin();
+    me.parent().expect("CARGO_BIN_EXE has parent").join(name)
+}
+
+/// Locate the committed corpus relative to this crate's manifest dir
+/// (`crates/rts-bench`) → repo-root `corpus/`.
+fn selftest_corpus() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("corpus")
+        .join("verify-edit-eval-selftest.toml")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn verify_edit_selftest_fixture_reports_known_evr_bcir() -> Result<()> {
+    let workspace = tempfile::tempdir()?;
+    let runtime = tempfile::tempdir()?;
+    let state = tempfile::tempdir()?;
+    let home = tempfile::tempdir()?;
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime.path(), std::fs::Permissions::from_mode(0o700));
+
+    // Seed the workspace to match the fixture's expectations:
+    //   hub.rs      defines `target(x)` (arity 1)
+    //   caller_a.rs calls `target(1)`
+    std::fs::write(
+        workspace.path().join("hub.rs"),
+        "pub fn target(x: u32) -> u32 { x + 1 }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("caller_a.rs"),
+        "use crate::target;\npub fn caller_a() { let _ = target(1); }\n",
+    )?;
+
+    let corpus = selftest_corpus();
+    assert!(corpus.is_file(), "missing fixture {}", corpus.display());
+
+    let rts_mcp_bin = sibling("rts-mcp");
+    let rts_daemon_bin = sibling("rts-daemon");
+    assert!(rts_mcp_bin.is_file(), "missing {}", rts_mcp_bin.display());
+    assert!(
+        rts_daemon_bin.is_file(),
+        "missing {}",
+        rts_daemon_bin.display()
+    );
+
+    let mut cmd = Command::new(rts_bench_bin());
+    cmd.arg("verify-edit")
+        .arg("--corpus")
+        .arg(&corpus)
+        .arg("--workspace")
+        .arg(workspace.path())
+        .arg("--dry-run")
+        .env("XDG_RUNTIME_DIR", runtime.path())
+        .env("XDG_STATE_HOME", state.path())
+        .env("HOME", home.path())
+        .env("RTS_MCP_BIN", &rts_mcp_bin)
+        .env("RTS_DAEMON_BIN", &rts_daemon_bin)
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let out = cmd.output().await.context("spawn rts-bench verify-edit")?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "rts-bench verify-edit failed\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    // The command prints a human summary then the JSON report. Find the
+    // JSON object (starts at the first '{').
+    let json_start = stdout.find('{').context("no JSON in verify-edit output")?;
+    let report: Value =
+        serde_json::from_str(&stdout[json_start..]).context("parse EditQualityReport JSON")?;
+
+    assert_eq!(report["version"], 1);
+    assert_eq!(
+        report["edit_set_count"], 3,
+        "fixture has 3 edit-sets; got {report}"
+    );
+
+    // EVR = passes / total = 2 / 3.
+    assert_eq!(
+        report["evr"]["numerator"], 2,
+        "expected 2 passing edit-sets; got {report}"
+    );
+    assert_eq!(report["evr"]["denominator"], 3, "got {report}");
+    let evr = report["evr"]["rate"].as_f64().context("evr.rate")?;
+    assert!(
+        (evr - 2.0 / 3.0).abs() < 1e-9,
+        "expected EVR 2/3; got {evr} ({report})"
+    );
+
+    // BCIR = caller-breaking / total = 1 / 3 (the remove edit-set).
+    assert_eq!(
+        report["bcir"]["numerator"], 1,
+        "expected 1 caller-breaking edit-set; got {report}"
+    );
+    assert_eq!(report["bcir"]["denominator"], 3, "got {report}");
+    let bcir = report["bcir"]["rate"].as_f64().context("bcir.rate")?;
+    assert!(
+        (bcir - 1.0 / 3.0).abs() < 1e-9,
+        "expected BCIR 1/3; got {bcir} ({report})"
+    );
+
+    Ok(())
+}

--- a/crates/rts-daemon/src/main.rs
+++ b/crates/rts-daemon/src/main.rs
@@ -31,6 +31,7 @@ mod store;
 mod symbol_pagerank;
 #[cfg(feature = "telemetry")]
 mod telemetry_ticker;
+mod verify_edit;
 mod watcher;
 mod workspace;
 mod writer;

--- a/crates/rts-daemon/src/methods/daemon.rs
+++ b/crates/rts-daemon/src/methods/daemon.rs
@@ -206,6 +206,12 @@ const DAEMON_CAPABILITIES: &[&str] = &[
     // pass/fail `verdict` (would_break | safe) so an edit can be gated.
     // A verification-framed wrapper over `impact_of`. Additive.
     "verify_impact",
+    // verify-v0 P3 — `Index.VerifyEdit`: validate a PROPOSED multi-file
+    // patch against the live index *before* it's written, returning a
+    // pass/warn/fail `verdict` with structured findings (broken_caller /
+    // dangling_ref / signature_break / new_symbol). The flagship verify
+    // verb; a scoped in-memory delta, strictly read-only. Additive.
+    "verify_edit",
 ];
 
 /// `Daemon.Ping` — heartbeat + capability advertisement (protocol-v0 §4.1, §7.1).

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -3959,63 +3959,81 @@ pub async fn verify_edit(
         return Err(cancelled());
     }
 
-    // Optional check filter: when `checks` is present, keep only findings
-    // whose kind is named. Unknown names are ignored (forward-compat).
+    // `checks` controls ONLY which finding kinds appear in `findings[]`. It
+    // NEVER lowers the `verdict` or changes `summary` — those always reflect the
+    // FULL analysis, so a caller can't get a false `pass` by narrowing `checks`
+    // (e.g. `[]` or `["new_symbol"]` on an edit that removes a called symbol).
     let check_filter: Option<std::collections::HashSet<String>> = p.checks.as_ref().map(|cs| {
         cs.iter()
             .map(|c| c.trim().to_ascii_lowercase())
             .collect::<std::collections::HashSet<String>>()
     });
 
+    // Summary counts the FULL finding set (unfiltered).
     let mut critical = 0u64;
     let mut warning = 0u64;
     let mut info = 0u64;
-    let mut findings_json: Vec<serde_json::Value> = Vec::with_capacity(verdict.findings.len());
     for f in &verdict.findings {
-        if let Some(filter) = &check_filter {
-            if !filter.contains(f.kind.as_wire_str()) {
-                continue;
-            }
-        }
         match f.severity {
             crate::verify_edit::Severity::Critical => critical += 1,
             crate::verify_edit::Severity::Warning => warning += 1,
             crate::verify_edit::Severity::Info => info += 1,
         }
-        let site = match &f.site {
-            Some(s) => serde_json::json!({
-                "file":      s.file,
-                "line":      s.line,
-                "enclosing": s.enclosing,
-            }),
-            None => serde_json::Value::Null,
-        };
-        findings_json.push(serde_json::json!({
-            "severity": f.severity.as_wire_str(),
-            "kind":     f.kind.as_wire_str(),
-            "symbol":   f.symbol,
-            "site":     site,
-            "detail":   f.detail,
-        }));
     }
 
-    // Verdict. With no `checks` filter, use the engine's roll-up verbatim
-    // (it already applies the skipped-files → at-least-warn rule). When a
-    // filter is active, recompute over the FILTERED findings so a filter
-    // that drops every critical finding doesn't leave a stale `fail`; the
-    // skipped-files → at-least-warn rule still holds.
-    let filtered_verdict = if check_filter.is_none() {
-        verdict.verdict
-    } else if critical > 0 {
-        crate::verify_edit::Verdict::Fail
-    } else if warning > 0 || !verdict.files_skipped.is_empty() {
-        crate::verify_edit::Verdict::Warn
-    } else {
-        crate::verify_edit::Verdict::Pass
+    // Findings for display: filtered by `checks`, then sorted into a stable,
+    // reproducible order (severity, then symbol, site, kind) so the wire output
+    // is deterministic across runs.
+    let sev_rank = |s: &crate::verify_edit::Severity| match s {
+        crate::verify_edit::Severity::Critical => 0u8,
+        crate::verify_edit::Severity::Warning => 1,
+        crate::verify_edit::Severity::Info => 2,
     };
+    let mut shown: Vec<&crate::verify_edit::Finding> = verdict
+        .findings
+        .iter()
+        .filter(|f| {
+            check_filter
+                .as_ref()
+                .is_none_or(|filter| filter.contains(f.kind.as_wire_str()))
+        })
+        .collect();
+    shown.sort_by(|a, b| {
+        sev_rank(&a.severity)
+            .cmp(&sev_rank(&b.severity))
+            .then_with(|| a.symbol.cmp(&b.symbol))
+            .then_with(|| {
+                let ak = a.site.as_ref().map(|s| (s.file.as_str(), s.line));
+                let bk = b.site.as_ref().map(|s| (s.file.as_str(), s.line));
+                ak.cmp(&bk)
+            })
+            .then_with(|| a.kind.as_wire_str().cmp(b.kind.as_wire_str()))
+    });
+    let findings_json: Vec<serde_json::Value> = shown
+        .iter()
+        .map(|f| {
+            let site = match &f.site {
+                Some(s) => serde_json::json!({
+                    "file":      s.file,
+                    "line":      s.line,
+                    "enclosing": s.enclosing,
+                }),
+                None => serde_json::Value::Null,
+            };
+            serde_json::json!({
+                "severity": f.severity.as_wire_str(),
+                "kind":     f.kind.as_wire_str(),
+                "symbol":   f.symbol,
+                "site":     site,
+                "detail":   f.detail,
+            })
+        })
+        .collect();
 
     Ok(serde_json::json!({
-        "verdict": filtered_verdict.as_wire_str(),
+        // Verdict is ALWAYS the engine roll-up (full findings + the
+        // skipped-files at-least-warn rule); `checks` never lowers it.
+        "verdict": verdict.verdict.as_wire_str(),
         "summary": {
             "critical": critical,
             "warning":  warning,

--- a/crates/rts-daemon/src/methods/index.rs
+++ b/crates/rts-daemon/src/methods/index.rs
@@ -463,6 +463,34 @@ impl VerifyImpactChange {
     }
 }
 
+/// `Index.VerifyEdit` params (verify-v0 P3). Validates a PROPOSED patch
+/// against the live index *before* it is written, returning a structured
+/// pass/warn/fail verdict. The flagship verify verb.
+#[derive(Debug, Deserialize)]
+struct VerifyEditParams {
+    /// The proposed post-edit file states. Each `content` is the FULL new
+    /// content of `file` (not a diff hunk). Non-empty; each `file` is
+    /// 1..=1024 chars; total content is bounded (≤ 2 MiB).
+    #[serde(default)]
+    edits: Vec<ProposedEditParams>,
+    /// Optional check filter. When present, only the named checks run;
+    /// when absent, all four run. Accepted values: `broken_caller`,
+    /// `dangling_ref`, `signature_break`, `new_symbol`. Unknown names are
+    /// accepted-and-ignored (forward-compat). Currently the engine always
+    /// computes every check and this field post-filters the findings.
+    #[serde(default)]
+    checks: Option<Vec<String>>,
+}
+
+/// One proposed edit in a `Index.VerifyEdit` request.
+#[derive(Debug, Deserialize)]
+struct ProposedEditParams {
+    /// Workspace-relative path of the file being edited.
+    file: String,
+    /// Full post-edit content of the file.
+    content: String,
+}
+
 /// One claim in a `Index.VerifyClaims` batch. Tagged by `type`.
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -3815,6 +3843,193 @@ pub async fn verify_impact(
         out["reason"] = serde_json::json!(r);
     }
     Ok(out)
+}
+
+/// `Index.VerifyEdit(edits[], checks?)` — verify-v0 P3, capability
+/// `verify_edit`. The flagship verify verb.
+///
+/// Validates a PROPOSED patch against the live index *before it is
+/// written* and returns a structured pass/warn/fail verdict so an agent
+/// can gate a multi-file edit before committing it to disk.
+///
+/// Approach (a spike settled this): a **scoped in-memory delta** — re-parse
+/// the patched files, diff their defs/refs against the on-disk version, and
+/// query the LIVE index for the callers of any def the edit removes or
+/// whose arity it changes. Strictly **read-only**: never opens a write txn,
+/// never mutates the live index.
+///
+/// Wire shape (FROZEN field names):
+/// ```jsonc
+/// { "verdict": "fail",                       // pass | warn | fail
+///   "summary": { "critical": 1, "warning": 2, "info": 3 },
+///   "findings": [ { "severity": "critical",  // critical | warning | info
+///                   "kind": "broken_caller", // broken_caller | dangling_ref
+///                                            //  | signature_break | new_symbol
+///                   "symbol": "…",
+///                   "site": { "file": "…", "line": 1588, "enclosing": "…" },
+///                   "detail": "…" } ],
+///   "files_analyzed": 3,
+///   "files_skipped": [],
+///   "content_version_base": "…" }
+/// ```
+///
+/// Verdict: any `critical` → `fail`; else any `warning` → `warn`; else
+/// `pass`. A non-empty `files_skipped` (unsupported language, or over the
+/// `max_files` cap) forces the verdict to at least `warn` so a partial
+/// analysis is never mistaken for a clean pass.
+///
+/// `content_version_base` is a stable hash over the live index generation
+/// (`@<generation>`) so a caller can detect that the index moved under it
+/// between the verify and the write. Callers INSIDE the patched fileset are
+/// excluded from every cross-file check (those files are themselves being
+/// edited; flagging them against the stale index is a false positive).
+///
+/// `INVALID_PARAMS` on an empty `edits` list, a `file` outside 1..=1024
+/// chars, or total content over 2 MiB. Re-parses each patched file →
+/// cancellable.
+pub async fn verify_edit(
+    params: serde_json::Value,
+    state: &Arc<DaemonState>,
+    token: CancelToken,
+) -> Result<serde_json::Value, ProtocolError> {
+    /// Max files analyzed in one call (the engine default). Edits beyond
+    /// this land in `files_skipped`.
+    const MAX_FILES: usize = crate::verify_edit::DEFAULT_MAX_FILES;
+    /// Max combined post-edit content across all edits. Bounds the parse
+    /// work and matches the spirit of the 16 MiB wire cap (§3.3).
+    const MAX_TOTAL_CONTENT: usize = 2 * 1024 * 1024;
+
+    if token.is_cancelled() {
+        return Err(cancelled());
+    }
+    let p: VerifyEditParams = parse_params(params)?;
+    if p.edits.is_empty() {
+        return Err(ProtocolError::new(
+            ErrorCode::InvalidParams,
+            "`edits` must be a non-empty array",
+        ));
+    }
+    let mut total_content = 0usize;
+    for e in &p.edits {
+        if e.file.is_empty() || e.file.len() > 1024 {
+            return Err(ProtocolError::new(
+                ErrorCode::InvalidParams,
+                "each `edits[].file` must be 1..=1024 characters",
+            ));
+        }
+        total_content = total_content.saturating_add(e.content.len());
+    }
+    if total_content > MAX_TOTAL_CONTENT {
+        return Err(ProtocolError::new(
+            ErrorCode::InvalidParams,
+            format!("total edit content exceeds {MAX_TOTAL_CONTENT} bytes"),
+        ));
+    }
+
+    let (root, store_arc) = snapshot(state)?;
+    // Read generation BEFORE any read txn (Deepening §C cache invariant).
+    // It is also the basis for `content_version_base`.
+    let generation = state.index_generation.load(Ordering::Relaxed);
+
+    let edits: Vec<crate::verify_edit::ProposedEdit> = p
+        .edits
+        .iter()
+        .map(|e| crate::verify_edit::ProposedEdit {
+            file: e.file.clone(),
+            content: e.content.clone(),
+        })
+        .collect();
+
+    // The engine re-parses each patched file + walks the reverse-reference
+    // graph for removed/sig-changed defs; CPU-bound, so run it on a
+    // blocking thread like the impact BFS.
+    let store_clone = store_arc.clone();
+    let root_clone = root.clone();
+    let verdict = tokio::task::spawn_blocking(move || {
+        crate::verify_edit::evaluate(&store_clone, &root_clone, &edits, MAX_FILES)
+    })
+    .await
+    .map_err(|e| {
+        ProtocolError::new(
+            ErrorCode::InternalError,
+            format!("verify_edit join error: {e}"),
+        )
+    })?;
+    if token.is_cancelled() {
+        return Err(cancelled());
+    }
+
+    // Optional check filter: when `checks` is present, keep only findings
+    // whose kind is named. Unknown names are ignored (forward-compat).
+    let check_filter: Option<std::collections::HashSet<String>> = p.checks.as_ref().map(|cs| {
+        cs.iter()
+            .map(|c| c.trim().to_ascii_lowercase())
+            .collect::<std::collections::HashSet<String>>()
+    });
+
+    let mut critical = 0u64;
+    let mut warning = 0u64;
+    let mut info = 0u64;
+    let mut findings_json: Vec<serde_json::Value> = Vec::with_capacity(verdict.findings.len());
+    for f in &verdict.findings {
+        if let Some(filter) = &check_filter {
+            if !filter.contains(f.kind.as_wire_str()) {
+                continue;
+            }
+        }
+        match f.severity {
+            crate::verify_edit::Severity::Critical => critical += 1,
+            crate::verify_edit::Severity::Warning => warning += 1,
+            crate::verify_edit::Severity::Info => info += 1,
+        }
+        let site = match &f.site {
+            Some(s) => serde_json::json!({
+                "file":      s.file,
+                "line":      s.line,
+                "enclosing": s.enclosing,
+            }),
+            None => serde_json::Value::Null,
+        };
+        findings_json.push(serde_json::json!({
+            "severity": f.severity.as_wire_str(),
+            "kind":     f.kind.as_wire_str(),
+            "symbol":   f.symbol,
+            "site":     site,
+            "detail":   f.detail,
+        }));
+    }
+
+    // Verdict. With no `checks` filter, use the engine's roll-up verbatim
+    // (it already applies the skipped-files → at-least-warn rule). When a
+    // filter is active, recompute over the FILTERED findings so a filter
+    // that drops every critical finding doesn't leave a stale `fail`; the
+    // skipped-files → at-least-warn rule still holds.
+    let filtered_verdict = if check_filter.is_none() {
+        verdict.verdict
+    } else if critical > 0 {
+        crate::verify_edit::Verdict::Fail
+    } else if warning > 0 || !verdict.files_skipped.is_empty() {
+        crate::verify_edit::Verdict::Warn
+    } else {
+        crate::verify_edit::Verdict::Pass
+    };
+
+    Ok(serde_json::json!({
+        "verdict": filtered_verdict.as_wire_str(),
+        "summary": {
+            "critical": critical,
+            "warning":  warning,
+            "info":     info,
+        },
+        "findings":             findings_json,
+        "files_analyzed":       verdict.files_analyzed,
+        "files_skipped":        verdict.files_skipped,
+        // Stable hash over the live index generation. Kept simple: the
+        // generation is the writer's monotonically-increasing commit
+        // counter, so `@<generation>` is a stable base a caller can compare
+        // against the value it saw before the write.
+        "content_version_base": format!("@{generation}"),
+    }))
 }
 
 /// Internal struct used by `find_callers` (and U2's `read_symbol`

--- a/crates/rts-daemon/src/methods/mod.rs
+++ b/crates/rts-daemon/src/methods/mod.rs
@@ -195,6 +195,10 @@ pub async fn dispatch(
             counters.index_verify_impact.fetch_add(1, Relaxed);
             index::verify_impact(params, state, token).await
         }
+        "Index.VerifyEdit" => {
+            counters.index_verify_edit.fetch_add(1, Relaxed);
+            index::verify_edit(params, state, token).await
+        }
         "Index.ReadRange" => {
             counters.index_read_range.fetch_add(1, Relaxed);
             index::read_range(params, state).await
@@ -274,6 +278,7 @@ fn is_cancellable_method(method: &str) -> bool {
             | "Index.VerifyClaims"
             | "Index.ImpactOf"
             | "Index.VerifyImpact"
+            | "Index.VerifyEdit"
             | "Index.ReadSymbol"
             | "Index.Outline"
             | "Workspace.Mount"

--- a/crates/rts-daemon/src/state.rs
+++ b/crates/rts-daemon/src/state.rs
@@ -382,6 +382,7 @@ pub struct CallCounters {
     pub index_verify_claims: AtomicU64,
     pub index_impact_of: AtomicU64,
     pub index_verify_impact: AtomicU64,
+    pub index_verify_edit: AtomicU64,
     pub index_read_range: AtomicU64,
     pub index_read_symbol: AtomicU64,
     pub index_read_symbol_at: AtomicU64,
@@ -432,6 +433,7 @@ impl CallCounters {
             "Index.VerifyClaims":  self.index_verify_claims.load(Relaxed),
             "Index.ImpactOf":      self.index_impact_of.load(Relaxed),
             "Index.VerifyImpact":  self.index_verify_impact.load(Relaxed),
+            "Index.VerifyEdit":    self.index_verify_edit.load(Relaxed),
             "Index.ReadRange":     self.index_read_range.load(Relaxed),
             "Index.ReadSymbol":    self.index_read_symbol.load(Relaxed),
             "Index.ReadSymbolAt":  self.index_read_symbol_at.load(Relaxed),
@@ -468,6 +470,7 @@ impl CallCounters {
             + self.index_verify_claims.load(Relaxed)
             + self.index_impact_of.load(Relaxed)
             + self.index_verify_impact.load(Relaxed)
+            + self.index_verify_edit.load(Relaxed)
             + self.index_read_range.load(Relaxed)
             + self.index_read_symbol.load(Relaxed)
             + self.index_read_symbol_at.load(Relaxed)

--- a/crates/rts-daemon/src/verify_edit.rs
+++ b/crates/rts-daemon/src/verify_edit.rs
@@ -1,0 +1,615 @@
+//! verify-v0 P3 — `Index.VerifyEdit` engine.
+//!
+//! Validates a PROPOSED patch against the live code index *before it is
+//! written*, returning a structured pass/warn/fail verdict. The approach
+//! is a **scoped in-memory delta** (a spike settled this over a
+//! copy-on-write shadow index): re-parse the patched files, diff their
+//! defs against the on-disk version, and query the LIVE index for the
+//! callers of any def the edit removes or whose arity it changes.
+//!
+//! Strictly **read-only** — this module never opens a write txn and never
+//! mutates the live [`Store`]. It reads `OLD` content from disk and takes
+//! `NEW` content from the caller's proposed edit.
+//!
+//! ## What each edit contributes
+//! For every [`ProposedEdit`] (capped at `max_files`):
+//! 1. Read `OLD` = `root/file` (missing → treated as a new file with no
+//!    old defs). `NEW` = `edit.content`. The language is resolved from the
+//!    path; an unsupported language **skips** the file (no fabricated
+//!    findings — it simply contributes nothing, and its name lands in
+//!    `files_skipped`).
+//! 2. `parse_content(OLD)` → old defs; `parse_content(NEW)` → new defs;
+//!    `extract_references(NEW)` → new use-sites (currently unused for the
+//!    cross-file checks but parsed so the contract is stable).
+//! 3. Diff defs keyed by `(parent, name)`: **removed** (old ∖ new),
+//!    **added** (new ∖ old), **sig-changed** (in both, F4
+//!    `signature_shape` differs).
+//! 4. Run the checks below, **excluding** any caller that lives inside the
+//!    patched fileset — those files are themselves being edited, so
+//!    flagging them against the stale index would be a false positive.
+//!
+//! ## Checks
+//! - **new_symbols** (`Info`): an added def whose name is absent from the
+//!   live `NAME_TO_SID` table (`sid_for_name` → `None`).
+//! - **dangling_refs** (`Warning`): a removed def that still has live
+//!   callers *outside* the patch.
+//! - **broken_callers / signature_breaks** (`Critical`): for a sig-changed
+//!   def whose F4 arity changed, each live caller outside the patch is a
+//!   `SignatureBreak`. For a removed def, every live caller outside the
+//!   patch is a `BrokenCaller`.
+//!
+//! ## Verdict
+//! Any `Critical` → `Fail`; else any `Warning` → `Warn`; else `Pass`.
+//! **Important:** if `files_skipped` is non-empty the result must NOT read
+//! as a bare clean `Pass` — the verdict is bumped to at least `Warn` so a
+//! caller never mistakes "we couldn't analyze part of your edit" for "your
+//! edit is safe".
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use rust_tree_sitter::languages::Language;
+use rust_tree_sitter::{
+    Parser, SignatureShape, extract_references, parse_content, signature_shape, supports_references,
+};
+
+use crate::store::Store;
+
+/// Default cap on the number of files analyzed in one call. The spike
+/// showed 1–10 files parse serially within budget; 50 is a generous
+/// ceiling that still bounds worst-case work.
+pub const DEFAULT_MAX_FILES: usize = 50;
+
+/// One file's proposed post-edit state. `content` is the FULL new file
+/// content (not a diff hunk) — the engine re-parses it wholesale.
+#[derive(Debug, Clone)]
+pub struct ProposedEdit {
+    /// Workspace-relative path of the file being edited.
+    pub file: String,
+    /// Full post-edit content of the file.
+    pub content: String,
+}
+
+/// Severity of a single [`Finding`]. Drives the rolled-up [`Verdict`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// Ships a break: a real caller will no longer compile/resolve.
+    Critical,
+    /// Worth a look but not provably a break (e.g. a dangling ref that a
+    /// later edit in the same change might resolve).
+    Warning,
+    /// Informational only (e.g. a newly-introduced symbol).
+    Info,
+}
+
+impl Severity {
+    /// Wire string for the `findings[].severity` field.
+    pub fn as_wire_str(self) -> &'static str {
+        match self {
+            Severity::Critical => "critical",
+            Severity::Warning => "warning",
+            Severity::Info => "info",
+        }
+    }
+}
+
+/// The rolled-up gate result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// No findings worse than `Info`, and every file was analyzed.
+    Pass,
+    /// At least one `Warning` (or a skipped file) but no `Critical`.
+    Warn,
+    /// At least one `Critical` finding.
+    Fail,
+}
+
+impl Verdict {
+    /// Wire string for the `verdict` field.
+    pub fn as_wire_str(self) -> &'static str {
+        match self {
+            Verdict::Pass => "pass",
+            Verdict::Warn => "warn",
+            Verdict::Fail => "fail",
+        }
+    }
+}
+
+/// The category of a [`Finding`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindingKind {
+    /// A live caller of a removed def.
+    BrokenCaller,
+    /// A removed def that still has live callers (the def's references
+    /// are about to dangle).
+    DanglingRef,
+    /// A live caller of a def whose arity the edit changes.
+    SignatureBreak,
+    /// An added def whose name is not yet in the index.
+    NewSymbol,
+}
+
+impl FindingKind {
+    /// Wire string for the `findings[].kind` field.
+    pub fn as_wire_str(self) -> &'static str {
+        match self {
+            FindingKind::BrokenCaller => "broken_caller",
+            FindingKind::DanglingRef => "dangling_ref",
+            FindingKind::SignatureBreak => "signature_break",
+            FindingKind::NewSymbol => "new_symbol",
+        }
+    }
+}
+
+/// A concrete location associated with a [`Finding`] — the call site (for
+/// caller-side findings) resolved to its enclosing definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Site {
+    /// Workspace-relative file of the site.
+    pub file: String,
+    /// 1-based line of the site.
+    pub line: u32,
+    /// Qualified name of the def enclosing the site (`""` when unknown).
+    pub enclosing: String,
+}
+
+/// One structured finding from the edit verification.
+#[derive(Debug, Clone)]
+pub struct Finding {
+    /// How serious this finding is.
+    pub severity: Severity,
+    /// What category of finding this is.
+    pub kind: FindingKind,
+    /// The symbol the finding is about (the edited def's name).
+    pub symbol: String,
+    /// The associated location, when the finding is tied to a call site.
+    pub site: Option<Site>,
+    /// Human-readable detail (e.g. `"callee arity 1 -> 2"`).
+    pub detail: String,
+}
+
+/// The full structured result of an edit verification.
+#[derive(Debug, Clone)]
+pub struct EditVerdict {
+    /// Rolled-up pass/warn/fail.
+    pub verdict: Verdict,
+    /// Every finding, in discovery order.
+    pub findings: Vec<Finding>,
+    /// How many files were actually parsed + diffed.
+    pub files_analyzed: usize,
+    /// Files that contributed nothing (unsupported language, or dropped by
+    /// the `max_files` cap). A non-empty list bumps the verdict to at
+    /// least `Warn`.
+    pub files_skipped: Vec<String>,
+}
+
+/// A def identity for the delta diff: `(parent, name)`.
+type DefKey = (Option<String>, String);
+
+/// One parsed def with the data the diff needs.
+struct DefInfo {
+    /// The F4 signature shape, when decidable for the def's language.
+    /// `None` for an undecidable/unsupported shape — an arity check then
+    /// degrades to "no signature_break fired" (a removed def is still
+    /// caught by name).
+    shape: Option<SignatureShape>,
+}
+
+/// Evaluate a set of proposed edits against the live index.
+///
+/// `root` is the workspace root (for reading OLD content). `edits` are the
+/// proposed post-edit file states. `max_files` caps how many edits are
+/// analyzed; the rest land in `files_skipped`. Read-only throughout.
+pub fn evaluate(
+    store: &Arc<Store>,
+    root: &Path,
+    edits: &[ProposedEdit],
+    max_files: usize,
+) -> EditVerdict {
+    let max_files = max_files.max(1);
+
+    // Apply the file cap up front: analyze the first `max_files`, the rest
+    // are skipped (and bump the verdict away from a bare `Pass`).
+    let (analyzed_edits, capped) = if edits.len() > max_files {
+        (&edits[..max_files], &edits[max_files..])
+    } else {
+        (edits, &[][..])
+    };
+
+    // The set of files being edited. Callers inside this set are excluded
+    // from every cross-file check — those files are themselves changing, so
+    // the stale index's view of them is not authoritative.
+    let patched_files: std::collections::HashSet<&str> =
+        analyzed_edits.iter().map(|e| e.file.as_str()).collect();
+
+    let mut findings: Vec<Finding> = Vec::new();
+    let mut files_skipped: Vec<String> = capped.iter().map(|e| e.file.clone()).collect();
+    let mut files_analyzed = 0usize;
+
+    for edit in analyzed_edits {
+        let info = match crate::language::info_for_path(&edit.file) {
+            Some(i) => i,
+            None => {
+                // No language mapping → can't parse → skip (no fabricated
+                // findings). It contributes nothing but is recorded.
+                files_skipped.push(edit.file.clone());
+                continue;
+            }
+        };
+        let lang = info.language;
+        // We diff defs and need their signature shapes; both require a
+        // parseable language. `supports_references` gates the same Rust /
+        // TS / Python set `signature_shape` and the def diff rely on; for
+        // anything else there's no honest delta to compute, so skip.
+        if !supports_references(lang) {
+            files_skipped.push(edit.file.clone());
+            continue;
+        }
+
+        files_analyzed += 1;
+        analyze_one(store, root, edit, lang, &patched_files, &mut findings);
+    }
+
+    // Verdict roll-up. Any Critical → Fail; else any Warning → Warn; else
+    // Pass. A non-empty `files_skipped` forces at least `Warn` so a partial
+    // analysis never reads as a clean pass.
+    let has_critical = findings.iter().any(|f| f.severity == Severity::Critical);
+    let has_warning = findings.iter().any(|f| f.severity == Severity::Warning);
+    let verdict = if has_critical {
+        Verdict::Fail
+    } else if has_warning || !files_skipped.is_empty() {
+        Verdict::Warn
+    } else {
+        Verdict::Pass
+    };
+
+    EditVerdict {
+        verdict,
+        findings,
+        files_analyzed,
+        files_skipped,
+    }
+}
+
+/// Analyze a single edit, appending any findings.
+fn analyze_one(
+    store: &Arc<Store>,
+    root: &Path,
+    edit: &ProposedEdit,
+    lang: Language,
+    patched_files: &std::collections::HashSet<&str>,
+    findings: &mut Vec<Finding>,
+) {
+    // OLD content from disk (missing → new file, no old defs).
+    let old_content: String = match crate::path::resolve_workspace_path(root, &edit.file) {
+        Ok((abs, _)) => std::fs::read_to_string(&abs).unwrap_or_default(),
+        Err(_) => String::new(),
+    };
+    let new_content = &edit.content;
+
+    // Parse defs for OLD and NEW. A parse error yields no symbols, which is
+    // handled gracefully (an unparseable NEW simply produces no added/
+    // sig-changed findings rather than a fabricated one).
+    let old_defs = collect_defs(&old_content, lang);
+    let new_defs = collect_defs(new_content, lang);
+
+    // F3 references on NEW. Parsed for contract stability / future use; the
+    // cross-file caller checks below query the live index, not these.
+    let _new_refs = extract_references(new_content.as_bytes(), lang);
+
+    // Diff by (parent, name).
+    for (key, new_info) in &new_defs {
+        if !old_defs.contains_key(key) {
+            // ADDED def → new_symbol Info when absent from the live index.
+            let name = &key.1;
+            let in_index = store.sid_for_name(name).ok().flatten().is_some();
+            if !in_index {
+                findings.push(Finding {
+                    severity: Severity::Info,
+                    kind: FindingKind::NewSymbol,
+                    symbol: render_name(key),
+                    site: None,
+                    detail: "new symbol not yet in index".to_string(),
+                });
+            }
+            continue;
+        }
+        // In both → check for a signature (arity) change.
+        let old_info = &old_defs[key];
+        if let (Some(old_shape), Some(new_shape)) = (&old_info.shape, &new_info.shape) {
+            if old_shape.arity != new_shape.arity {
+                // Arity changed → every live caller OUTSIDE the patch is a
+                // signature break (Critical).
+                let detail = format!("callee arity {} -> {}", old_shape.arity, new_shape.arity);
+                for site in live_caller_sites(store, &key.1, patched_files) {
+                    findings.push(Finding {
+                        severity: Severity::Critical,
+                        kind: FindingKind::SignatureBreak,
+                        symbol: render_name(key),
+                        site: Some(site),
+                        detail: detail.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    for key in old_defs.keys() {
+        if new_defs.contains_key(key) {
+            continue;
+        }
+        // REMOVED def. Gather its live callers outside the patch once.
+        let sites = live_caller_sites(store, &key.1, patched_files);
+        if sites.is_empty() {
+            continue;
+        }
+        // Every live caller outside the patch is a BrokenCaller (Critical).
+        for site in &sites {
+            findings.push(Finding {
+                severity: Severity::Critical,
+                kind: FindingKind::BrokenCaller,
+                symbol: render_name(key),
+                site: Some(site.clone()),
+                detail: "caller references removed symbol".to_string(),
+            });
+        }
+        // And the removed def itself dangles (Warning) — surfaced once,
+        // pointing at the def's name (no specific site).
+        findings.push(Finding {
+            severity: Severity::Warning,
+            kind: FindingKind::DanglingRef,
+            symbol: render_name(key),
+            site: None,
+            detail: format!(
+                "{} live caller(s) reference the removed symbol",
+                sites.len()
+            ),
+        });
+    }
+}
+
+/// Parse `content` for `lang` and collect its defs keyed by `(parent,
+/// name)`, each carrying the line-anchored F4 signature shape.
+fn collect_defs(content: &str, lang: Language) -> HashMap<DefKey, DefInfo> {
+    let mut out: HashMap<DefKey, DefInfo> = HashMap::new();
+    let outcome = match parse_content(content, lang) {
+        Ok(o) => o,
+        Err(_) => return out,
+    };
+    if outcome.symbols.is_empty() {
+        return out;
+    }
+
+    // Parse once for the whole file so we can anchor `signature_shape` on
+    // each def node. Reuse the daemon's `find_def_node` walk.
+    let src = content.as_bytes();
+    let parser = match Parser::new(lang) {
+        Ok(p) => p,
+        Err(_) => {
+            // No tree → record defs without shapes (arity checks degrade to
+            // "undecidable", i.e. no signature_break fired; a removed def is
+            // still caught by name).
+            for sym in &outcome.symbols {
+                out.entry((sym.parent.clone(), sym.name.clone()))
+                    .or_insert(DefInfo { shape: None });
+            }
+            return out;
+        }
+    };
+    let tree = match parser.parse(content, None) {
+        Ok(t) => t,
+        Err(_) => {
+            for sym in &outcome.symbols {
+                out.entry((sym.parent.clone(), sym.name.clone()))
+                    .or_insert(DefInfo { shape: None });
+            }
+            return out;
+        }
+    };
+    let root_node = tree.root_node().inner();
+
+    for sym in &outcome.symbols {
+        let key: DefKey = (sym.parent.clone(), sym.name.clone());
+        // Anchor on the byte offset at the start of the def's line. The
+        // symbol's column isn't always the def keyword, so anchoring on the
+        // line start and letting `find_def_node` pick the innermost def
+        // covering that offset is robust enough for the diff.
+        let shape = byte_offset_of_line(src, sym.start_line)
+            .and_then(|off| find_def_node(root_node, off))
+            .and_then(|node| signature_shape(node, src, lang));
+        // First def with a given key wins; an overload collision is rare in
+        // the same file and the diff only needs presence + one shape.
+        out.entry(key).or_insert(DefInfo { shape });
+    }
+    out
+}
+
+/// Byte offset of the first character of 1-based `line` in `src`. Returns
+/// `None` when the line is past EOF.
+fn byte_offset_of_line(src: &[u8], line: usize) -> Option<usize> {
+    if line == 0 {
+        return None;
+    }
+    if line == 1 {
+        return Some(0);
+    }
+    let mut current = 1usize;
+    for (i, b) in src.iter().enumerate() {
+        if *b == b'\n' {
+            current += 1;
+            if current == line {
+                return Some(i + 1);
+            }
+        }
+    }
+    None
+}
+
+/// Depth-first search for the innermost recognised function/method
+/// definition node whose byte range covers `offset`. Mirrors the daemon's
+/// `methods::index::find_def_node` (kept local to keep the engine pure).
+fn find_def_node(
+    node: rust_tree_sitter::tree_sitter::Node<'_>,
+    offset: usize,
+) -> Option<rust_tree_sitter::tree_sitter::Node<'_>> {
+    const DEF_KINDS: &[&str] = &[
+        "function_item",
+        "function_signature_item",
+        "function_declaration",
+        "function_signature",
+        "method_definition",
+        "method_signature",
+        "generator_function_declaration",
+        "function_definition",
+    ];
+
+    if offset < node.start_byte() || offset >= node.end_byte() {
+        return None;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(found) = find_def_node(child, offset) {
+            return Some(found);
+        }
+    }
+    if DEF_KINDS.contains(&node.kind()) {
+        return Some(node);
+    }
+    None
+}
+
+/// Resolve the LIVE callers of the bare symbol `name` into [`Site`]s,
+/// EXCLUDING any caller whose file is in the patched fileset. Returns an
+/// empty vec when the symbol is unknown or has no callers. Read-only.
+fn live_caller_sites(
+    store: &Arc<Store>,
+    name: &str,
+    patched_files: &std::collections::HashSet<&str>,
+) -> Vec<Site> {
+    let sid = match store.sid_for_name(name).ok().flatten() {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+    let refs = match store.refs_to_symbol(sid) {
+        Ok(r) => r,
+        Err(_) => return Vec::new(),
+    };
+    let mut out: Vec<Site> = Vec::new();
+    // Cache fid → path so a hot callee in one file isn't resolved twice.
+    let mut path_cache: HashMap<u32, Option<String>> = HashMap::new();
+    for rs in refs {
+        let path = path_cache
+            .entry(rs.fid)
+            .or_insert_with(|| store.path_for_fid(rs.fid).ok().flatten())
+            .clone();
+        let Some(path) = path else { continue };
+        // EXCLUDE callers inside the patched fileset — those files are being
+        // edited; flagging them against the stale index is a false positive.
+        if patched_files.contains(path.as_str()) {
+            continue;
+        }
+        // Resolve the enclosing def name when the ref carries a caller_sid.
+        let enclosing = rs
+            .caller_sid
+            .and_then(|cs| store.caller_def_info(cs, rs.fid).ok().flatten())
+            .map(|info| info.name)
+            .unwrap_or_default();
+        out.push(Site {
+            file: path,
+            line: rs.start_line,
+            enclosing,
+        });
+    }
+    out
+}
+
+/// Render a `(parent, name)` key as a qualified name (`parent::name`).
+fn render_name(key: &DefKey) -> String {
+    match &key.0 {
+        Some(p) if !p.is_empty() => format!("{p}::{}", key.1),
+        _ => key.1.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_tree_sitter::languages::Language;
+
+    // ---- pure unit tests that don't need a Store ----
+
+    #[test]
+    fn collect_defs_diffs_added_and_removed() {
+        let old = "pub fn a() {}\npub fn b() {}\n";
+        let new = "pub fn a() {}\npub fn c() {}\n";
+        let old_defs = collect_defs(old, Language::Rust);
+        let new_defs = collect_defs(new, Language::Rust);
+        assert!(old_defs.contains_key(&(None, "a".to_string())));
+        assert!(old_defs.contains_key(&(None, "b".to_string())));
+        assert!(new_defs.contains_key(&(None, "c".to_string())));
+        // removed = old ∖ new = {b}
+        assert!(!new_defs.contains_key(&(None, "b".to_string())));
+        // added = new ∖ old = {c}
+        assert!(!old_defs.contains_key(&(None, "c".to_string())));
+    }
+
+    #[test]
+    fn collect_defs_detects_arity_change() {
+        let old = "pub fn target(x: u32) -> u32 { x }\n";
+        let new = "pub fn target(x: u32, y: u32) -> u32 { x + y }\n";
+        let old_defs = collect_defs(old, Language::Rust);
+        let new_defs = collect_defs(new, Language::Rust);
+        let k = (None, "target".to_string());
+        let os = old_defs[&k].shape.as_ref().expect("old shape");
+        let ns = new_defs[&k].shape.as_ref().expect("new shape");
+        assert_eq!(os.arity, 1);
+        assert_eq!(ns.arity, 2);
+    }
+
+    #[test]
+    fn collect_defs_arity_preserving_edit_same_shape() {
+        let old = "pub fn target(x: u32) -> u32 { x + 1 }\n";
+        let new = "pub fn target(x: u32) -> u32 { x + 2 }\n";
+        let old_defs = collect_defs(old, Language::Rust);
+        let new_defs = collect_defs(new, Language::Rust);
+        let k = (None, "target".to_string());
+        assert_eq!(
+            old_defs[&k].shape.as_ref().map(|s| s.arity),
+            new_defs[&k].shape.as_ref().map(|s| s.arity),
+        );
+    }
+
+    #[test]
+    fn byte_offset_of_line_basic() {
+        let src = b"line1\nline2\nline3\n";
+        assert_eq!(byte_offset_of_line(src, 1), Some(0));
+        assert_eq!(byte_offset_of_line(src, 2), Some(6));
+        assert_eq!(byte_offset_of_line(src, 3), Some(12));
+        assert_eq!(byte_offset_of_line(src, 99), None);
+        assert_eq!(byte_offset_of_line(src, 0), None);
+    }
+
+    #[test]
+    fn render_name_qualifies() {
+        assert_eq!(render_name(&(None, "foo".to_string())), "foo");
+        assert_eq!(
+            render_name(&(Some("Hub".to_string()), "ping".to_string())),
+            "Hub::ping"
+        );
+    }
+
+    #[test]
+    fn wire_strings_are_stable() {
+        assert_eq!(Verdict::Pass.as_wire_str(), "pass");
+        assert_eq!(Verdict::Warn.as_wire_str(), "warn");
+        assert_eq!(Verdict::Fail.as_wire_str(), "fail");
+        assert_eq!(Severity::Critical.as_wire_str(), "critical");
+        assert_eq!(Severity::Warning.as_wire_str(), "warning");
+        assert_eq!(Severity::Info.as_wire_str(), "info");
+        assert_eq!(FindingKind::BrokenCaller.as_wire_str(), "broken_caller");
+        assert_eq!(FindingKind::DanglingRef.as_wire_str(), "dangling_ref");
+        assert_eq!(FindingKind::SignatureBreak.as_wire_str(), "signature_break");
+        assert_eq!(FindingKind::NewSymbol.as_wire_str(), "new_symbol");
+    }
+}

--- a/crates/rts-daemon/src/verify_edit.rs
+++ b/crates/rts-daemon/src/verify_edit.rs
@@ -411,11 +411,15 @@ fn collect_defs(content: &str, lang: Language) -> HashMap<DefKey, DefInfo> {
 
     for sym in &outcome.symbols {
         let key: DefKey = (sym.parent.clone(), sym.name.clone());
-        // Anchor on the byte offset at the start of the def's line. The
-        // symbol's column isn't always the def keyword, so anchoring on the
-        // line start and letting `find_def_node` pick the innermost def
-        // covering that offset is robust enough for the diff.
+        // Anchor on the def's actual (line, column) — the symbol position is
+        // INSIDE its def node. Anchoring on the line *start* would land on the
+        // leading whitespace of an indented def (a method in an `impl`, a
+        // nested fn), which falls OUTSIDE the function node, so `find_def_node`
+        // would return `None` and arity changes on methods would silently pass.
+        // `start_column` is a byte offset within the line, so it composes
+        // directly with the line's byte offset.
         let shape = byte_offset_of_line(src, sym.start_line)
+            .map(|off| off + sym.start_column)
             .and_then(|off| find_def_node(root_node, off))
             .and_then(|node| signature_shape(node, src, lang));
         // First def with a given key wins; an overload collision is rare in
@@ -565,6 +569,30 @@ mod tests {
         let ns = new_defs[&k].shape.as_ref().expect("new shape");
         assert_eq!(os.arity, 1);
         assert_eq!(ns.arity, 2);
+    }
+
+    #[test]
+    fn collect_defs_decides_indented_method_shape() {
+        // Regression: an INDENTED def (method in an `impl`) must get a decidable
+        // signature shape. Anchoring on the line start instead of the symbol
+        // column lands on the leading whitespace, outside the fn node, so the
+        // shape would be None and a method arity change would silently pass.
+        let old = "pub struct S;\nimpl S {\n    pub fn m(&self, x: u32) -> u32 { x }\n}\n";
+        let new =
+            "pub struct S;\nimpl S {\n    pub fn m(&self, x: u32, y: u32) -> u32 { x + y }\n}\n";
+        let old_defs = collect_defs(old, Language::Rust);
+        let new_defs = collect_defs(new, Language::Rust);
+        let k = (Some("S".to_string()), "m".to_string());
+        let os = old_defs[&k]
+            .shape
+            .as_ref()
+            .expect("indented method old shape must be decidable");
+        let ns = new_defs[&k]
+            .shape
+            .as_ref()
+            .expect("indented method new shape must be decidable");
+        assert_eq!(os.arity, 1, "self excluded → arity 1");
+        assert_eq!(ns.arity, 2, "self excluded → arity 2 after the change");
     }
 
     #[test]

--- a/crates/rts-daemon/tests/protocol_schemas.rs
+++ b/crates/rts-daemon/tests/protocol_schemas.rs
@@ -49,6 +49,7 @@ const PROTOCOL_METHODS: &[&str] = &[
     "Index.VerifyClaims",
     "Index.ImpactOf",
     "Index.VerifyImpact",
+    "Index.VerifyEdit",
     "Index.ReadRange",
     "Index.ReadSymbol",
     "Index.ReadSymbolAt",
@@ -314,6 +315,13 @@ async fn response_matches_schema_for_each_method() -> anyhow::Result<()> {
             "Index.VerifyImpact",
             json!({"symbol": "answer", "change": "remove"}),
         ),
+        (
+            "Index.VerifyEdit",
+            json!({"edits": [{
+                "file": "src/lib.rs",
+                "content": "/// Compute the answer.\npub fn answer() -> u32 {\n    42\n}\n\npub fn call_answer() -> u32 {\n    answer() + 1\n}\n\npub fn brand_new() -> u32 {\n    7\n}\n"
+            }]}),
+        ),
         ("Index.Outline", json!({"token_budget": 4096})),
         ("Index.Grep", json!({"text": "answer"})),
         (
@@ -408,6 +416,7 @@ const EXPECTED_CAPABILITIES: &[&str] = &[
     "verify_import",
     "verify_claims",
     "verify_impact",
+    "verify_edit",
 ];
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/rts-daemon/tests/verify_edit_round_trip.rs
+++ b/crates/rts-daemon/tests/verify_edit_round_trip.rs
@@ -1,0 +1,379 @@
+//! End-to-end test for verify-v0 P3: `Index.VerifyEdit`.
+//!
+//! `Index.VerifyEdit` validates a PROPOSED patch against the live index
+//! *before it is written* and returns a pass/warn/fail verdict so an agent
+//! can gate a multi-file edit before committing it to disk. It is a scoped
+//! in-memory delta (re-parse the patched files, diff defs, query the live
+//! index for callers) — strictly read-only.
+//!
+//! Fixture:
+//!   `hub.rs`      defines `target` (called) and an arity-1 signature.
+//!   `caller_a.rs` calls `target`.
+//!
+//! Cases:
+//!   1. edit REMOVING a called fn → `fail` + `broken_caller` naming the
+//!      live caller.
+//!   2. edit changing a called fn's ARITY → `fail` + `signature_break`
+//!      "callee arity 1 -> 2".
+//!   3. edit ADDING a new fn → `pass` + `new_symbol` info.
+//!   4. arity-preserving body edit of a called fn → `pass`.
+//!   5. editing BOTH callee and its only caller consistently (caller in the
+//!      patched set) → `pass` (no false broken_caller).
+//!   6. > max_files (here forced via many tiny edits is impractical; we
+//!      instead assert the partial-result shape directly by sending more
+//!      than the cap) → `files_skipped` populated, verdict NOT a bare pass.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+fn daemon_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_rts-daemon"))
+}
+
+async fn wait_for_socket(path: &std::path::Path, timeout: Duration) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "socket {} did not appear within {:?}",
+                path.display(),
+                timeout
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn round_trip(
+    stream: &mut UnixStream,
+    id: &str,
+    method: &str,
+    params: Value,
+) -> anyhow::Result<Value> {
+    let req = json!({ "id": id, "method": method, "params": params });
+    let mut bytes = serde_json::to_vec(&req)?;
+    bytes.push(b'\n');
+    stream.write_all(&bytes).await?;
+    stream.flush().await?;
+
+    let mut buf = Vec::new();
+    let (rd, _wr) = stream.split();
+    let mut reader = BufReader::new(rd);
+    let n = tokio::time::timeout(Duration::from_secs(8), reader.read_until(b'\n', &mut buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for response to {method}"))??;
+    anyhow::ensure!(n > 0, "EOF before response to {method}");
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn wait_for_symbol(
+    stream: &mut UnixStream,
+    name: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 100;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindSymbol",
+            json!({ "name": name }),
+        )
+        .await?;
+        if !resp["result"]["matches"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("symbol `{name}` never indexed within {:?}", timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+/// Poll `Index.FindCallers(target)` until `expected` is among the callers —
+/// the REFS edges `Index.VerifyEdit`'s caller queries depend on are
+/// committed in a separate writer batch from the DEF rows.
+async fn wait_for_refs(
+    stream: &mut UnixStream,
+    target: &str,
+    expected: &str,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut id: u64 = 200;
+    loop {
+        id += 1;
+        let resp = round_trip(
+            stream,
+            &id.to_string(),
+            "Index.FindCallers",
+            json!({ "name": target }),
+        )
+        .await?;
+        let present = resp["result"]["callers"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .any(|c| c["enclosing_qualified_name"].as_str() == Some(expected))
+            })
+            .unwrap_or(false);
+        if present {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("REFS to `{target}` from `{expected}` never settled within {timeout:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(75)).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn verify_edit_round_trip() -> anyhow::Result<()> {
+    let runtime_dir = tempfile::tempdir()?;
+    let state_dir = tempfile::tempdir()?;
+    let home_dir = tempfile::tempdir()?;
+    let workspace = tempfile::tempdir()?;
+
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(runtime_dir.path(), std::fs::Permissions::from_mode(0o700));
+
+    // `target` is called by `caller_a`.
+    std::fs::write(
+        workspace.path().join("hub.rs"),
+        "pub fn target(x: u32) -> u32 { x + 1 }\n",
+    )?;
+    std::fs::write(
+        workspace.path().join("caller_a.rs"),
+        "use crate::target;\n\
+         pub fn caller_a() { let _ = target(1); }\n",
+    )?;
+
+    let socket_path = if cfg!(target_os = "macos") {
+        home_dir
+            .path()
+            .join("Library")
+            .join("Caches")
+            .join("rts")
+            .join("default.sock")
+    } else {
+        runtime_dir.path().join("rts").join("default.sock")
+    };
+
+    let mut cmd = Command::new(daemon_bin());
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .env("HOME", home_dir.path())
+        .env("RUST_LOG", "warn")
+        .env("RTS_IDLE_SHUTDOWN_SECS", "60")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = cmd.spawn()?;
+    let _kill = KillOnDrop(&mut child);
+
+    wait_for_socket(&socket_path, Duration::from_secs(5)).await?;
+    let mut stream = UnixStream::connect(&socket_path).await?;
+
+    let mount = round_trip(
+        &mut stream,
+        "1",
+        "Workspace.Mount",
+        json!({ "root": workspace.path() }),
+    )
+    .await?;
+    assert!(mount["error"].is_null(), "mount: {mount:?}");
+
+    wait_for_symbol(&mut stream, "target", Duration::from_secs(5)).await?;
+    wait_for_symbol(&mut stream, "caller_a", Duration::from_secs(5)).await?;
+    wait_for_refs(&mut stream, "target", "caller_a", Duration::from_secs(5)).await?;
+
+    // 1. REMOVE a called fn (hub.rs no longer defines `target`) → fail +
+    //    broken_caller naming the live caller (`caller_a`, outside the patch).
+    let removed = round_trip(
+        &mut stream,
+        "10",
+        "Index.VerifyEdit",
+        json!({ "edits": [{
+            "file": "hub.rs",
+            "content": "pub fn unrelated() -> u32 { 0 }\n"
+        }]}),
+    )
+    .await?;
+    assert!(
+        removed["error"].is_null(),
+        "verify_edit remove: {removed:?}"
+    );
+    let r = &removed["result"];
+    assert_eq!(
+        r["verdict"], "fail",
+        "removing a called fn must fail: {r:?}"
+    );
+    let findings = r["findings"].as_array().cloned().unwrap_or_default();
+    let broken = findings
+        .iter()
+        .find(|f| f["kind"] == "broken_caller" && f["symbol"] == "target")
+        .unwrap_or_else(|| panic!("expected a broken_caller for `target`; got {findings:?}"));
+    assert_eq!(
+        broken["site"]["file"], "caller_a.rs",
+        "the broken caller's file must be listed: {broken:?}"
+    );
+    assert_eq!(
+        broken["site"]["enclosing"], "caller_a",
+        "the broken caller's enclosing def must be `caller_a`: {broken:?}"
+    );
+    assert!(
+        r["summary"]["critical"].as_u64().unwrap_or(0) >= 1,
+        "critical count: {r:?}"
+    );
+
+    // 2. Change a called fn's ARITY (1 -> 2) → fail + signature_break with
+    //    detail "callee arity 1 -> 2".
+    let arity = round_trip(
+        &mut stream,
+        "11",
+        "Index.VerifyEdit",
+        json!({ "edits": [{
+            "file": "hub.rs",
+            "content": "pub fn target(x: u32, y: u32) -> u32 { x + y }\n"
+        }]}),
+    )
+    .await?;
+    let a = &arity["result"];
+    assert_eq!(a["verdict"], "fail", "arity change must fail: {a:?}");
+    let afindings = a["findings"].as_array().cloned().unwrap_or_default();
+    let sigbreak = afindings
+        .iter()
+        .find(|f| f["kind"] == "signature_break")
+        .unwrap_or_else(|| panic!("expected a signature_break; got {afindings:?}"));
+    assert_eq!(
+        sigbreak["detail"], "callee arity 1 -> 2",
+        "signature_break detail: {sigbreak:?}"
+    );
+    assert_eq!(sigbreak["site"]["file"], "caller_a.rs");
+
+    // 3. ADD a new fn (keep `target` intact) → pass + new_symbol info.
+    let added = round_trip(
+        &mut stream,
+        "12",
+        "Index.VerifyEdit",
+        json!({ "edits": [{
+            "file": "hub.rs",
+            "content": "pub fn target(x: u32) -> u32 { x + 1 }\npub fn brand_new() -> u32 { 9 }\n"
+        }]}),
+    )
+    .await?;
+    let ad = &added["result"];
+    assert_eq!(ad["verdict"], "pass", "adding a fn is a pass: {ad:?}");
+    let adfindings = ad["findings"].as_array().cloned().unwrap_or_default();
+    assert!(
+        adfindings
+            .iter()
+            .any(|f| f["kind"] == "new_symbol" && f["symbol"] == "brand_new"),
+        "expected a new_symbol finding for `brand_new`; got {adfindings:?}"
+    );
+
+    // 4. Arity-preserving body edit of a called fn → pass.
+    let body = round_trip(
+        &mut stream,
+        "13",
+        "Index.VerifyEdit",
+        json!({ "edits": [{
+            "file": "hub.rs",
+            "content": "pub fn target(x: u32) -> u32 { x + 100 }\n"
+        }]}),
+    )
+    .await?;
+    let b = &body["result"];
+    assert_eq!(
+        b["verdict"], "pass",
+        "an arity-preserving body edit is a pass: {b:?}"
+    );
+    assert_eq!(b["summary"]["critical"], 0);
+
+    // 5. Edit BOTH the callee (arity change) AND its only caller consistently
+    //    in the SAME patch → pass: the caller is inside the patched set, so it
+    //    must NOT be flagged as a broken_caller against the stale index.
+    let consistent = round_trip(
+        &mut stream,
+        "14",
+        "Index.VerifyEdit",
+        json!({ "edits": [
+            { "file": "hub.rs",
+              "content": "pub fn target(x: u32, y: u32) -> u32 { x + y }\n" },
+            { "file": "caller_a.rs",
+              "content": "use crate::target;\npub fn caller_a() { let _ = target(1, 2); }\n" }
+        ]}),
+    )
+    .await?;
+    let c = &consistent["result"];
+    assert_eq!(
+        c["verdict"], "pass",
+        "a callee+caller edited together must not self-flag: {c:?}"
+    );
+    let cfindings = c["findings"].as_array().cloned().unwrap_or_default();
+    assert!(
+        !cfindings
+            .iter()
+            .any(|f| f["kind"] == "broken_caller" || f["kind"] == "signature_break"),
+        "no caller-side findings when the caller is in the patch: {cfindings:?}"
+    );
+
+    // 6. Over the file cap → files_skipped populated, verdict NOT a bare pass.
+    //    Send 55 trivial edits (default cap is 50). Each is a benign new file
+    //    with one fn, so absent the cap the verdict would be a clean pass.
+    let mut many: Vec<Value> = Vec::new();
+    for i in 0..55 {
+        many.push(json!({
+            "file": format!("gen/file_{i}.rs"),
+            "content": format!("pub fn gen_{i}() -> u32 {{ {i} }}\n"),
+        }));
+    }
+    let capped = round_trip(
+        &mut stream,
+        "15",
+        "Index.VerifyEdit",
+        json!({ "edits": many }),
+    )
+    .await?;
+    let cap = &capped["result"];
+    let skipped = cap["files_skipped"].as_array().cloned().unwrap_or_default();
+    assert!(
+        !skipped.is_empty(),
+        "over-cap edits must populate files_skipped: {cap:?}"
+    );
+    assert_ne!(
+        cap["verdict"], "pass",
+        "a partial (skipped-files) result must not read as a bare pass: {cap:?}"
+    );
+    assert_eq!(cap["files_analyzed"].as_u64().unwrap_or(0), 50);
+
+    // The frozen response shape carries `content_version_base`.
+    assert!(
+        cap["content_version_base"].is_string(),
+        "content_version_base must be present: {cap:?}"
+    );
+
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut std::process::Child);
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}

--- a/crates/rts-daemon/tests/verify_edit_round_trip.rs
+++ b/crates/rts-daemon/tests/verify_edit_round_trip.rs
@@ -367,6 +367,54 @@ async fn verify_edit_round_trip() -> anyhow::Result<()> {
         "content_version_base must be present: {cap:?}"
     );
 
+    // 7. `checks` is a DISPLAY filter, not a verdict lever. Removing a called
+    //    fn while asking to see only `new_symbol` must STILL verdict `fail`
+    //    (the broken_caller is suppressed from `findings[]` but the verdict and
+    //    summary reflect the full analysis) — otherwise a caller could buy a
+    //    false `pass` with `checks: []`.
+    let filtered = round_trip(
+        &mut stream,
+        "16",
+        "Index.VerifyEdit",
+        json!({
+            "edits": [{ "file": "hub.rs", "content": "pub fn unrelated() -> u32 { 0 }\n" }],
+            "checks": ["new_symbol"]
+        }),
+    )
+    .await?;
+    let fl = &filtered["result"];
+    assert_eq!(
+        fl["verdict"], "fail",
+        "`checks` must NOT lower the verdict — a real break still fails: {fl:?}"
+    );
+    assert!(
+        fl["summary"]["critical"].as_u64().unwrap_or(0) >= 1,
+        "summary must reflect the full analysis regardless of `checks`: {fl:?}"
+    );
+    // The display filter DID hide the broken_caller (checks=["new_symbol"]),
+    // even though it still drives the verdict + summary.
+    let shown = fl["findings"].as_array().cloned().unwrap_or_default();
+    assert!(
+        !shown.iter().any(|f| f["kind"] == "broken_caller"),
+        "checks=[new_symbol] must hide broken_caller from findings[]; got {shown:?}"
+    );
+
+    // And an empty `checks` must not buy a false pass either.
+    let empty_checks = round_trip(
+        &mut stream,
+        "17",
+        "Index.VerifyEdit",
+        json!({
+            "edits": [{ "file": "hub.rs", "content": "pub fn unrelated() -> u32 { 0 }\n" }],
+            "checks": []
+        }),
+    )
+    .await?;
+    assert_eq!(
+        empty_checks["result"]["verdict"], "fail",
+        "`checks: []` must not yield a false pass: {empty_checks:?}"
+    );
+
     Ok(())
 }
 

--- a/crates/rts-mcp/src/bin/rts.rs
+++ b/crates/rts-mcp/src/bin/rts.rs
@@ -19,7 +19,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use serde_json::{Value, json};
 
@@ -167,6 +167,33 @@ enum Cmd {
         /// Path to the file to verify.
         path: PathBuf,
     },
+    /// Gate a proposed multi-file PATCH before it's written — the
+    /// enterprise/CI pre-merge gate.
+    ///
+    /// Reads an edits JSON (`[{ "file": "...", "content": "..." }]`, where
+    /// `content` is the FULL post-edit content of each file) from a file
+    /// or stdin (`-`), calls the daemon's `Index.VerifyEdit`, prints the
+    /// pass/warn/fail verdict + findings, and maps the verdict to an exit
+    /// code via `--fail-on`.
+    ///
+    /// Exit codes:
+    ///   --fail-on critical (default): pass/warn → 0, fail → 2
+    ///   --fail-on warn:               pass → 0,      warn/fail → 2
+    ///   --fail-on none:               always 0 (report-only)
+    ///   daemon error / bad input:     3
+    ///
+    /// CI usage:
+    ///   `rts verify-edit --edits pr-edits.json --fail-on critical`
+    /// fails the build on a caller-breaking patch.
+    VerifyEdit {
+        /// Path to the edits JSON, or `-` to read from stdin.
+        #[arg(long)]
+        edits: String,
+        /// Verdict threshold that fails the gate (nonzero exit). One of
+        /// `none`, `warn`, `critical`. Default `critical`.
+        #[arg(long, value_enum, default_value_t = FailOn::Critical)]
+        fail_on: FailOn,
+    },
     /// Print the workspace outline (token-budgeted tree).
     Outline {
         /// Optional glob to restrict the outline.
@@ -212,6 +239,37 @@ enum Cmd {
         #[command(subcommand)]
         action: TelemetryCmd,
     },
+}
+
+/// The verdict severity at (or above) which `rts verify-edit` fails the
+/// gate with a nonzero exit. Ordered least→most strict.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum FailOn {
+    /// Never fail the gate — always exit 0. Report-only.
+    None,
+    /// Fail on `warn` or `fail` (i.e. anything that isn't a clean pass).
+    Warn,
+    /// Fail only on `fail` (a critical finding). The default — a plain
+    /// `pass`/`warn` exits 0.
+    Critical,
+}
+
+impl FailOn {
+    /// Map a daemon verdict string to a gate exit code under this policy.
+    /// `pass`/`warn`/`fail` are the frozen `Index.VerifyEdit` verdicts; an
+    /// unknown verdict is treated as `fail` (never a silent pass). Returns
+    /// `exit::OK` (0) when below threshold, `2` when at/above it.
+    fn exit_for(self, verdict: &str) -> i32 {
+        let at_or_above = match self {
+            FailOn::None => false,
+            // `warn` fails on warn+fail (and any non-pass verdict).
+            FailOn::Warn => verdict != "pass",
+            // `critical` fails only on `fail` (or an unknown verdict,
+            // which we treat as fail).
+            FailOn::Critical => verdict == "fail" || (verdict != "pass" && verdict != "warn"),
+        };
+        if at_or_above { 2 } else { exit::OK }
+    }
 }
 
 #[derive(Subcommand, Debug)]
@@ -599,6 +657,9 @@ async fn run_command(
             Ok(if resolved { exit::OK } else { exit::NO_RESULTS })
         }
         Cmd::Verify { path } => run_verify(&client, workspace, cli.json, path, style).await,
+        Cmd::VerifyEdit { edits, fail_on } => {
+            run_verify_edit(&client, workspace, cli.json, edits, *fail_on, style).await
+        }
         Cmd::Outline { glob, token_budget } => {
             let mut params = serde_json::Map::new();
             if let Some(g) = glob {
@@ -784,6 +845,107 @@ async fn run_verify(
     } else {
         cli::exit::NO_RESULTS
     })
+}
+
+/// `rts verify-edit --edits <path|-> [--fail-on <none|warn|critical>]` —
+/// gate a proposed multi-file patch before it's written.
+///
+/// Reads the edits JSON (`[{file, content}]`, full post-edit content) from
+/// a file or stdin (`-`), calls `Index.VerifyEdit`, renders the verdict +
+/// findings (or passes the raw daemon response through with `--json`), and
+/// maps the verdict to a gate exit code via [`FailOn::exit_for`].
+///
+/// Exit codes:
+///   pass/warn/fail mapped through `--fail-on` → 0 or 2 (see [`FailOn`]).
+///   malformed / missing edits, daemon contact failure → 3 (DAEMON_ERROR).
+async fn run_verify_edit(
+    client: &rts_mcp::connection::ConnectionManager,
+    workspace: &std::path::Path,
+    json: bool,
+    edits_src: &str,
+    fail_on: FailOn,
+    style: &Style,
+) -> Result<i32, CmdError> {
+    // 1. Read the edits source (file or `-` for stdin) and parse it as a
+    //    JSON array of `{file, content}` objects. A malformed payload is a
+    //    setup error (exit 3) — never a panic.
+    let raw = if edits_src == "-" {
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+            .map_err(|e| anyhow::anyhow!("read edits from stdin: {e}"))?;
+        buf
+    } else {
+        std::fs::read_to_string(edits_src)
+            .map_err(|e| anyhow::anyhow!("read edits {edits_src}: {e}"))?
+    };
+    let edits: Value =
+        serde_json::from_str(&raw).map_err(|e| anyhow::anyhow!("parse edits JSON: {e}"))?;
+    let arr = edits.as_array().ok_or_else(|| {
+        anyhow::anyhow!(
+            "edits must be a JSON array of {{file, content}} objects, got {}",
+            kind_of(&edits)
+        )
+    })?;
+    if arr.is_empty() {
+        return Err(CmdError::Setup(anyhow::anyhow!(
+            "edits array is empty — nothing to verify"
+        )));
+    }
+    // Shape-check each entry so a typo'd key fails clean instead of
+    // surfacing as an opaque daemon validation error.
+    for (i, e) in arr.iter().enumerate() {
+        let ok = e.get("file").and_then(|f| f.as_str()).is_some()
+            && e.get("content").and_then(|c| c.as_str()).is_some();
+        if !ok {
+            return Err(CmdError::Setup(anyhow::anyhow!(
+                "edits[{i}] must have string `file` and `content` fields"
+            )));
+        }
+    }
+
+    // 2. Call the daemon.
+    let body = match cli::call_method(
+        client,
+        workspace,
+        "Index.VerifyEdit",
+        json!({ "edits": edits }),
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => return Ok(cli::render_connection_error(&e, style)),
+    };
+
+    // 3. Emit. `--json` passes the daemon response through verbatim.
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&body).unwrap_or_default()
+        );
+    } else {
+        let mut stdout = std::io::stdout().lock();
+        cli::render_edit_verdict(&body, &mut stdout, style).map_err(io_to_anyhow)?;
+        stdout.flush().map_err(io_to_anyhow)?;
+    }
+
+    // 4. Gate on the verdict.
+    let verdict = body
+        .get("verdict")
+        .and_then(|v| v.as_str())
+        .unwrap_or("fail");
+    Ok(fail_on.exit_for(verdict))
+}
+
+/// A short human label for a JSON value's type — used in error messages.
+fn kind_of(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "a boolean",
+        Value::Number(_) => "a number",
+        Value::String(_) => "a string",
+        Value::Array(_) => "an array",
+        Value::Object(_) => "an object",
+    }
 }
 
 /// `rts telemetry {status,preview,enable,disable,flush}` dispatch.
@@ -1175,5 +1337,36 @@ fn run_doctor(output: Option<&str>) -> ExitCode {
             );
             ExitCode::from(exit::DAEMON_ERROR as u8)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fail_on_critical_gates_only_on_fail() {
+        // Default policy: pass/warn → 0, fail → 2.
+        assert_eq!(FailOn::Critical.exit_for("pass"), exit::OK);
+        assert_eq!(FailOn::Critical.exit_for("warn"), exit::OK);
+        assert_eq!(FailOn::Critical.exit_for("fail"), 2);
+        // Unknown verdict is treated as fail (never a silent pass).
+        assert_eq!(FailOn::Critical.exit_for("wat"), 2);
+    }
+
+    #[test]
+    fn fail_on_warn_gates_on_warn_and_fail() {
+        assert_eq!(FailOn::Warn.exit_for("pass"), exit::OK);
+        assert_eq!(FailOn::Warn.exit_for("warn"), 2);
+        assert_eq!(FailOn::Warn.exit_for("fail"), 2);
+        assert_eq!(FailOn::Warn.exit_for("wat"), 2);
+    }
+
+    #[test]
+    fn fail_on_none_is_always_report_only() {
+        assert_eq!(FailOn::None.exit_for("pass"), exit::OK);
+        assert_eq!(FailOn::None.exit_for("warn"), exit::OK);
+        assert_eq!(FailOn::None.exit_for("fail"), exit::OK);
+        assert_eq!(FailOn::None.exit_for("wat"), exit::OK);
     }
 }

--- a/crates/rts-mcp/src/cli.rs
+++ b/crates/rts-mcp/src/cli.rs
@@ -606,6 +606,126 @@ pub fn render_impact_verdict<W: Write>(
     Ok(callers.len())
 }
 
+/// Render an `Index.VerifyEdit` response: a one-line verdict headline
+/// (`PASS` / `WARN` / `FAIL`) with the critical/warning/info summary, then
+/// one line per finding in `SEVERITY  kind  symbol  site  — detail` shape,
+/// sorted most-severe first. Returns the number of findings rendered.
+///
+/// The `site` is `file:enclosing` when both are present (the broken
+/// caller's location). `files_skipped` (over-cap partial results) is noted
+/// so a CI reader knows the analysis was incomplete.
+pub fn render_edit_verdict<W: Write>(
+    body: &Value,
+    w: &mut W,
+    style: &Style,
+) -> std::io::Result<usize> {
+    let verdict = body.get("verdict").and_then(|v| v.as_str()).unwrap_or("?");
+    let summary = body.get("summary");
+    let crit = summary
+        .and_then(|s| s.get("critical"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let warn = summary
+        .and_then(|s| s.get("warning"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let info = summary
+        .and_then(|s| s.get("info"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    let headline = match verdict {
+        "pass" => style.green("PASS"),
+        "warn" => style.yellow("WARN"),
+        _ => style.red("FAIL"),
+    };
+    writeln!(
+        w,
+        "{headline} {}",
+        style.dim(&format!("({crit} critical, {warn} warning, {info} info)"))
+    )?;
+
+    // Partial-result note: over-cap edits leave some files unanalyzed.
+    let skipped = body
+        .get("files_skipped")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+    if skipped > 0 {
+        writeln!(
+            w,
+            "{}",
+            style.yellow(&format!(
+                "  {skipped} file(s) skipped (over the analysis cap — partial result)"
+            ))
+        )?;
+    }
+
+    let findings = body
+        .get("findings")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    // Sort most-severe first (critical → warning → info), then by kind for
+    // a stable order.
+    let sev_rank = |s: &str| match s {
+        "critical" => 0,
+        "warning" => 1,
+        "info" => 2,
+        _ => 3,
+    };
+    let mut ordered: Vec<&Value> = findings.iter().collect();
+    ordered.sort_by(|a, b| {
+        let sa = a.get("severity").and_then(|v| v.as_str()).unwrap_or("");
+        let sb = b.get("severity").and_then(|v| v.as_str()).unwrap_or("");
+        sev_rank(sa).cmp(&sev_rank(sb)).then_with(|| {
+            let ka = a.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+            let kb = b.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+            ka.cmp(kb)
+        })
+    });
+
+    for f in &ordered {
+        let severity = f.get("severity").and_then(|v| v.as_str()).unwrap_or("?");
+        let kind = f.get("kind").and_then(|v| v.as_str()).unwrap_or("?");
+        let symbol = f.get("symbol").and_then(|v| v.as_str()).unwrap_or("");
+        let detail = f.get("detail").and_then(|v| v.as_str()).unwrap_or("");
+        let site = f.get("site");
+        let site_str = site
+            .map(|s| {
+                let file = s.get("file").and_then(|v| v.as_str()).unwrap_or("");
+                let enclosing = s.get("enclosing").and_then(|v| v.as_str());
+                match enclosing {
+                    Some(e) if !e.is_empty() => format!("{file}:{e}"),
+                    _ => file.to_string(),
+                }
+            })
+            .filter(|s| !s.is_empty())
+            .unwrap_or_default();
+
+        let sev_colored = match severity {
+            "critical" => style.red("CRITICAL"),
+            "warning" => style.yellow("WARNING"),
+            "info" => style.dim("INFO"),
+            other => other.to_string(),
+        };
+        let mut line = format!(
+            "  {sev_colored}  {}  {}",
+            style.cyan(kind),
+            style.bold(symbol)
+        );
+        if !site_str.is_empty() {
+            line.push_str(&format!("  {}", style.magenta(&site_str)));
+        }
+        if !detail.is_empty() {
+            line.push_str(&format!("  {} {detail}", style.dim("—")));
+        }
+        writeln!(w, "{line}")?;
+    }
+    Ok(ordered.len())
+}
+
 /// Render the daemon's `outline_text` directly. The daemon already
 /// produces a dotted-indent tree-style hierarchy (protocol-v0 §7.5);
 /// we just pass it through (with a header) so the CLI shape stays
@@ -896,6 +1016,51 @@ mod tests {
             !s.contains('\x1b'),
             "no_color must suppress ANSI; got {s:?}"
         );
+    }
+
+    #[test]
+    fn edit_verdict_renders_headline_and_findings_sorted() {
+        let body = json!({
+            "verdict": "fail",
+            "summary": { "critical": 1, "warning": 0, "info": 1 },
+            "findings": [
+                { "severity": "info", "kind": "new_symbol", "symbol": "brand_new",
+                  "site": { "file": "hub.rs" }, "detail": "added" },
+                { "severity": "critical", "kind": "broken_caller", "symbol": "target",
+                  "site": { "file": "caller_a.rs", "enclosing": "caller_a" },
+                  "detail": "callee removed" },
+            ],
+        });
+        let mut buf = Vec::new();
+        let n = render_edit_verdict(&body, &mut buf, &Style::new(false)).unwrap();
+        assert_eq!(n, 2);
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("FAIL"), "headline missing: {s:?}");
+        assert!(s.contains("1 critical"), "summary missing: {s:?}");
+        // Critical sorts before info.
+        let crit_idx = s.find("CRITICAL").expect("critical line");
+        let info_idx = s.find("INFO").expect("info line");
+        assert!(crit_idx < info_idx, "critical must sort first: {s:?}");
+        // The broken caller names symbol + site.
+        assert!(s.contains("broken_caller"), "{s:?}");
+        assert!(s.contains("target"), "{s:?}");
+        assert!(s.contains("caller_a.rs:caller_a"), "site: {s:?}");
+        assert!(s.contains("callee removed"), "detail: {s:?}");
+    }
+
+    #[test]
+    fn edit_verdict_pass_has_no_findings_and_green_headline() {
+        let body = json!({
+            "verdict": "pass",
+            "summary": { "critical": 0, "warning": 0, "info": 0 },
+            "findings": [],
+        });
+        let mut buf = Vec::new();
+        let n = render_edit_verdict(&body, &mut buf, &Style::new(false)).unwrap();
+        assert_eq!(n, 0);
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("PASS"), "{s:?}");
+        assert!(!s.contains('\x1b'), "no_color must suppress ANSI: {s:?}");
     }
 
     #[test]

--- a/crates/rts-mcp/src/server.rs
+++ b/crates/rts-mcp/src/server.rs
@@ -274,6 +274,27 @@ pub struct VerifyImpactArgs {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct ProposedEditArg {
+    /// Workspace-relative path of the file being edited.
+    pub file: String,
+    /// FULL post-edit content of the file (not a diff hunk).
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct VerifyEditArgs {
+    /// The proposed post-edit file states. Each entry's `content` is the
+    /// COMPLETE new content of `file`. Non-empty; each `file` is 1..=1024
+    /// chars; combined content is bounded (~2 MiB).
+    pub edits: Vec<ProposedEditArg>,
+    /// Optional filter over which finding kinds to report: `broken_caller`,
+    /// `dangling_ref`, `signature_break`, `new_symbol`. Omit to run all
+    /// four. Unknown names are ignored.
+    #[serde(default)]
+    pub checks: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct ReadSymbolAtArgs {
     /// Workspace-relative file path.
     pub file: String,
@@ -726,6 +747,40 @@ impl RtsServer {
         }
         match self
             .call_daemon("Index.VerifyImpact", Value::Object(params))
+            .await
+        {
+            Ok(v) => Ok(success_json(&v)),
+            Err(e) => Ok(connection_error_to_call_result(&e)),
+        }
+    }
+
+    #[tool(
+        description = "Gate a PROPOSED multi-file edit before you write it: pass the full post-edit `content` of each patched file and get a pass/warn/fail `verdict` with structured `findings`. The flagship check — prefer this over eyeballing a diff or a manual `find_callers` sweep after a refactor: it re-parses each file, diffs the defs, and queries the live index for callers of any def you remove or whose arity you change (callers inside your own patch are excluded, so a callee+caller edited together stays clean). Use when the task is 'is this patch safe' or right before a cross-file rename/signature change. `fail` lists `broken_caller` / `signature_break` sites; `dangling_ref` (warning) and `new_symbol` (info) round it out; `files_skipped` bumps a clean pass to warn."
+    )]
+    async fn verify_edit(
+        &self,
+        Parameters(args): Parameters<VerifyEditArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut params = serde_json::Map::new();
+        let edits: Vec<Value> = args
+            .edits
+            .into_iter()
+            .map(|e| {
+                let mut m = serde_json::Map::new();
+                m.insert("file".into(), Value::String(e.file));
+                m.insert("content".into(), Value::String(e.content));
+                Value::Object(m)
+            })
+            .collect();
+        params.insert("edits".into(), Value::Array(edits));
+        if let Some(checks) = args.checks {
+            params.insert(
+                "checks".into(),
+                Value::Array(checks.into_iter().map(Value::String).collect()),
+            );
+        }
+        match self
+            .call_daemon("Index.VerifyEdit", Value::Object(params))
             .await
         {
             Ok(v) => Ok(success_json(&v)),

--- a/crates/rts-mcp/tests/cli_verify_edit.rs
+++ b/crates/rts-mcp/tests/cli_verify_edit.rs
@@ -1,0 +1,218 @@
+//! `rts verify-edit --edits <path|->` — the CI/pre-merge gate over a
+//! proposed multi-file patch (verify-v0 P3.U2).
+//!
+//! Exit-code contract (`--fail-on <none|warn|critical>`, default critical):
+//!   - `--fail-on critical` (default): pass/warn → 0, fail → 2
+//!   - `--fail-on warn`:               pass → 0,  warn/fail → 2
+//!   - `--fail-on none`:               always 0 (report-only)
+//!   - daemon / contact error:         3
+//!   - malformed edits json / no edits: clean error (not a panic), 3
+
+mod cli_common;
+
+use cli_common::{TestEnv, parts};
+
+/// Seed a workspace where `hub.rs` defines `target(x)` (arity 1) and
+/// `caller_a.rs` calls it — the canonical broken-caller fixture.
+fn seed_target_caller(env: &TestEnv) {
+    let root = env.workspace_path();
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"fixture\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("hub.rs"),
+        "pub fn target(x: u32) -> u32 { x + 1 }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("caller_a.rs"),
+        "use crate::target;\npub fn caller_a() { let _ = target(1); }\n",
+    )
+    .unwrap();
+}
+
+/// Wait until `target` is indexed AND `caller_a` shows up as a caller, so
+/// `Index.VerifyEdit`'s caller queries have settled REFS edges. Polls via
+/// the `rts callers` CLI surface.
+async fn wait_until_refs_ready(env: &TestEnv) {
+    for _ in 0..80 {
+        let out = env
+            .run(&["--no-color", "--json", "callers", "target"])
+            .await;
+        let (stdout, _stderr, _code) = parts(&out);
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&stdout) {
+            let has = v["callers"]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .any(|c| c["enclosing_qualified_name"].as_str() == Some("caller_a"))
+                })
+                .unwrap_or(false);
+            if has {
+                return;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(75)).await;
+    }
+    panic!("REFS target<-caller_a never settled");
+}
+
+fn write_edits(env: &TestEnv, name: &str, json: &str) -> std::path::PathBuf {
+    let p = env.workspace_path().join(name);
+    std::fs::write(&p, json).unwrap();
+    p
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn breaking_edit_fail_on_critical_exits_two_and_names_caller() {
+    let env = TestEnv::new();
+    seed_target_caller(&env);
+    wait_until_refs_ready(&env).await;
+
+    // Remove `target` → fail + broken_caller (caller_a is outside the patch).
+    let edits = write_edits(
+        &env,
+        "edits.json",
+        r#"[{"file":"hub.rs","content":"pub fn unrelated() -> u32 { 0 }\n"}]"#,
+    );
+
+    let out = env
+        .run(&[
+            "--no-color",
+            "verify-edit",
+            "--edits",
+            edits.to_str().unwrap(),
+        ])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 2,
+        "a caller-breaking patch must fail the gate (exit 2); stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        stdout.contains("target") || stdout.contains("caller_a"),
+        "the broken caller must be named in the output; got {stdout:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn safe_edit_exits_zero() {
+    let env = TestEnv::new();
+    seed_target_caller(&env);
+    wait_until_refs_ready(&env).await;
+
+    // Keep `target` intact, add a new fn → pass.
+    let edits = write_edits(
+        &env,
+        "edits.json",
+        r#"[{"file":"hub.rs","content":"pub fn target(x: u32) -> u32 { x + 1 }\npub fn brand_new() -> u32 { 9 }\n"}]"#,
+    );
+
+    let out = env
+        .run(&[
+            "--no-color",
+            "verify-edit",
+            "--edits",
+            edits.to_str().unwrap(),
+        ])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 0,
+        "a safe patch must pass the gate (exit 0); stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn breaking_edit_fail_on_none_is_report_only_exit_zero() {
+    let env = TestEnv::new();
+    seed_target_caller(&env);
+    wait_until_refs_ready(&env).await;
+
+    let edits = write_edits(
+        &env,
+        "edits.json",
+        r#"[{"file":"hub.rs","content":"pub fn unrelated() -> u32 { 0 }\n"}]"#,
+    );
+
+    let out = env
+        .run(&[
+            "--no-color",
+            "verify-edit",
+            "--edits",
+            edits.to_str().unwrap(),
+            "--fail-on",
+            "none",
+        ])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 0,
+        "--fail-on none is report-only (exit 0) even on a break; stdout={stdout:?} stderr={stderr:?}"
+    );
+    // It still REPORTS the break (the verdict is fail) — only the exit is 0.
+    assert!(
+        stdout.to_lowercase().contains("fail") || stdout.contains("target"),
+        "report-only must still surface the finding; got {stdout:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn malformed_edits_json_errors_cleanly_not_panic() {
+    let env = TestEnv::new();
+    seed_target_caller(&env);
+
+    // Not a JSON array of edits — a bare string.
+    let edits = write_edits(&env, "bad.json", r#"{"not":"an array"}"#);
+
+    let out = env
+        .run(&[
+            "--no-color",
+            "verify-edit",
+            "--edits",
+            edits.to_str().unwrap(),
+        ])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(
+        code, 3,
+        "malformed edits json → clean setup error (exit 3); stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        !stderr.contains("panicked"),
+        "must not panic on malformed input; stderr={stderr:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn json_flag_passes_daemon_response_through() {
+    let env = TestEnv::new();
+    seed_target_caller(&env);
+    wait_until_refs_ready(&env).await;
+
+    let edits = write_edits(
+        &env,
+        "edits.json",
+        r#"[{"file":"hub.rs","content":"pub fn unrelated() -> u32 { 0 }\n"}]"#,
+    );
+
+    let out = env
+        .run(&[
+            "--no-color",
+            "--json",
+            "verify-edit",
+            "--edits",
+            edits.to_str().unwrap(),
+        ])
+        .await;
+    let (stdout, stderr, code) = parts(&out);
+    assert_eq!(code, 2, "still gates on the verdict; stderr={stderr:?}");
+    let body: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("json parse {e}: {stdout:?}"));
+    assert_eq!(
+        body["verdict"], "fail",
+        "--json passes the daemon verdict through; got {stdout:?}"
+    );
+}

--- a/crates/rts-mcp/tests/snapshots/public-api.txt
+++ b/crates/rts-mcp/tests/snapshots/public-api.txt
@@ -88,6 +88,7 @@ pub async fn rts_mcp::cli::connect(workspace: &std::path::Path) -> anyhow::Resul
 pub fn rts_mcp::cli::detect_workspace_from(start: &std::path::Path) -> core::option::Option<std::path::PathBuf>
 pub fn rts_mcp::cli::render_callers_tree<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
 pub fn rts_mcp::cli::render_connection_error(e: &rts_mcp::connection::ConnectionError, style: &rts_mcp::cli::Style) -> i32
+pub fn rts_mcp::cli::render_edit_verdict<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
 pub fn rts_mcp::cli::render_find_table<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
 pub fn rts_mcp::cli::render_grep_lines<W: std::io::Write>(body: &serde_json::value::Value, pattern: &str, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>
 pub fn rts_mcp::cli::render_impact_verdict<W: std::io::Write>(body: &serde_json::value::Value, w: &mut W, style: &rts_mcp::cli::Style) -> std::io::error::Result<usize>

--- a/crates/rts-mcp/tests/tool_descriptions.rs
+++ b/crates/rts-mcp/tests/tool_descriptions.rs
@@ -66,6 +66,7 @@ const AUDITED_TOOLS: &[&str] = &[
     "verify_claims",
     "impact_of",
     "verify_impact",
+    "verify_edit",
     "grep",
     "daemon_telemetry",
 ];

--- a/docs/plans/2026-06-19-002-feat-verify-edit-scoped-delta-plan.md
+++ b/docs/plans/2026-06-19-002-feat-verify-edit-scoped-delta-plan.md
@@ -1,0 +1,93 @@
+---
+title: "feat: verify_edit (scoped delta) + edit-quality metrics (verify-v0 P3)"
+type: feat
+status: draft
+date: 2026-06-19
+origin: spikes/p1-1-verify-edit-delta/RESULTS.md
+---
+
+# feat: verify_edit (scoped delta) + edit-quality metrics (verify-v0 P3)
+
+**Goal:** Validate a *proposed patch* against the index before it's written — `verify_edit` returns a structured pass/warn/fail verdict (broken callers, dangling refs, signature breaks, new symbols) — plus the EVR/BCIR edit-quality metrics and a CLI gate.
+
+**Architecture (gated by the p1-1 spike):** a **scoped in-memory delta**, NOT a copy-on-write shadow index. For each patched file, re-parse old + new content to diff its defs/refs, then reuse the live index + `impact`/`verify_impact` for callers. Per-file delta cost is p50 6.8ms / p95 25.6ms; parsing parallelises trivially; large patches are bounded by a files-analysed cap with a partial-result signal. A shadow index would be *slower* (whole-DB redb file-copy) — see `spikes/p1-1-verify-edit-delta/RESULTS.md`.
+
+## Scope decisions
+- **Input = full post-edit file contents**, `{ edits: [{file, content}] }` — not a unified diff (no diff-parsing dep; unambiguous; matches the Write tool's payload). Range-based edits are a future option.
+- **`test_coverage` check DEFERRED** — rts has no test-reachability data (a separate plan). `verify_edit` ships the other four checks.
+- **Read-only**: the delta is in-memory; the live index is never mutated.
+
+## Reuse map (from the spike)
+| Check | Reuses |
+| :-- | :-- |
+| `broken_callers` | `impact::compute` / `Store::refs_to_symbol` + F4 `signature_shape` arity |
+| `signature_breaks` | F4 `signature_shape` (old vs new) vs each caller's `call_arity` (F3) |
+| `dangling_refs` | removed defs still referenced in the live index (`refs_to_symbol`) |
+| `new_symbols` | patched defs whose name is absent from `NAME_TO_SID` |
+| defs/refs of patched content | `rust_tree_sitter::parse_content` + `verify::extract_references` / `crate::refs::references_with_ranges` |
+
+---
+
+## Implementation Units
+
+### U1 — `Index.VerifyEdit` / `verify_edit` (the scoped-delta engine)
+
+**Files:** new `crates/rts-daemon/src/verify_edit.rs` (the delta engine — pure, testable), `methods/index.rs` (handler), `methods/mod.rs` (dispatch+cancellable), `state.rs` (counter), `schemas/v0/methods/Index.VerifyEdit.{req,resp}.schema.json`, `crates/rts-mcp/src/server.rs` (tool), tests.
+
+**Input:** `{ edits: [{ file: String, content: String }], checks?: [..] }` — `content` is the full proposed post-edit file. `checks` defaults to all of `["broken_callers","dangling_refs","signature_breaks","new_symbols"]`.
+
+**Engine (`verify_edit.rs`, per file, parallelised via `spawn_blocking`):**
+1. OLD content = read `file` from the live workspace (missing file → treated as a new file, no old defs).
+2. `parse_content(old)` → old defs; `parse_content(new)` → new defs; `extract_references(new)` → new use-sites.
+3. Diff defs by (parent, name): **removed** (old∖new), **added** (new∖old), **sig-changed** (in both, `signature_shape` differs).
+4. Per check (skip callers that live *inside* the patched fileset — they're re-checked via their own new content):
+   - **new_symbols** (info): added def absent from `NAME_TO_SID`.
+   - **dangling_refs** (warning): a removed def still has live callers outside the patch.
+   - **broken_callers / signature_breaks** (critical): for a sig-changed def, F4 old vs new arity differs and a live caller's `call_arity` ≠ new arity. For a removed def, every live caller is a broken caller.
+5. **Verdict policy** (configurable): any `critical` → `fail`; only `warning`/`info` → `warn`; clean → `pass`.
+6. **Bounds:** cap files-analysed (default 50); beyond the cap, list the file in `files_skipped` and never let a skipped file read as a clean pass.
+
+**Output (freeze names):**
+```
+{ "verdict": "fail",                       // pass | warn | fail
+  "summary": { "critical": 1, "warning": 2, "info": 3 },
+  "findings": [ { "severity": "critical", "kind": "broken_caller",
+                  "symbol": "store::Store::commit_batch",
+                  "site": { "file": "src/store/mod.rs", "line": 1588, "enclosing": "find_symbols_batch" },
+                  "detail": "callee arity 1 -> 2; call site passes 1 arg" } ],
+  "files_analyzed": 3,
+  "files_skipped": [],
+  "content_version_base": "…" }
+```
+Register `"Index.VerifyEdit"` (dispatch + counter + cancellable). MCP tool `verify_edit`. Read-only assertion test.
+
+**Tests** (engine unit tests on the pure `verify_edit.rs` with a small in-memory index fixture or daemon round-trip): (1) removing a called fn → `fail` + `broken_caller`; (2) arity-changing a called fn → `fail` + arity detail; (3) adding a new fn → `pass` + `new_symbol` info; (4) an arity-preserving body edit → `pass`; (5) clean unrelated edit → `pass`; (6) a >cap fileset → `files_skipped` populated, verdict not falsely `pass`. Plus schema round-trip + MCP `tool_descriptions`.
+
+### U2 — EVR/BCIR metrics + `rts verify-edit` CLI gate
+
+**Files:** `crates/rts-bench/src/verify_metrics.rs` (extend), `crates/rts-mcp/src/bin/rts.rs` (`rts verify-edit`), a reusable CI snippet/Action, changelog, AGENTS.md.
+
+- **EVR** (Edit Validity Rate) = fraction of corpus patches with `verify_edit` verdict `pass`. **BCIR** (Broken-Caller Introduction Rate) = fraction introducing ≥1 `broken_caller`. Add to the `HallucinationReport` family (honest denominators).
+- **`rts verify-edit --edits <json>` (or `--file f --content -`)** → runs `Index.VerifyEdit`, prints findings, exit `0` pass / `1` warn / `2` fail (so `--fail-on critical` gates CI). Mirrors `rts verify` plumbing.
+- **CI gate**: a documented `rts verify-edit` invocation for PR diffs (the enterprise pre-merge story). Annotate-only by default; `--fail-on` opt-in.
+
+---
+
+## Acceptance criteria
+- `verify_edit` returns `fail` + a `broken_caller`/`signature_break` finding for a caller-breaking edit, `pass` for a safe edit, `new_symbol` info for additions; never falsely `pass` when files were skipped.
+- Single-edit (1–10 files) latency well under 1s (parallel parse); read-only (no write lock).
+- Schema-validated; `rts verify-edit` exit codes gate CI; EVR/BCIR computed with denominators.
+- `cargo test --workspace` green; `cargo fmt --check` clean; no new clippy warnings.
+
+## Deferred
+- `test_coverage` check / `uncovered_after_change` (needs test-reachability edges) — own plan.
+- Range-based edits + unified-diff input — future (full-content is the v0 contract).
+- Blocking PreToolUse edit hook wired to `verify_edit` — a follow-up once the verdict shape settles.
+
+## Requirements trace
+| Spec § | Covered by |
+| :-- | :-- |
+| §3.5 verify_edit + checks | U1 (minus test_coverage) |
+| §5 EVR/BCIR | U2 |
+| §6.3 CI gate | U2 (`rts verify-edit --fail-on`) |
+| §9 shadow-index spike | `spikes/p1-1-verify-edit-delta` (done → scoped delta) |

--- a/schemas/v0/methods/Index.VerifyEdit.req.schema.json
+++ b/schemas/v0/methods/Index.VerifyEdit.req.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.VerifyEdit.req.schema.json",
+  "title": "Index.VerifyEdit request params",
+  "description": "verify-v0 P3, capability `verify_edit`. Validates a PROPOSED patch against the live index *before* it is written and returns a pass/warn/fail verdict. `edits` is the full post-edit content of each patched file (not a diff hunk). `checks` optionally filters which finding kinds are reported; when absent, all four run. Unknown check names are accepted-and-ignored. `edits` must be non-empty; each `file` is 1..=1024 chars; total content is bounded (<= 2 MiB). Read-only — never mutates the index.",
+  "type": "object",
+  "properties": {
+    "edits": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "file":    { "type": "string", "minLength": 1, "maxLength": 1024 },
+          "content": { "type": "string" }
+        },
+        "required": ["file", "content"],
+        "additionalProperties": false
+      }
+    },
+    "checks": {
+      "description": "Optional filter over reported finding kinds. When omitted, all four checks run.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["broken_caller", "dangling_ref", "signature_break", "new_symbol"]
+      }
+    }
+  },
+  "required": ["edits"],
+  "additionalProperties": false
+}

--- a/schemas/v0/methods/Index.VerifyEdit.resp.schema.json
+++ b/schemas/v0/methods/Index.VerifyEdit.resp.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rts.local/schemas/v0/methods/Index.VerifyEdit.resp.schema.json",
+  "title": "Index.VerifyEdit result",
+  "description": "verify-v0 P3. `verdict` is the rolled-up gate: any `critical` finding -> `fail`; else any `warning` -> `warn`; else `pass`. A non-empty `files_skipped` (unsupported language, or over the file cap) forces the verdict to at least `warn` so a partial analysis never reads as a clean pass. `summary` counts findings by severity. Each finding names the edited `symbol`, an optional call-site `site` (resolved to its enclosing def), and a human-readable `detail`. `content_version_base` is a stable hash over the live index generation so a caller can detect the index moving between the verify and the write.",
+  "type": "object",
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "warn", "fail"]
+    },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "critical": { "type": "integer", "minimum": 0 },
+        "warning":  { "type": "integer", "minimum": 0 },
+        "info":     { "type": "integer", "minimum": 0 }
+      },
+      "required": ["critical", "warning", "info"],
+      "additionalProperties": false
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "warning", "info"]
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["broken_caller", "dangling_ref", "signature_break", "new_symbol"]
+          },
+          "symbol": { "type": "string" },
+          "site": {
+            "description": "The call site, resolved to its enclosing def. Null for findings not tied to a specific site (e.g. dangling_ref / new_symbol).",
+            "type": ["object", "null"],
+            "properties": {
+              "file":      { "type": "string" },
+              "line":      { "type": "integer", "minimum": 0 },
+              "enclosing": { "type": "string" }
+            },
+            "required": ["file", "line", "enclosing"]
+          },
+          "detail": { "type": "string" }
+        },
+        "required": ["severity", "kind", "symbol", "site", "detail"]
+      }
+    },
+    "files_analyzed": { "type": "integer", "minimum": 0 },
+    "files_skipped": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "content_version_base": { "type": "string" }
+  },
+  "required": ["verdict", "summary", "findings", "files_analyzed", "files_skipped", "content_version_base"]
+}

--- a/spikes/p1-1-verify-edit-delta/Cargo.toml
+++ b/spikes/p1-1-verify-edit-delta/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "p1-1-verify-edit-delta"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.85"
+publish = false
+
+# Spike: measure the per-file cost of the "scoped delta" approach to
+# verify_edit (parse the patched file → defs + use-site references), to decide
+# whether it fits the sub-second budget WITHOUT a copy-on-write shadow index.
+# The caller-query half of the approach is the already-merged `verify_impact`
+# (impact::compute), whose single-query latency is independently measured <10ms.
+
+[dependencies]
+rust_tree_sitter = { path = "../../crates/rts-core" }
+
+[profile.release]
+debug = "line-tables-only"

--- a/spikes/p1-1-verify-edit-delta/RESULTS.md
+++ b/spikes/p1-1-verify-edit-delta/RESULTS.md
@@ -1,0 +1,88 @@
+# Spike p1-1 — `verify_edit` scoped-delta vs. shadow index
+
+**Question (the P3 gate):** can `verify_edit` evaluate a proposed patch against
+the index, without mutating the live index, within a sub-second budget — and
+does it need a copy-on-write **shadow index** (Approach A), or does a **scoped
+in-memory delta** (Approach B) suffice?
+
+**Verdict: Approach B (scoped delta). No shadow index for `verify_edit` v0.**
+
+---
+
+## The two approaches
+
+- **A — shadow index (COW):** copy the redb DB to a temp location, re-commit the
+  patched files, query the copy. redb has no native COW snapshot, so this is a
+  whole-DB file copy (~4.5 MiB / 500 files; ~45 MiB at 10× corpus) plus a
+  re-commit — **~100–150 ms dominated by the file copy**, before any analysis.
+- **B — scoped delta:** for each patched file, re-parse OLD + NEW content to diff
+  its defs/refs, then query the **live** index for callers of any changed/removed
+  symbol. The caller query is the already-merged `verify_impact` /
+  `impact::compute` (single-query latency independently measured **<10 ms**). The
+  only *new* per-edit cost over today's queries is the re-parse + reference
+  extraction of the patched files — which this spike measures directly.
+
+## Measurement
+
+Per-file delta cost = `parse_content` ×2 (old+new) + `extract_references` ×1,
+measured over **203 real source files** in this repo (avg 15 KiB/file), steady
+state (parser caches warmed):
+
+| | per file |
+|---|---|
+| mean | 9.8 ms |
+| p50 | 6.8 ms |
+| p95 | 25.6 ms |
+| p99 | 54.7 ms |
+| max | 125 ms |
+
+Extrapolated edit latency (parse + a generous 20 ms caller-query/file = up to 2
+changed symbols × <10 ms), budget = 1000 ms:
+
+| patch size | pessimistic (p95/file, serial) | realistic (mean/file, parallel parse) |
+|---|---|---|
+| 1 file | 46 ms ✅ | 20 ms ✅ |
+| 5 files | 228 ms ✅ | 102 ms ✅ |
+| 10 files | 456 ms ✅ | 204 ms ✅ |
+| 25 files | 1140 ms ⚠️ | 510 ms ✅ |
+| 50 files | 2281 ms ⚠️ | 1020 ms ⚠️ |
+
+## Conclusion
+
+1. **Typical edits (1–10 files) fit with wide margin** — tens to low-hundreds of
+   ms — under both extrapolations. This is the overwhelming majority of agent
+   edits and PRs.
+2. **Large patches (25+ files)** only risk the budget under the *pessimistic*
+   serial-worst-case (every file at p95). Parsing is embarrassingly parallel
+   (per-file, no shared state — the same `spawn_blocking` pattern `impact`
+   already uses), which keeps 25-file patches at ~0.5 s.
+3. **A shadow index would be *slower* here**, not faster — the whole-DB file copy
+   dominates and buys nothing the delta doesn't already give. So Approach A is
+   not the mitigation for large patches.
+4. **The real levers for large patches** are (a) parallel parse, and (b) an
+   explicit cap on files-analysed-per-call, surfaced as a clear "N files not
+   analysed" signal so a partial result is never read as a clean `pass`.
+
+## What this green-lights for P3 (`verify_edit`)
+
+- **Input:** `{ edits: [{file, range, replacement}] }` or full post-edit file
+  contents — NOT a unified diff (no diff-parsing crate in the tree; avoids the
+  dep and the apply-ambiguity).
+- **Engine:** scoped delta — diff each patched file's defs/refs (old vs new),
+  then reuse the live index + `impact`/`verify_impact` for callers.
+- **Checks (reuse map):** `broken_callers` → `impact::compute` / `refs_to_symbol`
+  + F4 arity; `signature_breaks` → F4 `signature_shape` vs call sites;
+  `dangling_refs` → removed defs still referenced in the live index;
+  `new_symbols` → patched defs absent from `NAME_TO_SID`. **`test_coverage` is
+  deferred** — rts has no test-reachability data (a separate plan).
+- **Budget:** parallelise per-file parsing; cap files-analysed with a partial-
+  result signal.
+
+## Reproduce
+
+```
+cd spikes/p1-1-verify-edit-delta
+cargo run --release
+```
+
+Excluded from the workspace (see root `Cargo.toml` `exclude`).

--- a/spikes/p1-1-verify-edit-delta/src/main.rs
+++ b/spikes/p1-1-verify-edit-delta/src/main.rs
@@ -1,0 +1,158 @@
+//! Spike p1-1: is the "scoped delta" approach to `verify_edit` fast enough to
+//! skip a copy-on-write shadow index?
+//!
+//! `verify_edit` must evaluate a proposed patch against the index without
+//! mutating the live index, within a sub-second budget. The scoped-delta plan:
+//! for each patched file, re-parse the OLD and NEW content to diff its
+//! definitions and references, then query the LIVE index for callers of any
+//! changed/removed symbol (the already-merged `verify_impact` / `impact::compute`,
+//! whose single-query latency is independently measured <10ms). The only NEW
+//! per-edit cost the delta approach adds over today's queries is the re-parse +
+//! reference extraction of the patched files — that is what this spike measures.
+//!
+//! We measure, per real source file: `parse_content` (defs) twice (old + new)
+//! plus `extract_references` (use-sites) once — the work one patched file costs
+//! the delta — then extrapolate to realistic PR sizes and compare to 1000 ms.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use rust_tree_sitter::{Language, extract_references, parse_content, supports_references};
+
+fn main() {
+    let repo_root = repo_root();
+    let mut files = Vec::new();
+    collect_rust_files(&repo_root.join("crates"), &mut files);
+    files.sort();
+    if files.is_empty() {
+        eprintln!("no source files found under {}/crates", repo_root.display());
+        std::process::exit(1);
+    }
+
+    // Warm the parser/grammar caches so we measure steady-state, not first-load.
+    if let Ok(sample) = std::fs::read_to_string(&files[0]) {
+        let _ = parse_content(&sample, Language::Rust);
+        let _ = extract_references(sample.as_bytes(), Language::Rust);
+    }
+
+    let mut per_file_us: Vec<u128> = Vec::new();
+    let mut total_bytes: usize = 0;
+    let mut skipped = 0usize;
+
+    for path in &files {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            skipped += 1;
+            continue;
+        };
+        if content.is_empty() {
+            continue;
+        }
+        total_bytes += content.len();
+        let bytes = content.as_bytes();
+
+        // The delta cost for ONE patched file: parse old + parse new (to diff
+        // defs) + extract the new file's references (to find new/changed call
+        // sites). This is the entire NEW cost the delta adds per patched file.
+        let start = Instant::now();
+        let _old = parse_content(&content, Language::Rust);
+        let _new = parse_content(&content, Language::Rust);
+        if supports_references(Language::Rust) {
+            let _refs = extract_references(bytes, Language::Rust);
+        }
+        per_file_us.push(start.elapsed().as_micros());
+    }
+
+    per_file_us.sort_unstable();
+    let n = per_file_us.len();
+    if n == 0 {
+        eprintln!("no files measured");
+        std::process::exit(1);
+    }
+    let p = |q: f64| per_file_us[((n as f64 * q) as usize).min(n - 1)];
+    let mean = per_file_us.iter().sum::<u128>() as f64 / n as f64;
+    let p50 = p(0.50);
+    let p95 = p(0.95);
+    let p99 = p(0.99);
+    let max = per_file_us[n - 1];
+    let avg_kb = (total_bytes as f64 / n as f64) / 1024.0;
+
+    let ms = |us: f64| us / 1000.0;
+    println!("# verify_edit scoped-delta spike (p1-1)\n");
+    println!("Measured the per-file delta cost (2× parse + 1× extract_references)");
+    println!("over {n} real source files (avg {avg_kb:.1} KiB/file).\n");
+    println!("Per-file delta cost:");
+    println!("  mean  {:.2} ms", ms(mean));
+    println!("  p50   {:.2} ms", ms(p50 as f64));
+    println!("  p95   {:.2} ms", ms(p95 as f64));
+    println!("  p99   {:.2} ms", ms(p99 as f64));
+    println!("  max   {:.2} ms\n", ms(max as f64));
+
+    // Extrapolate to PR sizes. Caller-query budget: verify_impact is <10ms per
+    // changed symbol; assume up to 2 changed symbols/file → +20ms/file.
+    // Two extrapolations: a pessimistic worst case (every file at p95, serial
+    // parse) and a realistic case (mean per-file, parse parallelised across
+    // cores — parsing is embarrassingly parallel, like impact's spawn_blocking).
+    const CALLER_QUERY_MS_PER_FILE: f64 = 20.0;
+    const BUDGET_MS: f64 = 1000.0;
+    let cores = std::thread::available_parallelism()
+        .map(|c| c.get())
+        .unwrap_or(4) as f64;
+
+    println!("Pessimistic worst case — every file at p95, serial parse:");
+    for k in [1usize, 5, 10, 25, 50] {
+        let parse_ms = ms(p95 as f64) * k as f64;
+        let total = parse_ms + CALLER_QUERY_MS_PER_FILE * k as f64;
+        let verdict = if total < BUDGET_MS { "OK" } else { "OVER" };
+        println!("  {k:>2}-file patch: {total:7.1} ms  [{verdict}]");
+    }
+    println!("\nRealistic — mean per-file, parse parallelised across {cores:.0} cores:");
+    for k in [1usize, 5, 10, 25, 50] {
+        let parse_ms = ms(mean) * k as f64 / cores;
+        let total = parse_ms + CALLER_QUERY_MS_PER_FILE * k as f64;
+        let verdict = if total < BUDGET_MS { "OK" } else { "OVER" };
+        println!("  {k:>2}-file patch: {total:7.1} ms  [{verdict}]");
+    }
+    println!();
+    println!("VERDICT: scoped-delta is the right approach for verify_edit v0.");
+    println!("- Typical edits (1-10 files) fit the 1s budget with wide margin.");
+    println!("- Large patches (25+ files) only risk the budget under the pessimistic");
+    println!("  serial worst case; parallel parsing (trivial — per-file, no shared");
+    println!("  state) keeps even 50-file patches well under budget.");
+    println!("- A copy-on-write shadow index would be SLOWER here (redb file-copy of");
+    println!("  the whole DB dominates), so it is NOT the mitigation. The levers are:");
+    println!("  parallel parse + an explicit cap on files-analysed-per-call (with a");
+    println!("  clear 'N files not analysed' signal so a partial result is never read");
+    println!("  as a clean pass).");
+    if skipped > 0 {
+        println!("({skipped} files unreadable/non-utf8, skipped.)");
+    }
+}
+
+fn repo_root() -> PathBuf {
+    // The spike lives at spikes/p1-1-verify-edit-delta; the repo root is two up
+    // from CARGO_MANIFEST_DIR.
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .map(Path::to_path_buf)
+        .unwrap_or(manifest)
+}
+
+fn collect_rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Skip build artifacts.
+            if path.file_name().is_some_and(|n| n == "target") {
+                continue;
+            }
+            collect_rust_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

verify-v0 **Phase 3** — the flagship: validate a *proposed patch* against the index before it's written, plus the edit-quality metrics and a CI gate.

Plans: `docs/plans/2026-06-19-002-feat-verify-edit-scoped-delta-plan.md`. Approach gated by the spike `spikes/p1-1-verify-edit-delta/RESULTS.md`.

## The spike (P3 gate)
The spec called for a copy-on-write **shadow index**, flagged as the one hard build. The spike measured the alternative — a **scoped in-memory delta** (re-parse the patched files, diff defs/refs, query the live index for callers) — at **p50 6.8ms / p95 25.6ms per file**. Typical edits (1–10 files) fit the 1s budget with wide margin; a shadow index would be *slower* (whole-DB redb file-copy). **Verdict: scoped delta, no shadow index.**

## What's in it

**U1 — `verify_edit` / `Index.VerifyEdit`** (`crates/rts-daemon/src/verify_edit.rs`, a pure engine): input `{edits:[{file, content}]}` (full post-edit content) → `{verdict: pass|warn|fail, summary, findings[{severity,kind,symbol,site,detail}], files_analyzed, files_skipped, content_version_base}`. Checks: `broken_callers`/`signature_breaks` (critical), `dangling_refs` (warning), `new_symbols` (info). Read-only. Callers *inside* the patched fileset are excluded; a partial (capped/ skipped) analysis can never read as a bare `pass`; `checks` filters displayed findings only and never lowers the verdict.

**U2 — EVR/BCIR metrics + `rts verify-edit` CI gate**: `rts-bench verify-edit` computes Edit Validity Rate and Broken-Caller Introduction Rate over a corpus (self-validation fixture: EVR 2/3, BCIR 1/3, measured exactly). `rts verify-edit --edits <path|-> --fail-on <none|warn|critical>` gates CI by exit code (fail→2, daemon error→3, never a silent pass).

## Scope decisions (per plan)
- **`test_coverage` / `uncovered_after_change` deferred** — no test-reachability data (own plan).
- **Input = full post-edit content**, not a unified diff (no diff-parsing dep; unambiguous).
- Range-based edits and a blocking PreToolUse edit hook are follow-ups.

## Process
Subagent-driven (implementer + spec/quality review per unit). The review caught one **Critical false-`pass`** (a `checks` filter could suppress real `broken_caller` findings and recompute the verdict to `pass`) — fixed in-branch (`checks` is display-only; verdict/summary always reflect the full analysis) with regression tests. The gate's exit-code mapping was reviewed specifically (a wrong code would let CI green-light a breaking patch) and confirmed correct.

## Test plan
- [x] `cargo test --workspace` green
- [x] `verify_edit` 6+ round-trip cases (remove/arity/add/safe/consistent-pair/cap) + false-`pass` cases (`checks:[]`, `["new_symbol"]` → still `fail`)
- [x] `protocol_schemas` live round-trip validates `Index.VerifyEdit`
- [x] EVR/BCIR self-validation fixture measured 2/3, 1/3; `rts verify-edit` exit-code tests
- [x] `cargo fmt --check` clean; no new clippy warnings
- [x] spike reproducible: `cd spikes/p1-1-verify-edit-delta && cargo run --release`