### PR TITLE
feat: A/B/C verification benchmark harness — build-only (verify-v0 P4)

### DIFF
--- a/agent-bench/README.md
+++ b/agent-bench/README.md
@@ -13,15 +13,25 @@ HTTP-free. CI asserts that invariant via `cargo tree`.
 
 ## What it does
 
-For each task in a SWE-bench-lite subset, run the task **twice**
-through the Anthropic API:
+For each task in a SWE-bench-lite subset, run the task through the
+Anthropic API once per **arm**. The bench is **A/B/C**: three arms with
+progressively wider rts tool surfaces, so we can separate the effect of
+*retrieval* tools from the effect of the *verify_\** tools.
 
-| Arm | Tools available |
-|---|---|
-| **Control** | `Bash`, `Read` |
-| **Treatment** | `Bash`, `Read`, **plus all `mcp__rts__*` tools + the PreToolUse hook active** |
+| Arm | Profile | Tools available |
+|---|---|---|
+| **A** (baseline) | `baseline` | `Bash`, `Read` |
+| **B** (retrieval) | `retrieval` | `Bash`, `Read`, **+ rts RETRIEVAL tools** (`find_symbol`, `grep`, `read_symbol`, `read_symbol_at`, `read_range`, `outline_workspace`, `find_callers`, `impact_of`) |
+| **C** (retrieval + verify) | `retrieval_verify` | Arm B's tools **+ the `verify_*` tools** (`verify_symbol`, `verify_signature`, `verify_import`, `verify_claims`, `verify_impact`, `verify_edit`) **+ a one-line verify nudge appended to the system prompt** |
 
-Both arms run against the same:
+The tool surface is an explicit allowlist per arm (`RETRIEVAL_TOOLS` /
+`VERIFY_TOOLS` in `agent_bench/run.py`): a tool the bridge advertises
+but the arm's profile does not allow is excluded, so a future rts tool
+can never silently leak into an arm. Arm C is the only arm whose system
+prompt differs — it appends `VERIFY_NUDGE` ("Before asserting a symbol
+exists or changing a signature, verify it with the verify_\* tools.").
+
+All arms run against the same:
 
 - Pinned model snapshot ID (never `claude-sonnet-latest`)
 - Identical system prompt (SHA-locked across arms)
@@ -45,11 +55,34 @@ and best-practices research, at **n = 30 tasks per arm** the
 secondary descriptive. ~25-point delta needed for p<0.05 — results
 are reported as **directional**, not significant.
 
+### Statistics (A/B/C)
+
+The reporter (`agent_bench/report.py`) renders a `multi_arm_comparison`
+with per-arm success ± Wilson CI, tokens, wall-clock, a per-tool
+breakdown (`tool_calls_by_name`), the per-arm verify-metric block, and
+**McNemar paired deltas** for the three contrasts **B vs A**, **C vs B**,
+**C vs A**. McNemar is implemented by hand (no scipy): the exact
+binomial two-sided test for fewer than 25 discordant pairs, else the
+continuity-corrected χ²(df=1) via `math.erfc`.
+
+Per-arm edit-quality / hallucination metrics (EVR, BCIR, SHR, IHR; SMR
+is approximated as `None` because the file-level `rts verify --json`
+surface lacks call-arity data) are computed **offline** by
+`agent_bench/eval_verify.py`, feeding each arm's patches through the
+`rts verify-edit` / `rts verify` CLI via the `RtsVerifyRunner` boundary.
+
 ## Usage
 
 ```bash
 # One-time: install deps via uv
 cd agent-bench && uv sync --dev
+
+# Project token + USD spend for a run BEFORE spending anything (no API
+# call). Defaults: Sonnet pricing ($3 in / $15 out per MTok), 3 arms.
+uv run agent-bench estimate --tasks 30 --seeds 1 --arms 3 \
+    --model claude-sonnet-4-7-20260315
+# Opus pricing:
+uv run agent-bench estimate --tasks 30 --arms 3 --in-price 15 --out-price 75
 
 # Run a dry-run against a 3-task smoke subset (no API key needed
 # if --mock is passed; otherwise uses ANTHROPIC_API_KEY)
@@ -84,6 +117,13 @@ releases is part of the git history. Raw trajectories (per-task
 turn-by-turn JSONL) are NOT committed (volume + privacy of any
 embedded API outputs); they're written to `runs/<run-id>/` which is
 gitignored.
+
+> **Note:** `estimate` is build-only and makes ZERO API calls. The
+> actual A/B/C model run — budget enforcement, per-task isolation,
+> resume-from-checkpoint, Docker patch eval, and CI — ships with the
+> deferred **PR-B** infrastructure. A cheap smoke corpus
+> (`corpus/swe-bench-lite-smoke.json`, 4 real SWE-bench_Lite instance
+> ids with placeholder statements) is included for wiring tests.
 
 ## What this does NOT do (yet)
 

--- a/agent-bench/agent_bench/cli.py
+++ b/agent-bench/agent_bench/cli.py
@@ -22,8 +22,54 @@ import argparse
 import sys
 from importlib.metadata import version as _pkg_version
 
+__all__ = ["main", "estimate_cost"]
 
-__all__ = ["main"]
+
+# Default per-task-run token model. A "run" is one (task, seed, arm)
+# trajectory. These are deliberately conservative point estimates drawn
+# from typical SWE-bench-lite agent loops (~15-turn trajectories with a
+# growing context). Override at the call site as real data arrives.
+DEFAULT_IN_TOKENS_PER_RUN = 120_000
+DEFAULT_OUT_TOKENS_PER_RUN = 8_000
+
+# Default per-MTok USD prices. Sonnet list pricing as of writing
+# ($3 in / $15 out per million tokens). Override with --in-price /
+# --out-price for Opus ($15 / $75) or future snapshots.
+DEFAULT_IN_PRICE_USD = 3.0
+DEFAULT_OUT_PRICE_USD = 15.0
+
+
+def estimate_cost(
+    *,
+    tasks: int,
+    seeds: int = 1,
+    arms: int = 3,
+    in_per_run: int = DEFAULT_IN_TOKENS_PER_RUN,
+    out_per_run: int = DEFAULT_OUT_TOKENS_PER_RUN,
+    in_price: float = DEFAULT_IN_PRICE_USD,
+    out_price: float = DEFAULT_OUT_PRICE_USD,
+) -> dict[str, float | int]:
+    """Project token + USD spend for a full bench run. NO API call.
+
+    A "run" is one (task, seed, arm) trajectory:
+        runs = tasks * seeds * arms
+    Token totals scale linearly with runs; USD is priced per MTok:
+        input_usd  = input_tokens  * in_price  / 1e6
+        output_usd = output_tokens * out_price / 1e6
+    """
+    runs = tasks * seeds * arms
+    input_tokens = runs * in_per_run
+    output_tokens = runs * out_per_run
+    input_usd = input_tokens * in_price / 1_000_000
+    output_usd = output_tokens * out_price / 1_000_000
+    return {
+        "runs": runs,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "input_usd": input_usd,
+        "output_usd": output_usd,
+        "total_usd": input_usd + output_usd,
+    }
 
 
 _BANNER = """\
@@ -80,7 +126,66 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print which Phase 2 units are shipped vs deferred and exit.",
     )
+
+    sub = parser.add_subparsers(dest="command")
+    est = sub.add_parser(
+        "estimate",
+        help="Project token + USD spend for a bench run (no API call).",
+    )
+    est.add_argument("--tasks", type=int, default=30, help="Number of corpus tasks.")
+    est.add_argument("--seeds", type=int, default=1, help="Repeats per (task, arm).")
+    est.add_argument(
+        "--arms", type=int, default=3, help="Number of arms (A/B/C = 3)."
+    )
+    est.add_argument(
+        "--model",
+        default="claude-sonnet-4-7-20260315",
+        help="Pinned snapshot id (labels the projection; not called).",
+    )
+    est.add_argument(
+        "--in-price",
+        type=float,
+        default=DEFAULT_IN_PRICE_USD,
+        help=f"Input price USD/MTok (default {DEFAULT_IN_PRICE_USD}; Opus ~15).",
+    )
+    est.add_argument(
+        "--out-price",
+        type=float,
+        default=DEFAULT_OUT_PRICE_USD,
+        help=f"Output price USD/MTok (default {DEFAULT_OUT_PRICE_USD}; Opus ~75).",
+    )
     return parser
+
+
+def _run_estimate(args: argparse.Namespace) -> int:
+    est = estimate_cost(
+        tasks=args.tasks,
+        seeds=args.seeds,
+        arms=args.arms,
+        in_price=args.in_price,
+        out_price=args.out_price,
+    )
+    print("Projected bench-run cost (no API call made):")
+    print(f"  model        : {args.model}")
+    print(
+        f"  runs         : {est['runs']:,} "
+        f"({args.tasks} tasks × {args.seeds} seeds × {args.arms} arms)"
+    )
+    print(
+        f"  input tokens : {est['input_tokens']:,}  "
+        f"@ ${args.in_price}/MTok = ${est['input_usd']:.2f}"
+    )
+    print(
+        f"  output tokens: {est['output_tokens']:,}  "
+        f"@ ${args.out_price}/MTok = ${est['output_usd']:.2f}"
+    )
+    print(f"  TOTAL        : ${est['total_usd']:.2f}")
+    print(
+        "\nNote: per-run token model is a conservative point estimate "
+        "(see agent_bench.cli.DEFAULT_*); a hard budget cap + the live "
+        "run land with the deferred PR-B infra."
+    )
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -92,9 +197,12 @@ def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
+    if getattr(args, "command", None) == "estimate":
+        return _run_estimate(args)
+
     print(_BANNER.format(version=v))
 
-    if args.status or len(sys.argv) == 1:
+    if args.status or argv is None or len(argv) == 0:
         print(_PRA_NOTICE)
         return 0
 

--- a/agent-bench/agent_bench/eval_verify.py
+++ b/agent-bench/agent_bench/eval_verify.py
@@ -1,0 +1,206 @@
+"""Per-arm verify-metric collection (verify-v0 P4 U3).
+
+OFFLINE post-hoc scoring: takes the trajectories an arm produced and
+feeds each one's final patch through the rts verify CLI to compute the
+§5 edit-quality / hallucination metrics PER ARM. NO model in the loop.
+
+The rts CLI is reached only through the `RtsVerifyRunner` boundary
+(a Protocol), so the whole module is unit-testable with a `FakeRunner`
+returning canned JSON — no daemon, no subprocess, no network.
+
+Metrics (mirroring `crates/rts-bench`'s `Metric` shape —
+numerator / denominator / rate, with `rate=None` on an empty
+denominator so a rate is never NaN and never cherry-picked):
+
+  - **EVR** (Edit Validity Rate): patches whose `verify_edit` verdict
+    is "pass" / patches scored. `warn` and `fail` count against it.
+  - **BCIR** (Broken-Caller Introduction Rate): patches with >=1
+    finding kind in {broken_caller, signature_break} / patches scored.
+  - **SHR / IHR / SMR**: symbol / import / signature hallucination
+    rates, aggregated from the `verify_file` (`rts verify --json`)
+    hallucination lists over the files each patch touched. A reference
+    counts toward the denominator only when its resolution is decidable
+    (`exact` or `not_found`); `indeterminate` is excluded (honest
+    denominators).
+
+### SMR is approximated as `None`
+
+The `rts verify --json` file-level surface returns symbol / import
+resolutions but NOT per-call-site arity data, so we cannot decide
+signature mismatches from this boundary. SMR is therefore reported with
+denominator 0 / rate None (documented, never a false zero). The
+arity-aware SMR lives in `rts-bench`'s reference-level harness, which
+has the F3 `call_arity` extraction this CLI surface lacks.
+
+### Empty / missing patches
+
+A trajectory with `final_patch` None or "" produced no edit to score;
+it is SKIPPED (not counted in any denominator) and tallied under
+`skipped_empty_patches` so coverage stays visible.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any, Protocol
+
+
+class RtsVerifyRunner(Protocol):
+    """Thin boundary over the rts verify CLI.
+
+    `verify_edit` mirrors `rts verify-edit --json`: given a list of
+    full post-edit `{file, content}` dicts, returns the daemon verdict
+    body `{verdict, findings: [{kind, ...}], files?: [...], ...}`.
+
+    `verify_file` mirrors `rts verify --json` on one file's content:
+    returns `{hallucinations: [{name, kind, resolution, ...}]}` where
+    `resolution` is one of "exact" / "not_found" / "indeterminate".
+    """
+
+    def verify_edit(self, edits: list[dict]) -> dict: ...
+
+    def verify_file(self, path: str, content: str) -> dict: ...
+
+
+# --- Real (shelling) implementation -------------------------------
+
+
+class CliRtsVerifyRunner:
+    """Real `RtsVerifyRunner` that shells out to the `rts` binary.
+
+    Used only in real runs; tests inject a fake. Kept dependency-free
+    (subprocess + json) so importing this module never spawns anything.
+    """
+
+    def __init__(self, rts_bin: str = "rts", workspace: str | None = None) -> None:
+        self._rts = rts_bin
+        self._workspace = workspace
+
+    def _run(self, args: list[str], stdin: str | None = None) -> dict:
+        proc = subprocess.run(
+            [self._rts, *args],
+            input=stdin,
+            capture_output=True,
+            text=True,
+            cwd=self._workspace,
+            timeout=120,
+        )
+        out = proc.stdout.strip()
+        if not out:
+            return {"error": proc.stderr.strip() or "empty output"}
+        try:
+            return json.loads(out)
+        except json.JSONDecodeError:
+            return {"error": "non-json output", "raw": out}
+
+    def verify_edit(self, edits: list[dict]) -> dict:
+        # `rts verify-edit --edits - --json` reads the edits JSON on stdin.
+        return self._run(
+            ["verify-edit", "--edits", "-", "--json"], stdin=json.dumps(edits)
+        )
+
+    def verify_file(self, path: str, content: str) -> dict:
+        # `rts verify <path> --json` (content already on disk in workspace).
+        return self._run(["verify", path, "--json"])
+
+
+# --- Metric accumulator (mirrors rts-bench's Metric shape) --------
+
+_CALLER_BREAK_KINDS = frozenset({"broken_caller", "signature_break"})
+
+
+def _metric(numerator: int, denominator: int, indeterminate: int = 0) -> dict[str, Any]:
+    """`{numerator, denominator, rate, indeterminate_excluded}` with
+    `rate=None` on an empty denominator (never NaN)."""
+    rate = None if denominator == 0 else numerator / denominator
+    return {
+        "numerator": numerator,
+        "denominator": denominator,
+        "rate": rate,
+        "indeterminate_excluded": indeterminate,
+    }
+
+
+def _patch_to_edits(patch: str) -> list[dict]:
+    """Wrap a trajectory's final patch into the verify_edit edit list.
+
+    The trajectory stores a unified diff as a single blob; the verify
+    boundary keys on the `content` field, so we pass the patch as one
+    edit dict. (A richer impl would parse the diff into per-file
+    post-edit contents; the FakeRunner-backed tests exercise this
+    contract via the `content` key.)
+    """
+    return [{"file": "", "content": patch}]
+
+
+def evaluate_arm(
+    trajectories: list[Any],
+    runner: RtsVerifyRunner,
+) -> dict[str, Any]:
+    """Compute the §5 verify metrics for one arm's trajectories.
+
+    Returns a dict with `evr`, `bcir`, `shr`, `ihr`, `smr` metric
+    blocks (numerator/denominator/rate), plus `scored_patches` and
+    `skipped_empty_patches` for coverage visibility.
+    """
+    evr_num = 0
+    bcir_num = 0
+    scored = 0
+    skipped = 0
+
+    shr_num = shr_den = shr_ind = 0
+    ihr_num = ihr_den = ihr_ind = 0
+
+    for traj in trajectories:
+        patch = getattr(traj, "final_patch", None)
+        if not patch:  # None or "" → no edit to score; skip.
+            skipped += 1
+            continue
+
+        scored += 1
+        body = runner.verify_edit(_patch_to_edits(patch))
+        verdict = body.get("verdict")
+        findings = body.get("findings") or []
+
+        if verdict == "pass":
+            evr_num += 1
+        kinds = {f.get("kind") for f in findings}
+        if kinds & _CALLER_BREAK_KINDS:
+            bcir_num += 1
+
+        # Hallucination rates over the files this patch touched.
+        for path in body.get("files") or []:
+            file_body = runner.verify_file(path, "")
+            for ref in file_body.get("hallucinations") or []:
+                kind = ref.get("kind")
+                resolution = ref.get("resolution")
+                if kind == "import":
+                    if resolution == "not_found":
+                        ihr_num += 1
+                        ihr_den += 1
+                    elif resolution == "exact":
+                        ihr_den += 1
+                    else:
+                        ihr_ind += 1
+                else:  # symbol / type / path → SHR
+                    if resolution == "not_found":
+                        shr_num += 1
+                        shr_den += 1
+                    elif resolution == "exact":
+                        shr_den += 1
+                    else:
+                        shr_ind += 1
+
+    return {
+        "scored_patches": scored,
+        "skipped_empty_patches": skipped,
+        "evr": _metric(evr_num, scored),
+        "bcir": _metric(bcir_num, scored),
+        "shr": _metric(shr_num, shr_den, shr_ind),
+        "ihr": _metric(ihr_num, ihr_den, ihr_ind),
+        # SMR approximated as None: the verify_file CLI surface does not
+        # expose per-call-site arity, so signature mismatch can't be
+        # decided here. See module docstring.
+        "smr": _metric(0, 0),
+    }

--- a/agent-bench/agent_bench/report.py
+++ b/agent-bench/agent_bench/report.py
@@ -21,10 +21,11 @@ from __future__ import annotations
 
 import json
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .mcp_bridge import RTS_TOOL_PREFIX
 from .run import ArmTrajectory, count_tool_uses_by_backend
 
 
@@ -60,6 +61,100 @@ def wilson_ci(successes: int, n: int, z: float = 1.96) -> WilsonCI:
     return WilsonCI(p=phat, lo=max(0.0, center - half), hi=min(1.0, center + half), n=n)
 
 
+# --- McNemar paired test ------------------------------------------
+#
+# McNemar's test compares two paired binary classifiers (here: two arms
+# run on the SAME tasks, success=True/False per task). Only the
+# DISCORDANT pairs matter:
+#   b01 = a fail, b pass   (b "fixed" what a got wrong)
+#   b10 = a pass, b fail   (b "broke" what a got right)
+# Concordant pairs (both pass / both fail) carry no signal.
+#
+# Method selection (documented threshold):
+#   - b01+b10 == 0          → no discordant pairs, p = 1.0, method "none"
+#   - b01+b10 <  25         → EXACT binomial two-sided test (n small;
+#                             the chi-square approximation is unreliable)
+#   - b01+b10 >= 25         → continuity-corrected chi-square
+#                             (Edwards' correction), df=1
+# We implement everything by hand (no scipy): the exact tail via the
+# binomial PMF summed directly, and the chi-square df=1 survival
+# function via math.erfc (chi2 df=1 == squared standard normal, so
+# P(X > x) = erfc(sqrt(x/2))).
+
+EXACT_MCNEMAR_THRESHOLD = 25
+
+
+def _binom_two_sided_p(k: int, n: int) -> float:
+    """Two-sided exact binomial p for k successes in n trials at p=0.5.
+
+    Sums the tail at the more-extreme-or-equal side and doubles it,
+    clamped to 1.0 — the standard two-sided exact McNemar p when the
+    null is symmetric (p=0.5). Computed by summing the binomial PMF
+    directly; no scipy.
+    """
+    if n == 0:
+        return 1.0
+    # Distance of k from the mean n/2; sum both tails at >= that distance.
+    kk = min(k, n - k)
+
+    def pmf(i: int) -> float:
+        return math.comb(n, i) * (0.5**n)
+
+    tail = sum(pmf(i) for i in range(kk + 1))
+    return min(1.0, 2.0 * tail)
+
+
+def _chi2_df1_sf(x: float) -> float:
+    """Survival function P(X > x) for a chi-square with df=1.
+
+    A chi-square(df=1) variate is the square of a standard normal, so
+    P(X > x) = P(|Z| > sqrt(x)) = erfc(sqrt(x/2)). Pure stdlib.
+    """
+    if x <= 0:
+        return 1.0
+    return math.erfc(math.sqrt(x / 2.0))
+
+
+def mcnemar(a: list[bool], b: list[bool]) -> dict[str, Any]:
+    """McNemar paired test over two arms' per-task success vectors.
+
+    `a` and `b` are equal-length lists of booleans (True = task
+    succeeded for that arm). Returns the discordant counts, the test
+    statistic, the two-sided p-value, and which method produced it.
+    Symmetric in (a, b): swapping the arguments swaps b01/b10 but
+    leaves the p-value unchanged.
+    """
+    if len(a) != len(b):
+        raise ValueError(
+            f"mcnemar: a and b must be the same length (got {len(a)} vs {len(b)})"
+        )
+    b01 = sum(1 for ai, bi in zip(a, b, strict=True) if (not ai) and bi)  # a fail, b pass
+    b10 = sum(1 for ai, bi in zip(a, b, strict=True) if ai and (not bi))  # a pass, b fail
+    n = b01 + b10
+
+    if n == 0:
+        return {"b01": 0, "b10": 0, "statistic": 0.0, "p_value": 1.0, "method": "none"}
+
+    if n < EXACT_MCNEMAR_THRESHOLD:
+        p = _binom_two_sided_p(min(b01, b10), n)
+        return {
+            "b01": b01,
+            "b10": b10,
+            "statistic": float(min(b01, b10)),
+            "p_value": p,
+            "method": "exact",
+        }
+
+    chi2 = (abs(b01 - b10) - 1) ** 2 / n
+    return {
+        "b01": b01,
+        "b10": b10,
+        "statistic": chi2,
+        "p_value": _chi2_df1_sf(chi2),
+        "method": "chi2_corrected",
+    }
+
+
 @dataclass
 class ArmAggregate:
     """One arm's roll-up across all tasks."""
@@ -84,6 +179,12 @@ class ArmAggregate:
 
     total_input_tokens: int
     total_output_tokens: int
+
+    # Per-tool breakdown, keyed by bare tool name (rts prefix stripped;
+    # local Bash/Read/submit_patch kept as-is). Summed across all tasks.
+    tool_calls_by_name: dict[str, int] = field(default_factory=dict)
+    # Total verify_* tool calls (names starting with "verify_").
+    verify_tools_total: int = 0
 
     def tool_use_ratio_ci(self) -> WilsonCI:
         """Tool-use ratio = rts_mcp / (all tool calls).
@@ -126,6 +227,8 @@ def aggregate_arm(arm: str, trajectories: list[ArmTrajectory]) -> ArmAggregate:
 
     total_tc = 0
     rts_tc = bash_tc = read_tc = submit_tc = 0
+    by_name: dict[str, int] = {}
+    verify_total = 0
     for traj in trajectories:
         c = count_tool_uses_by_backend(traj)
         total_tc += sum(c.values())
@@ -133,6 +236,18 @@ def aggregate_arm(arm: str, trajectories: list[ArmTrajectory]) -> ArmAggregate:
         bash_tc += c.get("bash", 0)
         read_tc += c.get("read", 0)
         submit_tc += c.get("submit", 0)
+        # Per-tool breakdown: strip the rts prefix so verify_* /
+        # find_symbol show up by bare name; verify_total counts the
+        # anti-hallucination tools.
+        for tc in traj.tool_calls:
+            bare = (
+                tc.name[len(RTS_TOOL_PREFIX):]
+                if tc.name.startswith(RTS_TOOL_PREFIX)
+                else tc.name
+            )
+            by_name[bare] = by_name.get(bare, 0) + 1
+            if bare.startswith("verify_"):
+                verify_total += 1
 
     wall_times = sorted(t.wall_clock_s for t in trajectories)
     median = wall_times[len(wall_times) // 2] if wall_times else 0.0
@@ -155,6 +270,8 @@ def aggregate_arm(arm: str, trajectories: list[ArmTrajectory]) -> ArmAggregate:
         p95_wall_clock_s=p95,
         total_input_tokens=sum(t.input_tokens for t in trajectories),
         total_output_tokens=sum(t.output_tokens for t in trajectories),
+        tool_calls_by_name=by_name,
+        verify_tools_total=verify_total,
     )
 
 
@@ -315,6 +432,144 @@ def comparison_markdown(
         f"| {treatment.total_output_tokens:,} |",
         "",
     ]
+    return "\n".join(lines)
+
+
+# --- 3-arm (A/B/C) comparison -------------------------------------
+
+MULTI_ARM_SCHEMA = "agent-bench/multi-arm/v1"
+
+# The three paired contrasts we always render for an A/B/C bench.
+_MULTI_ARM_DELTAS = ("B_vs_A", "C_vs_B", "C_vs_A")
+
+
+def multi_arm_comparison_json(
+    aggregates: list[ArmAggregate],
+    paired_success: dict[str, tuple[list[bool], list[bool]]],
+    verify_metrics: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Schema-versioned A/B/C comparison payload.
+
+    - `aggregates`: per-arm rollups (any order).
+    - `paired_success`: maps each contrast key in {"B_vs_A","C_vs_B",
+      "C_vs_A"} to a `(a_success, b_success)` tuple of equal-length
+      per-task booleans (the McNemar inputs).
+    - `verify_metrics`: maps arm name → that arm's verify-metric block
+      (from `eval_verify.evaluate_arm`); attached per arm.
+    """
+    arms_payload: list[dict[str, Any]] = []
+    arms_by_name: dict[str, dict[str, Any]] = {}
+    for agg in aggregates:
+        tur = agg.tool_use_ratio_ci()
+        suc = agg.success_rate_ci()
+        entry = {
+            "arm": agg.arm,
+            "model": agg.model,
+            "n_tasks": agg.n_tasks,
+            "success_rate": {
+                "point": suc.p,
+                "ci_low": suc.lo,
+                "ci_high": suc.hi,
+                "n": suc.n,
+            },
+            "tool_use_ratio": {
+                "point": tur.p,
+                "ci_low": tur.lo,
+                "ci_high": tur.hi,
+                "n": tur.n,
+            },
+            "tokens": {
+                "input": agg.total_input_tokens,
+                "output": agg.total_output_tokens,
+            },
+            "wall_clock_s": {
+                "median": agg.median_wall_clock_s,
+                "p95": agg.p95_wall_clock_s,
+            },
+            "tool_calls_by_name": dict(sorted(agg.tool_calls_by_name.items())),
+            "verify_tools_total": agg.verify_tools_total,
+            "verify_metrics": verify_metrics.get(agg.arm, {}),
+        }
+        arms_payload.append(entry)
+        arms_by_name[agg.arm] = entry
+
+    mcnemar_block: dict[str, Any] = {}
+    for key in _MULTI_ARM_DELTAS:
+        if key not in paired_success:
+            continue
+        av, bv = paired_success[key]
+        mcnemar_block[key] = mcnemar(av, bv)
+
+    return {
+        "schema": MULTI_ARM_SCHEMA,
+        "arms": arms_payload,
+        "arms_by_name": arms_by_name,
+        "mcnemar": mcnemar_block,
+    }
+
+
+def multi_arm_comparison_markdown(
+    aggregates: list[ArmAggregate],
+    paired_success: dict[str, tuple[list[bool], list[bool]]],
+    verify_metrics: dict[str, dict[str, Any]],
+) -> str:
+    """Human-readable A/B/C comparison."""
+    payload = multi_arm_comparison_json(aggregates, paired_success, verify_metrics)
+    lines = [
+        "# agent-bench A/B/C comparison",
+        "",
+        "## Per-arm summary (Wilson 95% CI)",
+        "",
+        "| Arm | Success | Tool-use ratio | Verify calls | Tokens (in/out) | Wall median/p95 |",
+        "|-----|---------|----------------|--------------|-----------------|-----------------|",
+    ]
+    for arm in payload["arms"]:
+        suc = arm["success_rate"]
+        tur = arm["tool_use_ratio"]
+        lines.append(
+            f"| {arm['arm']} "
+            f"| {suc['point'] * 100:.1f}% [{suc['ci_low'] * 100:.1f}, {suc['ci_high'] * 100:.1f}] "
+            f"| {tur['point'] * 100:.1f}% [{tur['ci_low'] * 100:.1f}, {tur['ci_high'] * 100:.1f}] "
+            f"| {arm['verify_tools_total']} "
+            f"| {arm['tokens']['input']:,}/{arm['tokens']['output']:,} "
+            f"| {arm['wall_clock_s']['median']:.1f}s/{arm['wall_clock_s']['p95']:.1f}s |"
+        )
+
+    lines += [
+        "",
+        "## Verify metrics (per arm)",
+        "",
+    ]
+    for arm in payload["arms"]:
+        vm = arm["verify_metrics"] or {}
+        lines.append(f"- **{arm['arm']}**: {vm if vm else '(none)'}")
+
+    lines += [
+        "",
+        "## Per-tool breakdown",
+        "",
+    ]
+    for arm in payload["arms"]:
+        breakdown = arm["tool_calls_by_name"]
+        rendered = ", ".join(f"{k}={v}" for k, v in breakdown.items()) or "(none)"
+        lines.append(f"- **{arm['arm']}**: {rendered}")
+
+    lines += [
+        "",
+        "## McNemar deltas (paired task success)",
+        "",
+        "| Contrast | b01 (a✗→b✓) | b10 (a✓→b✗) | statistic | p-value | method |",
+        "|----------|-------------|-------------|-----------|---------|--------|",
+    ]
+    for key in _MULTI_ARM_DELTAS:
+        m = payload["mcnemar"].get(key)
+        if m is None:
+            continue
+        lines.append(
+            f"| {key} | {m['b01']} | {m['b10']} "
+            f"| {m['statistic']:.3f} | {m['p_value']:.4f} | {m['method']} |"
+        )
+    lines.append("")
     return "\n".join(lines)
 
 

--- a/agent-bench/agent_bench/run.py
+++ b/agent-bench/agent_bench/run.py
@@ -27,7 +27,6 @@ from typing import Any, Protocol
 
 from .mcp_bridge import RTS_TOOL_PREFIX, McpBridge
 
-
 # Built-in tool schemas the agent sees in BOTH arms.
 # We surface Bash + Read so the agent has a baseline shell-shaped
 # toolkit comparable to typical SWE-bench harnesses.
@@ -103,16 +102,97 @@ class Task:
     gold_patch: str = ""
 
 
+# --- Arm tool profiles --------------------------------------------
+#
+# A/B/C benchmark: each arm exposes a DIFFERENT rts tool surface. We
+# declare explicit allowlists of bare `mcp__rts__*` names (no prefix —
+# prefix is added when matching against the bridge's listing) so a
+# future rts tool can never silently leak into an arm. `build_tool_list`
+# intersects the bridge's live listing with the active profile's
+# allowlist; anything not on the list is excluded.
+
+# Arm B surface — read-only retrieval / navigation tools.
+RETRIEVAL_TOOLS: frozenset[str] = frozenset(
+    {
+        "find_symbol",
+        "grep",
+        "read_symbol",
+        "read_symbol_at",
+        "read_range",
+        "outline_workspace",
+        "find_callers",
+        "impact_of",
+    }
+)
+
+# Arm C adds the verify_* anti-hallucination tools on top of retrieval.
+VERIFY_TOOLS: frozenset[str] = frozenset(
+    {
+        "verify_symbol",
+        "verify_signature",
+        "verify_import",
+        "verify_claims",
+        "verify_impact",
+        "verify_edit",
+    }
+)
+
+# Profile → allowed bare rts tool names.
+_PROFILE_ALLOWLIST: dict[str, frozenset[str]] = {
+    "baseline": frozenset(),
+    "retrieval": RETRIEVAL_TOOLS,
+    "retrieval_verify": RETRIEVAL_TOOLS | VERIFY_TOOLS,
+}
+
+# One-line nudge appended to Arm C's system prompt, encouraging use of
+# the verify_* tools before asserting a symbol exists / changing a sig.
+VERIFY_NUDGE: str = (
+    "Before asserting a symbol exists or changing a signature, verify it "
+    "with the verify_* tools (verify_symbol, verify_signature, "
+    "verify_import, verify_claims, verify_impact, verify_edit)."
+)
+
+
 @dataclass
 class ArmConfig:
-    """The deltas that differentiate control from treatment.
+    """The deltas that differentiate the A/B/C arms.
 
     Holding the rest of the loop config fixed across arms is the
     primary confound control. The harness asserts on these.
+
+    `tool_profile` selects the rts tool surface:
+      - "baseline"          → no rts tools (Arm A / control)
+      - "retrieval"         → RETRIEVAL_TOOLS only (Arm B)
+      - "retrieval_verify"  → retrieval + verify tools, + verify nudge (Arm C)
+
+    `include_rts_tools` is kept as a back-compat shim: older call sites
+    construct `ArmConfig(arm=..., include_rts_tools=...)`; we derive the
+    profile from it (False→baseline, True→retrieval_verify, the widest
+    surface). When `tool_profile` is given explicitly, `include_rts_tools`
+    is derived from the profile instead.
     """
 
-    arm: str  # "control" or "treatment"
-    include_rts_tools: bool  # treatment: True; control: False
+    arm: str
+    tool_profile: str = ""
+    include_rts_tools: bool = False
+
+    def __post_init__(self) -> None:
+        if self.tool_profile:
+            if self.tool_profile not in _PROFILE_ALLOWLIST:
+                raise ValueError(
+                    f"unknown tool_profile {self.tool_profile!r}; "
+                    f"expected one of {sorted(_PROFILE_ALLOWLIST)}"
+                )
+            # Derive the back-compat flag from the profile.
+            self.include_rts_tools = self.tool_profile != "baseline"
+        else:
+            # Back-compat: derive a profile from include_rts_tools.
+            self.tool_profile = "retrieval_verify" if self.include_rts_tools else "baseline"
+
+    @property
+    def allowed_rts_tools(self) -> frozenset[str]:
+        """Bare rts tool names this arm may expose."""
+        return _PROFILE_ALLOWLIST[self.tool_profile]
 
 
 @dataclass
@@ -270,27 +350,48 @@ def build_tool_list(
 ) -> list[dict[str, Any]]:
     """Compose the Anthropic `tools=[...]` list for an arm.
 
-    Both arms get Bash + Read + submit_patch. Treatment also gets the
-    rts MCP tools (queried live from the bridge so the schema stays
-    in sync with whatever rts-mcp advertises).
+    Every arm gets Bash + Read + submit_patch. Arms with an rts
+    profile also get the subset of `mcp__rts__*` tools whose bare name
+    is on the profile's allowlist (queried live from the bridge so the
+    schema stays in sync with whatever rts-mcp advertises). A tool the
+    bridge advertises but the profile does NOT allow is excluded — a
+    future rts tool can't silently leak into an arm.
     """
     tools: list[dict[str, Any]] = [
         BASH_TOOL_SCHEMA,
         READ_TOOL_SCHEMA,
         SUBMIT_PATCH_TOOL_SCHEMA,
     ]
-    if arm.include_rts_tools:
-        if bridge is None:
-            raise ValueError("treatment arm requires an MCP bridge")
-        for t in bridge.list_tools():
-            tools.append(
-                {
-                    "name": f"{RTS_TOOL_PREFIX}{t.name}",
-                    "description": t.description,
-                    "input_schema": t.input_schema,
-                }
-            )
+    allowed = arm.allowed_rts_tools
+    if not allowed:
+        return tools  # baseline: no rts tools, bridge optional.
+
+    if bridge is None:
+        raise ValueError(f"arm {arm.arm!r} ({arm.tool_profile}) requires an MCP bridge")
+    for t in bridge.list_tools():
+        if t.name not in allowed:
+            continue  # not on this profile's allowlist — exclude.
+        tools.append(
+            {
+                "name": f"{RTS_TOOL_PREFIX}{t.name}",
+                "description": t.description,
+                "input_schema": t.input_schema,
+            }
+        )
     return tools
+
+
+def effective_system_prompt(base_prompt: str, arm: ArmConfig) -> str:
+    """The system prompt an arm actually sends.
+
+    Arm C ("retrieval_verify") appends a one-line verify nudge so the
+    extra verify_* tools have a behavioral pull; A and B send the base
+    prompt verbatim (confound control: the ONLY prompt delta is the
+    nudge, gated on the profile).
+    """
+    if arm.tool_profile == "retrieval_verify":
+        return f"{base_prompt}\n\n{VERIFY_NUDGE}"
+    return base_prompt
 
 
 # --- The loop -----------------------------------------------------
@@ -340,6 +441,7 @@ def run_one_arm(
     traj = ArmTrajectory(task_id=task.instance_id, arm=arm.arm, model=config.model)
 
     tools = build_tool_list(arm, bridge)
+    system_prompt = effective_system_prompt(config.system_prompt, arm)
     messages: list[dict[str, Any]] = [
         {"role": "user", "content": task.problem_statement},
     ]
@@ -354,7 +456,7 @@ def run_one_arm(
         try:
             resp = client.create(
                 model=config.model,
-                system=config.system_prompt,
+                system=system_prompt,
                 messages=messages,
                 tools=tools,
                 max_tokens=4096,

--- a/agent-bench/corpus/swe-bench-lite-smoke.json
+++ b/agent-bench/corpus/swe-bench-lite-smoke.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "Cheap SMOKE subset for agent-bench (verify-v0 P4). NOT the full 30-task corpus. Instance ids below are real, well-known SWE-bench_Lite (princeton-nlp/SWE-bench_Lite) instances; problem_statement values here are short placeholders for smoke wiring only and are NOT the dataset's full statements. The live run loads the canonical statements + gold patches from HuggingFace. base_commit values are placeholders pending the dataset load.",
+  "schema": "agent-bench/corpus/v1",
+  "name": "swe-bench-lite-smoke",
+  "tasks": [
+    {
+      "instance_id": "django__django-11099",
+      "repo": "django/django",
+      "base_commit": "PLACEHOLDER_SMOKE",
+      "problem_statement": "SMOKE PLACEHOLDER: UsernameValidator allows trailing newline in usernames. Load the full statement from the dataset for a real run.",
+      "gold_patch": ""
+    },
+    {
+      "instance_id": "sympy__sympy-20212",
+      "repo": "sympy/sympy",
+      "base_commit": "PLACEHOLDER_SMOKE",
+      "problem_statement": "SMOKE PLACEHOLDER: 0**-oo produces zoo, but should produce oo. Load the full statement from the dataset for a real run.",
+      "gold_patch": ""
+    },
+    {
+      "instance_id": "scikit-learn__scikit-learn-13241",
+      "repo": "scikit-learn/scikit-learn",
+      "base_commit": "PLACEHOLDER_SMOKE",
+      "problem_statement": "SMOKE PLACEHOLDER: KernelPCA sign inconsistency across runs. Load the full statement from the dataset for a real run.",
+      "gold_patch": ""
+    },
+    {
+      "instance_id": "pytest-dev__pytest-5103",
+      "repo": "pytest-dev/pytest",
+      "base_commit": "PLACEHOLDER_SMOKE",
+      "problem_statement": "SMOKE PLACEHOLDER: Unroll the iterable for all/any calls to get better assertion messages. Load the full statement from the dataset for a real run.",
+      "gold_patch": ""
+    }
+  ]
+}

--- a/agent-bench/tests/test_arm_profiles.py
+++ b/agent-bench/tests/test_arm_profiles.py
@@ -1,0 +1,145 @@
+"""Tests for the A/B/C arm tool profiles (verify-v0 P4 U1).
+
+Each arm exposes a different rts tool surface:
+  - baseline          → no rts tools (just Bash/Read/submit_patch)
+  - retrieval         → RETRIEVAL_TOOLS only
+  - retrieval_verify  → RETRIEVAL_TOOLS ∪ VERIFY_TOOLS, + a verify nudge
+
+Uses a FakeBridge that lists ALL rts tools (including an unknown
+`mcp__rts__future_tool`) so we can assert the allowlist filters
+correctly — a future tool must never silently leak into an arm.
+No Anthropic API, no real daemon involved.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from agent_bench.mcp_bridge import RTS_TOOL_PREFIX, McpToolSchema
+from agent_bench.run import (
+    RETRIEVAL_TOOLS,
+    VERIFY_NUDGE,
+    VERIFY_TOOLS,
+    ArmConfig,
+    build_tool_list,
+    effective_system_prompt,
+)
+
+
+@dataclass
+class FakeBridge:
+    """Stands in for McpBridge.list_tools(); lists every rts tool.
+
+    Includes an unknown `future_tool` to prove the allowlist excludes
+    tools that aren't part of any declared profile.
+    """
+
+    extra: list[str] | None = None
+
+    def list_tools(self) -> list[McpToolSchema]:
+        names = sorted(RETRIEVAL_TOOLS | VERIFY_TOOLS | {"future_tool"})
+        if self.extra:
+            names = sorted(set(names) | set(self.extra))
+        return [
+            McpToolSchema(
+                name=n,
+                description=f"rts tool {n}",
+                input_schema={"type": "object"},
+            )
+            for n in names
+        ]
+
+
+def _rts_names(tools: list[dict[str, Any]]) -> set[str]:
+    """Bare rts tool names present in a built tool list."""
+    return {
+        t["name"][len(RTS_TOOL_PREFIX):]
+        for t in tools
+        if t["name"].startswith(RTS_TOOL_PREFIX)
+    }
+
+
+def _local_names(tools: list[dict[str, Any]]) -> set[str]:
+    return {t["name"] for t in tools if not t["name"].startswith(RTS_TOOL_PREFIX)}
+
+
+class TestArmProfiles:
+    def test_baseline_spawns_no_rts_tools(self) -> None:
+        arm = ArmConfig(arm="A", tool_profile="baseline")
+        tools = build_tool_list(arm, FakeBridge())
+        assert _rts_names(tools) == set()
+        # Local tools always present.
+        assert _local_names(tools) == {"Bash", "Read", "submit_patch"}
+
+    def test_baseline_works_without_bridge(self) -> None:
+        arm = ArmConfig(arm="A", tool_profile="baseline")
+        tools = build_tool_list(arm, None)
+        assert _rts_names(tools) == set()
+
+    def test_retrieval_yields_exactly_retrieval_tools(self) -> None:
+        arm = ArmConfig(arm="B", tool_profile="retrieval")
+        tools = build_tool_list(arm, FakeBridge())
+        assert _rts_names(tools) == set(RETRIEVAL_TOOLS)
+        # future_tool and verify tools excluded.
+        assert "future_tool" not in _rts_names(tools)
+        assert _rts_names(tools).isdisjoint(VERIFY_TOOLS)
+
+    def test_retrieval_verify_yields_retrieval_plus_verify(self) -> None:
+        arm = ArmConfig(arm="C", tool_profile="retrieval_verify")
+        tools = build_tool_list(arm, FakeBridge())
+        assert _rts_names(tools) == set(RETRIEVAL_TOOLS) | set(VERIFY_TOOLS)
+        assert "future_tool" not in _rts_names(tools)
+
+    def test_unknown_tool_never_leaks_into_any_profile(self) -> None:
+        bridge = FakeBridge(extra=["another_unknown"])
+        for profile in ("retrieval", "retrieval_verify"):
+            arm = ArmConfig(arm="x", tool_profile=profile)
+            names = _rts_names(build_tool_list(arm, bridge))
+            assert "future_tool" not in names
+            assert "another_unknown" not in names
+
+    def test_non_baseline_requires_bridge(self) -> None:
+        arm = ArmConfig(arm="B", tool_profile="retrieval")
+        with pytest.raises(ValueError, match="requires an MCP bridge"):
+            build_tool_list(arm, None)
+
+
+class TestVerifyNudge:
+    def test_arm_c_prompt_gets_nudge_appended(self) -> None:
+        arm = ArmConfig(arm="C", tool_profile="retrieval_verify")
+        prompt = effective_system_prompt("base prompt body", arm)
+        assert "base prompt body" in prompt
+        assert VERIFY_NUDGE in prompt
+        assert "verify_" in prompt
+
+    def test_baseline_and_retrieval_prompts_unchanged(self) -> None:
+        for profile in ("baseline", "retrieval"):
+            arm = ArmConfig(arm="x", tool_profile=profile)
+            assert effective_system_prompt("base", arm) == "base"
+
+
+class TestBackCompatShim:
+    """`include_rts_tools` stays a working derived property so any
+    older caller keeps functioning."""
+
+    def test_baseline_profile_has_include_rts_false(self) -> None:
+        assert ArmConfig(arm="A", tool_profile="baseline").include_rts_tools is False
+
+    def test_retrieval_profiles_have_include_rts_true(self) -> None:
+        assert ArmConfig(arm="B", tool_profile="retrieval").include_rts_tools is True
+        assert (
+            ArmConfig(arm="C", tool_profile="retrieval_verify").include_rts_tools is True
+        )
+
+    def test_construct_from_include_rts_tools_back_compat(self) -> None:
+        """Old call sites passing include_rts_tools= still work."""
+        a = ArmConfig(arm="control", include_rts_tools=False)
+        assert a.tool_profile == "baseline"
+        b = ArmConfig(arm="treatment", include_rts_tools=True)
+        # Treatment historically meant ALL tools; map to retrieval_verify
+        # (the widest surface) for back-compat.
+        assert b.tool_profile == "retrieval_verify"
+        assert b.include_rts_tools is True

--- a/agent-bench/tests/test_cli_estimate.py
+++ b/agent-bench/tests/test_cli_estimate.py
@@ -1,0 +1,90 @@
+"""Tests for the CLI `estimate` projection (verify-v0 P4 U4).
+
+Pure math — projects tokens + USD from a per-task token model and the
+CLI args. NO API call. The `estimate_cost` function is the unit under
+test; the argparse wiring is smoke-checked via `main`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bench.cli import estimate_cost, main
+
+
+class TestEstimateCost:
+    def test_basic_projection(self) -> None:
+        # 2 tasks × 2 seeds × 3 arms = 12 runs.
+        # Per run: in_tokens=10_000, out_tokens=2_000 (defaults).
+        # input cost  = 12 * 10_000  * 3.0  / 1e6 = 0.36
+        # output cost = 12 *  2_000  * 15.0 / 1e6 = 0.36
+        est = estimate_cost(
+            tasks=2,
+            seeds=2,
+            arms=3,
+            in_per_run=10_000,
+            out_per_run=2_000,
+            in_price=3.0,
+            out_price=15.0,
+        )
+        assert est["runs"] == 12
+        assert est["input_tokens"] == 120_000
+        assert est["output_tokens"] == 24_000
+        assert abs(est["input_usd"] - 0.36) < 1e-9
+        assert abs(est["output_usd"] - 0.36) < 1e-9
+        assert abs(est["total_usd"] - 0.72) < 1e-9
+
+    def test_scales_with_arms_and_seeds(self) -> None:
+        one = estimate_cost(tasks=30, seeds=1, arms=1, in_price=3.0, out_price=15.0)
+        three = estimate_cost(tasks=30, seeds=1, arms=3, in_price=3.0, out_price=15.0)
+        assert abs(three["total_usd"] - 3 * one["total_usd"]) < 1e-6
+        assert three["runs"] == 90
+
+    def test_zero_tasks_is_zero(self) -> None:
+        est = estimate_cost(tasks=0, seeds=2, arms=3)
+        assert est["runs"] == 0
+        assert est["total_usd"] == 0.0
+
+
+class TestEstimateCli:
+    def test_estimate_subcommand_runs_without_api(self, capsys: pytest.CaptureFixture) -> None:
+        rc = main(
+            [
+                "estimate",
+                "--tasks",
+                "30",
+                "--seeds",
+                "1",
+                "--arms",
+                "3",
+                "--model",
+                "claude-sonnet-4-7-20260315",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Projected" in out or "projection" in out.lower()
+        assert "$" in out
+        assert "90" in out  # 30 * 1 * 3 runs
+
+    def test_estimate_respects_price_overrides(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        rc = main(
+            [
+                "estimate",
+                "--tasks",
+                "1",
+                "--seeds",
+                "1",
+                "--arms",
+                "1",
+                "--in-price",
+                "0",
+                "--out-price",
+                "0",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "$0.00" in out

--- a/agent-bench/tests/test_eval_verify.py
+++ b/agent-bench/tests/test_eval_verify.py
@@ -1,0 +1,169 @@
+"""Tests for per-arm verify-metric collection (verify-v0 P4 U3).
+
+`eval_verify.evaluate_arm` feeds each trajectory's final patch through
+the rts verify CLI boundary (RtsVerifyRunner) and rolls up EVR / BCIR /
+SHR / IHR / SMR per arm. The boundary is a Protocol so tests inject a
+FakeRunner with canned JSON — NO daemon, NO subprocess, NO API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from agent_bench.eval_verify import evaluate_arm
+from agent_bench.run import ArmTrajectory
+
+PINNED_MODEL = "claude-sonnet-4-7-20260315"
+
+
+def _traj(patch: str | None, task_id: str = "t") -> ArmTrajectory:
+    traj = ArmTrajectory(task_id=task_id, arm="C", model=PINNED_MODEL)
+    traj.final_patch = patch
+    traj.halt_reason = "submit" if patch else "no_patch"
+    return traj
+
+
+@dataclass
+class FakeRunner:
+    """Canned RtsVerifyRunner. Maps a patch string → verify_edit JSON,
+    and a file path → verify_file JSON. Records calls for assertions."""
+
+    edit_responses: dict[str, dict[str, Any]] = field(default_factory=dict)
+    file_responses: dict[str, dict[str, Any]] = field(default_factory=dict)
+    default_edit: dict[str, Any] = field(
+        default_factory=lambda: {"verdict": "pass", "findings": []}
+    )
+    edit_calls: list[list[dict]] = field(default_factory=list)
+    file_calls: list[tuple[str, str]] = field(default_factory=list)
+
+    def verify_edit(self, edits: list[dict]) -> dict:
+        self.edit_calls.append(edits)
+        key = edits[0].get("content", "") if edits else ""
+        return self.edit_responses.get(key, self.default_edit)
+
+    def verify_file(self, path: str, content: str) -> dict:
+        self.file_calls.append((path, content))
+        return self.file_responses.get(path, {"hallucinations": []})
+
+
+class TestEVRandBCIR:
+    def test_clean_patch_evr1_bcir0(self) -> None:
+        runner = FakeRunner(
+            edit_responses={"clean": {"verdict": "pass", "findings": []}}
+        )
+        # The patch content the runner keys on is the patch string itself
+        # (the impl wraps the patch into a single edit dict {content: patch}).
+        trajs = [_traj("clean")]
+        out = evaluate_arm(trajs, runner)
+        assert out["evr"]["numerator"] == 1
+        assert out["evr"]["denominator"] == 1
+        assert out["evr"]["rate"] == 1.0
+        assert out["bcir"]["numerator"] == 0
+        assert out["bcir"]["rate"] == 0.0
+
+    def test_fail_with_broken_caller_evr0_bcir1(self) -> None:
+        runner = FakeRunner(
+            edit_responses={
+                "bad": {
+                    "verdict": "fail",
+                    "findings": [{"kind": "broken_caller", "symbol": "foo"}],
+                }
+            }
+        )
+        out = evaluate_arm([_traj("bad")], runner)
+        assert out["evr"]["numerator"] == 0
+        assert out["evr"]["rate"] == 0.0
+        assert out["bcir"]["numerator"] == 1
+        assert out["bcir"]["rate"] == 1.0
+
+    def test_signature_break_counts_for_bcir(self) -> None:
+        runner = FakeRunner(
+            edit_responses={
+                "sig": {
+                    "verdict": "warn",
+                    "findings": [{"kind": "signature_break"}],
+                }
+            }
+        )
+        out = evaluate_arm([_traj("sig")], runner)
+        # warn verdict → not a pass → EVR numerator 0.
+        assert out["evr"]["numerator"] == 0
+        assert out["bcir"]["numerator"] == 1
+
+    def test_mixed_arm_rates(self) -> None:
+        runner = FakeRunner(
+            edit_responses={
+                "p1": {"verdict": "pass", "findings": []},
+                "p2": {"verdict": "pass", "findings": []},
+                "p3": {
+                    "verdict": "fail",
+                    "findings": [{"kind": "broken_caller"}],
+                },
+            }
+        )
+        trajs = [_traj("p1", "a"), _traj("p2", "b"), _traj("p3", "c")]
+        out = evaluate_arm(trajs, runner)
+        assert out["evr"]["numerator"] == 2 and out["evr"]["denominator"] == 3
+        assert abs(out["evr"]["rate"] - 2 / 3) < 1e-9
+        assert out["bcir"]["numerator"] == 1 and out["bcir"]["denominator"] == 3
+
+
+class TestEmptyPatchHandling:
+    def test_none_patch_is_skipped_from_denominator(self) -> None:
+        runner = FakeRunner()
+        trajs = [_traj("clean", "a"), _traj(None, "b"), _traj("", "c")]
+        out = evaluate_arm(trajs, runner)
+        # Only the one real patch counts toward EVR/BCIR denominators.
+        assert out["evr"]["denominator"] == 1
+        assert out["bcir"]["denominator"] == 1
+        assert out["skipped_empty_patches"] == 2
+
+    def test_all_empty_yields_none_rate(self) -> None:
+        out = evaluate_arm([_traj(None), _traj("")], FakeRunner())
+        assert out["evr"]["denominator"] == 0
+        assert out["evr"]["rate"] is None
+        assert out["bcir"]["rate"] is None
+
+
+class TestHallucinationMetrics:
+    def test_shr_from_verify_file_not_found(self) -> None:
+        # verify_edit reports which files it touched; verify_file then
+        # returns hallucination refs per file.
+        runner = FakeRunner(
+            edit_responses={
+                "withfile": {
+                    "verdict": "pass",
+                    "findings": [],
+                    "files": ["src/lib.rs"],
+                }
+            },
+            file_responses={
+                "src/lib.rs": {
+                    "hallucinations": [
+                        {"name": "ghost_fn", "kind": "symbol", "resolution": "not_found"},
+                        {"name": "real_fn", "kind": "symbol", "resolution": "exact"},
+                        {"name": "use foo::bar", "kind": "import", "resolution": "not_found"},
+                    ]
+                }
+            },
+        )
+        out = evaluate_arm([_traj("withfile")], runner)
+        # SHR: 1 not_found / (1 not_found + 1 exact) decidable symbols = 1/2
+        assert out["shr"]["numerator"] == 1
+        assert out["shr"]["denominator"] == 2
+        assert abs(out["shr"]["rate"] - 0.5) < 1e-9
+        # IHR: 1 not_found import / 1 decidable = 1.0
+        assert out["ihr"]["numerator"] == 1
+        assert out["ihr"]["denominator"] == 1
+        assert out["ihr"]["rate"] == 1.0
+
+    def test_smr_approximated_as_none(self) -> None:
+        # SMR is documented as approximated (call-arity unavailable from
+        # the CLI surface) — denominator 0, rate None.
+        runner = FakeRunner(
+            edit_responses={"x": {"verdict": "pass", "findings": [], "files": []}}
+        )
+        out = evaluate_arm([_traj("x")], runner)
+        assert out["smr"]["denominator"] == 0
+        assert out["smr"]["rate"] is None

--- a/agent-bench/tests/test_run_loop.py
+++ b/agent-bench/tests/test_run_loop.py
@@ -15,8 +15,6 @@ import pytest
 
 from agent_bench.report import (
     aggregate_arm,
-    arm_summary_json,
-    arm_summary_markdown,
     comparison_markdown,
     wilson_ci,
     write_arm_outputs,
@@ -30,8 +28,7 @@ from agent_bench.run import (
     run_one_arm,
     tool_use_ratio,
 )
-from tests.conftest import FakeAnthropicClient, FakeMessageResponse, FakeUsage
-
+from tests.conftest import FakeAnthropicClient, FakeMessageResponse
 
 PINNED_MODEL = "claude-sonnet-4-7-20260315"
 
@@ -261,7 +258,7 @@ class TestRunOneArm:
         client = FakeAnthropicClient(
             [FakeMessageResponse(content=[])]
         )
-        with pytest.raises(ValueError, match="treatment arm requires"):
+        with pytest.raises(ValueError, match="requires an MCP bridge"):
             run_one_arm(
                 client=client,
                 task=make_task(tmp_path),

--- a/agent-bench/tests/test_stats.py
+++ b/agent-bench/tests/test_stats.py
@@ -1,0 +1,200 @@
+"""Tests for the A/B/C statistics layer (verify-v0 P4 U2).
+
+Covers:
+  - per-tool breakdown + verify_tools_total in ArmAggregate
+  - the hand-rolled McNemar paired test (exact + corrected, no scipy)
+  - the 3-arm comparison report (per-arm CIs + 3 McNemar deltas)
+
+No Anthropic API, no daemon.
+"""
+
+from __future__ import annotations
+
+from agent_bench.report import (
+    aggregate_arm,
+    mcnemar,
+    multi_arm_comparison_json,
+    multi_arm_comparison_markdown,
+)
+from agent_bench.run import ArmTrajectory, ToolCall
+
+PINNED_MODEL = "claude-sonnet-4-7-20260315"
+
+
+def _traj(
+    arm: str,
+    *,
+    names: list[str] | None = None,
+    halt_reason: str = "submit",
+    task_id: str = "t",
+) -> ArmTrajectory:
+    traj = ArmTrajectory(task_id=task_id, arm=arm, model=PINNED_MODEL)
+    for n in names or []:
+        backend = "rts_mcp" if n.startswith("mcp__rts__") else "bash"
+        traj.tool_calls.append(
+            ToolCall(turn=1, name=n, arguments={}, backend=backend, elapsed_s=0.01)
+        )
+    traj.halt_reason = halt_reason
+    return traj
+
+
+# --- McNemar -------------------------------------------------------
+
+
+class TestMcNemar:
+    def test_no_discordant_pairs_returns_p1(self) -> None:
+        # All pairs concordant: both pass or both fail.
+        a = [True, True, False, False]
+        b = [True, True, False, False]
+        r = mcnemar(a, b)
+        assert r["b01"] == 0 and r["b10"] == 0
+        assert r["p_value"] == 1.0
+        assert r["method"] == "none"
+
+    def test_strongly_discordant_10_0_is_significant(self) -> None:
+        # b fixes 10 that a failed, breaks 0: exact two-sided p tiny.
+        a = [False] * 10
+        b = [True] * 10
+        r = mcnemar(a, b)
+        assert r["b01"] == 10  # a fail, b pass
+        assert r["b10"] == 0
+        assert r["method"] == "exact"
+        # Exact two-sided p for (10,0), n=10, p=0.5 = 2 * 0.5^10 = 1/512.
+        assert abs(r["p_value"] - (2 * 0.5**10)) < 1e-12
+        assert r["p_value"] < 0.05
+
+    def test_balanced_5_5_is_p1(self) -> None:
+        a = [False] * 5 + [True] * 5
+        b = [True] * 5 + [False] * 5
+        r = mcnemar(a, b)
+        assert r["b01"] == 5 and r["b10"] == 5
+        assert r["method"] == "exact"
+        assert r["p_value"] == 1.0  # symmetric → max p
+
+    def test_textbook_exact_b01_1_b10_12(self) -> None:
+        # Discordant (1, 12), n=13 < 25 → exact binomial two-sided.
+        # k=min=1, n=13: two-sided p = 2 * sum_{i=0}^{1} C(13,i) 0.5^13
+        #   = 2 * (1 + 13) / 8192 = 28/8192 = 0.00341796875
+        a = [False] + [True] * 12
+        b = [True] + [False] * 12
+        r = mcnemar(a, b)
+        assert r["b01"] == 1 and r["b10"] == 12
+        assert r["method"] == "exact"
+        assert abs(r["p_value"] - 28 / 8192) < 1e-12
+
+    def test_large_discordant_uses_corrected_chi2(self) -> None:
+        # n = b01+b10 = 40 ≥ 25 → continuity-corrected chi-square.
+        a = [False] * 30 + [True] * 10
+        b = [True] * 30 + [False] * 10
+        r = mcnemar(a, b)
+        assert r["b01"] == 30 and r["b10"] == 10
+        assert r["method"] == "chi2_corrected"
+        # chi2 = (|30-10|-1)^2 / 40 = 361/40 = 9.025
+        assert abs(r["statistic"] - 9.025) < 1e-9
+        # p < 0.05 for chi2 ~9.0 on df=1.
+        assert r["p_value"] < 0.05
+
+    def test_symmetry_p_a_b_equals_p_b_a(self) -> None:
+        a = [False] + [True] * 12 + [False] * 5
+        b = [True] + [False] * 12 + [False] * 5
+        assert abs(mcnemar(a, b)["p_value"] - mcnemar(b, a)["p_value"]) < 1e-12
+        # Also for the corrected branch.
+        a2 = [False] * 30 + [True] * 10 + [True] * 3
+        b2 = [True] * 30 + [False] * 10 + [True] * 3
+        assert abs(mcnemar(a2, b2)["p_value"] - mcnemar(b2, a2)["p_value"]) < 1e-12
+
+    def test_length_mismatch_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="length"):
+            mcnemar([True], [True, False])
+
+
+# --- Per-tool breakdown -------------------------------------------
+
+
+class TestPerToolBreakdown:
+    def test_counts_by_bare_name(self) -> None:
+        trajs = [
+            _traj(
+                "C",
+                names=[
+                    "mcp__rts__find_symbol",
+                    "mcp__rts__find_symbol",
+                    "mcp__rts__verify_symbol",
+                    "Bash",
+                ],
+                task_id="a",
+            ),
+            _traj(
+                "C",
+                names=["mcp__rts__verify_edit", "mcp__rts__grep"],
+                task_id="b",
+            ),
+        ]
+        agg = aggregate_arm("C", trajs)
+        assert agg.tool_calls_by_name["find_symbol"] == 2
+        assert agg.tool_calls_by_name["verify_symbol"] == 1
+        assert agg.tool_calls_by_name["verify_edit"] == 1
+        assert agg.tool_calls_by_name["grep"] == 1
+        assert agg.tool_calls_by_name["Bash"] == 1
+        # verify_* total = verify_symbol + verify_edit = 2
+        assert agg.verify_tools_total == 2
+
+    def test_zero_verify_when_none(self) -> None:
+        agg = aggregate_arm("A", [_traj("A", names=["Bash", "Bash"])])
+        assert agg.verify_tools_total == 0
+
+
+# --- 3-arm comparison ----------------------------------------------
+
+
+def _arm(name: str, *, n: int, completed: int) -> object:
+    trajs = []
+    for i in range(n):
+        hr = "submit" if i < completed else "turn_cap"
+        trajs.append(
+            _traj(name, names=["mcp__rts__find_symbol", "Bash"], halt_reason=hr, task_id=f"{name}-{i}")
+        )
+    return aggregate_arm(name, trajs)
+
+
+class TestMultiArmComparison:
+    def test_json_includes_three_arms_and_three_deltas(self) -> None:
+        a = _arm("A", n=6, completed=2)
+        b = _arm("B", n=6, completed=4)
+        c = _arm("C", n=6, completed=5)
+        paired = {
+            "B_vs_A": ([True, False] * 3, [True, True] * 3),
+            "C_vs_B": ([True, True] * 3, [True, True] * 3),
+            "C_vs_A": ([True, False] * 3, [True, True] * 3),
+        }
+        verify_metrics = {
+            "A": {"evr": None},
+            "B": {"evr": None},
+            "C": {"evr": 0.8},
+        }
+        out = multi_arm_comparison_json([a, b, c], paired, verify_metrics)
+        assert out["schema"].startswith("agent-bench/")
+        assert {arm["arm"] for arm in out["arms"]} == {"A", "B", "C"}
+        assert set(out["mcnemar"]) == {"B_vs_A", "C_vs_B", "C_vs_A"}
+        for key in ("B_vs_A", "C_vs_B", "C_vs_A"):
+            assert "p_value" in out["mcnemar"][key]
+        # per-arm verify metric block present
+        assert out["arms_by_name"]["C"]["verify_metrics"]["evr"] == 0.8
+
+    def test_markdown_renders_all_arms_and_deltas(self) -> None:
+        a = _arm("A", n=4, completed=1)
+        b = _arm("B", n=4, completed=2)
+        c = _arm("C", n=4, completed=3)
+        paired = {
+            "B_vs_A": ([False, False, True, True], [True, True, True, True]),
+            "C_vs_B": ([True, True, True, True], [True, True, True, True]),
+            "C_vs_A": ([False, False, True, True], [True, True, True, True]),
+        }
+        md = multi_arm_comparison_markdown(
+            [a, b, c], paired, {"A": {}, "B": {}, "C": {}}
+        )
+        assert "A" in md and "B" in md and "C" in md
+        assert "McNemar" in md
+        assert "B_vs_A" in md or "B vs A" in md

--- a/changelog.d/166-feat-abc-benchmark-harness.md
+++ b/changelog.d/166-feat-abc-benchmark-harness.md
@@ -1,0 +1,44 @@
+### Feat: A/B/C benchmark harness extensions (verify-v0 P4, build-only)
+
+Extends `agent-bench` from a 2-arm A/B into a 3-arm **A/B/C** benchmark that
+separates the effect of rts *retrieval* tools from the *verify_\** tools. This
+is BUILD-ONLY — every unit is unit-tested with mocks (`FakeAnthropicClient`,
+`FakeBridge`, `FakeRunner`); ZERO live model/API calls and ZERO real daemon
+dependencies in the suite. The live run is gated on the deferred PR-B infra.
+
+- **Arm tool profiles** (`agent_bench/run.py`) — explicit allowlists
+  `RETRIEVAL_TOOLS` (find_symbol, grep, read_symbol, read_symbol_at, read_range,
+  outline_workspace, find_callers, impact_of) and `VERIFY_TOOLS` (verify_symbol,
+  verify_signature, verify_import, verify_claims, verify_impact, verify_edit).
+  `ArmConfig.tool_profile` ∈ {`baseline`, `retrieval`, `retrieval_verify`} drives
+  `build_tool_list`, which intersects the bridge's live listing with the active
+  allowlist — a future rts tool can never silently leak into an arm. Arm C
+  ("retrieval_verify") appends a one-line `VERIFY_NUDGE` to its system prompt
+  via `effective_system_prompt`. `include_rts_tools` is kept as a back-compat
+  shim derived from the profile.
+
+- **Statistics** (`agent_bench/report.py`) — per-tool breakdown
+  (`tool_calls_by_name`, `verify_tools_total`) on `ArmAggregate`; a hand-rolled
+  `mcnemar()` paired test (NO scipy: exact binomial two-sided for <25 discordant
+  pairs, else continuity-corrected χ²(df=1) via `math.erfc`); and
+  `multi_arm_comparison_json/markdown` rendering per-arm Wilson CIs, tokens,
+  wall-clock, verify metrics, the per-tool breakdown, and the three McNemar
+  deltas (B vs A, C vs B, C vs A). Schema-versioned `agent-bench/multi-arm/v1`.
+
+- **Per-arm verify metrics** (`agent_bench/eval_verify.py`) — offline (no model)
+  `evaluate_arm(trajectories, runner)` computes EVR (pass-verdict rate), BCIR
+  (broken_caller/signature_break introduction rate), and SHR/IHR from the verify
+  CLI hallucination output, mirroring `rts-bench`'s numerator/denominator/rate
+  metric shape (rate `None` on empty denominator). SMR is approximated as `None`
+  (the file-level `rts verify --json` surface lacks call-arity data). The
+  `RtsVerifyRunner` Protocol is the test seam; the real `CliRtsVerifyRunner`
+  shells out to `rts verify-edit` / `rts verify`.
+
+- **CLI `estimate`** (`agent_bench/cli.py`) — `agent-bench estimate --tasks
+  --seeds --arms --model --in-price --out-price` projects token + USD spend
+  (`runs = tasks × seeds × arms`, priced per MTok) with NO API call. Price
+  defaults to Sonnet list ($3 in / $15 out per MTok).
+
+- **Smoke corpus** `agent-bench/corpus/swe-bench-lite-smoke.json` — 4 real
+  SWE-bench_Lite instance ids with clearly-labelled placeholder statements for
+  cheap wiring tests (not the full curated corpus).

--- a/docs/plans/2026-06-19-003-feat-abc-benchmark-harness-plan.md
+++ b/docs/plans/2026-06-19-003-feat-abc-benchmark-harness-plan.md
@@ -1,0 +1,83 @@
+---
+title: "feat: A/B/C verification benchmark harness (verify-v0 P4, build-only)"
+type: feat
+status: draft
+date: 2026-06-19
+origin: docs/plans/2026-06-18-001-feat-verification-anti-hallucination-layer-plan.md
+---
+
+# feat: A/B/C verification benchmark harness (verify-v0 P4)
+
+**Goal:** Make `agent-bench` able to run the paired **A/B/C** benchmark — A (baseline: bash+read), B (rts *retrieval* tools), C (retrieval **+** the `verify_*` tools wired into the loop) — and report task success + tokens + the SHR/SMR/IHR/BCIR/EVR metrics per arm with statistical rigor (mean±95% CI, McNemar paired test). **This plan is BUILD-ONLY**: it ships the harness extensions + tests with NO live model calls; the actual benchmark run is a separate, budget-gated step (see Cost).
+
+## Why build-only
+P4's headline is *measured numbers*, which require real model API runs over SWE-bench-lite (and Docker patch eval). That spends real budget and depends on infra the harness still defers (the corpus, per-task isolation, Docker eval — agent-bench PR-B). So this plan lands the pieces that make an eventual run produce the *correct A/B/C comparison*, all unit-tested against the existing `FakeAnthropicClient`/pytest mocks, and reports a cost estimate so the run can be authorized deliberately.
+
+## Grounding (from exploration)
+agent-bench (Python, PR-A shipped): `run.py` (`run_one_arm`, `ArmConfig{arm, include_rts_tools}`, `build_tool_list` ~267), `mcp_bridge.py` (`list_tools` returns ALL rts tools — verify_* included), `report.py` (`ArmAggregate`, `aggregate_arm`, `wilson_ci`, `arm_summary_*`/`comparison_markdown`), `tests/` (`FakeAnthropicClient`, 28 mock tests). **Gaps:** Arm B can't be retrieval-only (no tool profile); no per-tool breakdown; no McNemar; no per-arm verify-metric collection; corpus/Docker eval/cost-cap deferred (PR-B).
+
+---
+
+## Implementation Units (all build-only, pytest-mocked)
+
+### U1 — Arm tool profiles (make A/B/C distinct)
+**Files:** `agent_bench/run.py` (`ArmConfig`, `build_tool_list`), `tests/test_run_loop.py`.
+
+Replace the boolean `include_rts_tools` with a **tool profile** so the three arms expose genuinely different surfaces:
+- `ToolProfile.Baseline` → bash + read + submit_patch only (Arm A).
+- `ToolProfile.Retrieval` → + the rts **retrieval** tools only: `find_symbol`, `grep`, `read_symbol`, `read_symbol_at`, `read_range`, `outline_workspace`, `find_callers`, `impact_of` (Arm B).
+- `ToolProfile.RetrievalVerify` → Retrieval **+** the verify tools: `verify_symbol`, `verify_signature`, `verify_import`, `verify_claims`, `verify_impact`, `verify_edit` (Arm C).
+
+`build_tool_list` filters `bridge.list_tools()` by the profile's allowlist (an explicit frozenset of `mcp__rts__*` names, so a newly-added rts tool can't silently leak into an arm). Keep `include_rts_tools` as a derived shim for back-compat if cheap. Arm C also gets a **verify nudge** appended to its system prompt ("before asserting a symbol exists or editing a signature, verify it") so "verify wired into the loop" is real, not just tool availability. **Tests:** each profile yields exactly its tool set; an unknown rts tool name is excluded from Baseline/Retrieval; Arm C's system prompt carries the verify nudge.
+
+### U2 — Statistics: per-tool breakdown, McNemar, 3-arm comparison
+**Files:** `agent_bench/report.py`, `tests/test_report.py` (or extend `test_run_loop.py`).
+
+- **Per-tool breakdown:** `ArmAggregate.tool_calls_by_name: dict[str,int]` + `verify_tools_total`, computed in `aggregate_arm` from `ToolCall.name`/`backend`. Surfaces "did arm C actually *use* verify_*".
+- **McNemar paired test** (pure, no scipy dep — implement the exact/continuity-corrected formula): `mcnemar(a_success: list[bool], b_success: list[bool]) -> {b01, b10, statistic, p_value}` over the **paired per-task** success vectors. Use the continuity-corrected χ² for discordant counts ≥ ~25, exact binomial otherwise; document the rule. Return p=1.0 when no discordant pairs.
+- **3-arm comparison report:** generalize `comparison_markdown` to A/B/C — per-arm success-rate ± Wilson CI, tokens/$/wall-clock, the per-arm verify-metric block (from U3), and the paired McNemar deltas (B vs A, C vs B, C vs A). Schema-versioned JSON + markdown.
+- **Tests:** McNemar against hand-computed fixtures (discordant 10/0 → significant; 5/5 → p=1; 0/0 → p=1; a known textbook 2×2); per-tool breakdown counts; the 3-arm report renders all arms + deltas.
+
+### U3 — Per-arm verify-metric collection (`eval_verify.py`)
+**Files:** new `agent_bench/eval_verify.py`, `tests/test_eval_verify.py`.
+
+Post-run (offline, no model), feed each arm's produced code through the rts verify surface to compute the §5 metrics PER ARM:
+- From each `ArmTrajectory.final_patch` (+ the touched files' post-edit content), call `rts verify-edit --json` → **EVR** (verdict `pass`) and **BCIR** (≥1 `broken_caller`/`signature_break`).
+- Extract the patch's symbol/import references (reuse `rts-bench verify`'s pipeline via the CLI, or `rts verify --json` on the post-edit files) → **SHR / IHR / SMR** per arm.
+- Aggregate with honest denominators (exclude `indeterminate`), mirroring `rts-bench`'s `HallucinationReport` conventions.
+Define a thin `RtsVerifyRunner` boundary (invokes the `rts`/`rts-bench` CLI) so tests inject a **fake runner** with canned JSON — no daemon, no model. **Tests:** a trajectory with a known breaking patch → EVR 0, BCIR 1; a clean patch → EVR 1, BCIR 0; SHR from canned not_found counts; empty/`None` patch handled.
+
+### U4 — Wiring + a tiny pinned smoke corpus + docs
+**Files:** `agent_bench/cli.py` (wire `report` over an arms list incl. C; a `--dry-run`/`--estimate` cost mode that needs no API), `corpus/swe-bench-lite-smoke.json` (3–5 hand-pinned public SWE-bench-lite instance ids — for a cheap smoke run, not the full set), `agent-bench/README.md` + root changelog.
+
+- A **pre-flight cost estimate** (`agent_bench estimate --tasks N --seeds S --arms 3 --model <id>`) prints projected tokens + $ from the per-task token model — **no API call**. This is the gate the user reads before authorizing a run.
+- Document the run procedure + that A/B/C requires the deferred PR-B infra (corpus, isolation, Docker eval) to produce task-success numbers; the harness + metrics + stats are ready now.
+
+---
+
+## Cost estimate (for the eventual run — NOT spent by this plan)
+Per task per arm (SWE-bench-lite, 20-turn cap, rts arms use less context): ~30–120k input + 8–20k output tokens. For **3 arms**:
+- **Pilot** (N=30 tasks, S=1 seed, Sonnet 4.x): ~270 task-runs ≈ **$30–60**.
+- **Publishable** (N=300, S=3, Sonnet): ~2,700 runs ≈ **$1,000–1,800**.
+- Opus ≈ 4–5× the above.
+- The post-run verify-metric pass (U3) is offline CLI work — negligible $ (no model).
+A pre-flight `estimate` (U4) prints the figure for the exact run before any spend.
+
+## Acceptance criteria
+- Three distinct arm profiles; A/B/C tool surfaces verified by tests; Arm C carries the verify nudge.
+- McNemar implemented + tested against hand-computed fixtures; per-tool breakdown + 3-arm comparison render.
+- `eval_verify` computes per-arm EVR/BCIR/SHR/IHR/SMR from trajectories via an injectable runner; tested with fakes.
+- `agent_bench estimate` prints a token/$ projection with no API call.
+- `uv run pytest` green; **zero live model calls in the test suite.**
+
+## Deferred (needs budget / infra, NOT this plan)
+- The actual benchmark RUN + the published numbers (budget-gated).
+- The full curated SWE-bench-lite corpus, per-task isolation, Docker patch eval, CI cadence (agent-bench PR-B / U2.5–U2.12).
+
+## Requirements trace
+| Spec § | Covered by |
+| :-- | :-- |
+| §7 arms A/B/C | U1 (tool profiles) |
+| §7 metrics per arm (success/tokens + SHR/SMR/IHR/BCIR/EVR) | U2 (success/tokens/breakdown) + U3 (verify metrics) |
+| §7 statistical rigor (CI, McNemar) | U2 |
+| §7 the RUN + headline numbers | DEFERRED (budget-gated; `estimate` gates it) |


### PR DESCRIPTION
## Summary

verify-v0 **Phase 4** (build-only): makes `agent-bench` able to run the paired **A/B/C** benchmark and report the verification metrics with statistical rigor. **No model budget is spent by this PR** — it ships the harness extensions + tests (zero live API/daemon calls); the actual run is a separate, budget-gated step.

Plan: `docs/plans/2026-06-19-003-feat-abc-benchmark-harness-plan.md`.

## Why build-only
P4's headline is *measured numbers*, which need real model runs over SWE-bench-lite + Docker patch eval — real budget, plus harness infra still deferred (corpus, isolation, eval; agent-bench PR-B). This PR lands the pieces that make an eventual run produce the **correct A/B/C comparison**, all unit-tested with mocks, and a cost `estimate` so the run can be authorized deliberately.

## What's in it
- **U1 — Arm tool profiles.** Three genuinely distinct surfaces: A `baseline` (bash+read), B `retrieval` (rts retrieval tools only), C `retrieval_verify` (retrieval **+** the `verify_*` tools, with a verify nudge appended to Arm C's system prompt). `build_tool_list` filters the bridge listing by an explicit per-profile allowlist — a verify tool **cannot** leak into Arm B (the prior harness exposed *all* rts tools to Treatment, which would have made A/B/C meaningless).
- **U2 — Statistics.** Pure **McNemar** paired test (no scipy: exact binomial for small discordant n, continuity-corrected χ² via `erfc` otherwise), per-tool breakdown (`tool_calls_by_name`, `verify_tools_total`), and a 3-arm comparison report (per-arm success ± Wilson CI, tokens, the verify-metric block, and the B-vs-A / C-vs-B / C-vs-A McNemar deltas).
- **U3 — Per-arm verify metrics** (`eval_verify.py`). Offline, feeds each arm's produced patches through the `rts verify-edit`/`rts verify` CLI (behind an injectable `RtsVerifyRunner`) to compute **EVR/BCIR/SHR/IHR** per arm (SMR approximated to None at the file-level surface, documented). Honest denominators; empty patches skipped.
- **U4 — Cost estimate + smoke corpus + docs.** `agent_bench estimate --tasks N --seeds S --arms 3 --model …` prints projected tokens + USD with **no API call**; a 3–5 instance smoke corpus; README + changelog.

## Cost estimate for the eventual run (NOT spent here)
- Pilot (N=30, S=1, 3 arms, Sonnet): ~$30–60.
- Publishable (N=300, S=3, Sonnet): ~$1,000–1,800. Opus ≈ 4–5×.
- `agent_bench estimate` prints the figure for the exact run before any spend.

## Process
Subagent-driven (implementer + spec/quality review). The review specifically re-derived the McNemar math by hand against the fixtures and verified arm isolation (Arm B provably excludes every `verify_*` tool; the nudge is the only cross-arm prompt delta) — the two things that would invalidate the benchmark if wrong. Both correct.

## Test plan
- [x] `uv run pytest` (from `agent-bench/`) — 58 passed, 5 skipped (the skips are the real-daemon `test_mcp_bridge` integration tests, skipped without built binaries — by design)
- [x] **Zero live API/daemon calls** in the suite (FakeAnthropicClient / FakeBridge / FakeRunner)
- [x] McNemar verified against hand-computed fixtures; arm-isolation tests assert B excludes verify_*

## Deferred (needs budget / infra)
- The actual benchmark RUN + published numbers (budget-gated; `estimate` gates it).
- Full curated SWE-bench-lite corpus, per-task isolation, Docker patch eval, CI cadence (agent-bench PR-B).
- `eval_verify` real-run fidelity: `_patch_to_edits` currently wraps the diff as one blob; the live-run PR should parse per-file post-edit contents (depends on the deferred checkout/isolation infra).