### PR TITLE
feat: agent-bench run infrastructure — build-only (PR-B)

### DIFF
--- a/agent-bench/README.md
+++ b/agent-bench/README.md
@@ -200,12 +200,17 @@ budget, same lifecycle.
 
 ## Cost expectations
 
-Per the [research](../docs/plans/2026-05-16-001-feat-agent-habit-and-benchmark-plan.md#risk-analysis--mitigation):
+The `estimate` subcommand projects `tasks × seeds × arms` runs, each at a
+per-run token model (defaults ~120k in / 8k out), priced by `--in-price` /
+`--out-price` (Sonnet list by default). Examples for the A/B/C (3-arm) design:
 
-| Configuration | Estimate per full bench run (30 tasks × 2 arms) |
+| Configuration | Projected spend |
 |---|---|
-| Sonnet 4 | ~$50-100 |
-| Opus 4 | ~$300+ |
+| Pilot — 30 tasks × 1 seed × 3 arms, Sonnet | ~$30–60 |
+| Publishable — 300 tasks × 3 seeds × 3 arms, Sonnet | ~$1,000–1,800 |
+| Opus | ≈ 4–5× the above |
 
-Pre-flight estimates `n × mean_tokens × $/Mtok × 2 × 1.5_safety`
-before any API call; hard ceiling aborts the run at 90 % consumed.
+`run --max-usd <cap>` computes this projection up front and **aborts before any
+API call** if it exceeds the cap (a hard pre-flight gate — there is no
+mid-run/runtime abort). Run `agent_bench estimate ...` for the exact figure of a
+specific run before authorizing spend.

--- a/agent-bench/README.md
+++ b/agent-bench/README.md
@@ -84,46 +84,69 @@ uv run agent-bench estimate --tasks 30 --seeds 1 --arms 3 \
 # Opus pricing:
 uv run agent-bench estimate --tasks 30 --arms 3 --in-price 15 --out-price 75
 
-# Run a dry-run against a 3-task smoke subset (no API key needed
-# if --mock is passed; otherwise uses ANTHROPIC_API_KEY)
-uv run agent-bench --mock --tasks smoke
-
-# Full bench, Sonnet default, $100 budget cap:
-ANTHROPIC_API_KEY=sk-ant-... uv run agent-bench \
-    --tasks corpus/swe-bench-lite-v1.json \
+# Run the A/B/C bench. The PRE-FLIGHT budget gate computes the projected
+# spend and ABORTS (nonzero exit) BEFORE constructing any client or
+# making any API call if it exceeds --max-usd. A real run needs:
+#   - ANTHROPIC_API_KEY in the environment
+#   - git on PATH (to clone + checkout each task at base_commit)
+#   - the rts-mcp / rts-daemon binaries (for the retrieval / verify arms)
+ANTHROPIC_API_KEY=sk-ant-... uv run agent-bench run \
+    --corpus corpus/swe-bench-lite-smoke.json \
+    --arms baseline,retrieval,retrieval_verify \
+    --seeds 1 \
     --model claude-sonnet-4-7-20260315 \
-    --budget-usd 100
+    --max-usd 100 \
+    --out bench-results/ \
+    [--resume] [--limit N]
 
-# Run with Opus for release-gate confidence (more expensive):
-ANTHROPIC_API_KEY=sk-ant-... uv run agent-bench \
-    --tasks corpus/swe-bench-lite-v1.json \
-    --model claude-opus-4-7-20260315 \
-    --budget-usd 400
+# Re-render the reports from an existing run dir — NO API call. Reads the
+# stored trajectory JSONs and re-aggregates.
+uv run agent-bench report --runs bench-results/runs/<run-id>
 ```
+
+`--max-usd` is a **hard pre-flight gate**: `run` calls `estimate_cost`
+for `tasks × seeds × arms` and, if the projection exceeds the cap, prints
+an `ABORT:` line and exits nonzero **before any Anthropic client is
+constructed**. `--resume` skips any `(task, arm, seed)` tuple whose
+trajectory file already exists on disk, so an interrupted run picks up
+where it left off without re-paying for completed work.
 
 ## Output
 
 ```
-bench-results/<version>/
-├── control-summary.json     # machine-readable per-task results
-├── control-summary.md       # human-readable aggregate
-├── treatment-summary.json
-├── treatment-summary.md
-└── comparison.md            # side-by-side with deltas + Wilson CIs
+<out>/runs/<run-id>/
+├── raw/<arm>/<instance_id>__seed<seed>.json   # per-run ArmTrajectory.to_dict()
+├── <arm>-summary.json                         # machine-readable per-arm
+├── <arm>-summary.md                           # human-readable per-arm
+├── comparison.json                            # A/B/C multi-arm payload
+└── comparison.md                              # A/B/C side-by-side + McNemar
 ```
 
-The summary files are **committed to the repo** so the trend across
-releases is part of the git history. Raw trajectories (per-task
-turn-by-turn JSONL) are NOT committed (volume + privacy of any
-embedded API outputs); they're written to `runs/<run-id>/` which is
-gitignored.
+The trajectory file name encodes the `(instance_id, seed)` tuple so
+`--resume` can detect completed runs and the reporter can re-aggregate
+offline. The summary files can be **committed to the repo** so the trend
+across releases lives in git history; raw trajectories are large and may
+embed API output, so keep `runs/` gitignored if that's a concern.
 
-> **Note:** `estimate` is build-only and makes ZERO API calls. The
-> actual A/B/C model run — budget enforcement, per-task isolation,
-> resume-from-checkpoint, Docker patch eval, and CI — ships with the
-> deferred **PR-B** infrastructure. A cheap smoke corpus
-> (`corpus/swe-bench-lite-smoke.json`, 4 real SWE-bench_Lite instance
-> ids with placeholder statements) is included for wiring tests.
+> **Note:** `estimate` and `report` make ZERO API calls. `run` is
+> **build-only** in this milestone: the harness runs **end-to-end with a
+> fake client** (see `tests/test_cli_run.py`), and a real run is gated on
+> a budget (`--max-usd`) plus the live infrastructure below. A cheap
+> smoke corpus (`corpus/swe-bench-lite-smoke.json`, 4 real SWE-bench_Lite
+> instance ids with placeholder statements) is included for wiring tests.
+
+### What a REAL run needs
+
+- `ANTHROPIC_API_KEY` in the environment (the agent loop hits the API).
+- `git` on PATH — `GitRepoProvider` clones each task's repo and checks
+  out `base_commit` into an isolated per-task tempdir.
+- The `rts-mcp` / `rts-daemon` binaries for the `retrieval` /
+  `retrieval_verify` arms (the `baseline` arm needs neither).
+- **Docker + x86_64 + the `swebench` harness + multi-GB per-repo images**
+  for *real* task success (FAIL_TO_PASS resolution via
+  `eval_docker.evaluate_patches`). Without Docker results, success falls
+  back to a `halt_reason == "submit"` **proxy**, labelled as such in the
+  report.
 
 ## What this does NOT do (yet)
 
@@ -141,18 +164,31 @@ gitignored.
 agent-bench/
 ├── agent_bench/
 │   ├── mcp_bridge.py   # spawn rts-mcp, JSON-RPC stdio, list_tools, call_tool
-│   ├── run.py          # one task → two arms → trajectory
-│   ├── isolation.py    # per-task tempdir + per-task daemon socket
-│   ├── preflight.py    # cost estimate + budget caps + confound asserts
-│   ├── report.py       # tool-use ratio + Wilson CI + Markdown summary
-│   └── cli.py          # `agent-bench` entry point
+│   ├── run.py          # one task → one arm → trajectory
+│   ├── isolation.py    # per-task tempdir + per-task daemon socket (boundaries)
+│   ├── corpus.py       # load Task records from JSON or a dataset id (boundary)
+│   ├── eval_verify.py  # offline EVR/BCIR/SHR/IHR via the rts verify CLI boundary
+│   ├── eval_docker.py  # swebench-in-Docker patch eval + success vectors (boundary)
+│   ├── report.py       # tool-use ratio + Wilson CI + McNemar + Markdown
+│   └── cli.py          # `agent-bench` entry point: estimate / run / report
 ├── corpus/
-│   └── swe-bench-lite-v1.json   # curated 30-instance subset
-├── prompts/
-│   └── system.md       # SHA-locked across arms
+│   └── swe-bench-lite-smoke.json   # cheap smoke subset for wiring tests
 └── tests/
     └── test_mcp_bridge.py   # integration test against real rts-mcp
 ```
+
+Every external boundary is a `Protocol` injected into the code under
+test, so the suite runs with **zero** real model / API / daemon / Docker
+/ network:
+
+| Boundary | Real implementation | Test fake |
+|---|---|---|
+| `run.AnthropicClient` | `anthropic.Anthropic` | `FakeAnthropicClient` |
+| `isolation.RepoProvider` | `GitRepoProvider` (git clone + checkout) | `FakeRepoProvider` (fixture tree) |
+| `isolation.DaemonHandle` | `RtsDaemonHandle` (spawn rts-daemon) | fake socket path |
+| `corpus.CorpusLoader` | `HuggingFaceLoader` | `FakeLoader` (canned rows) |
+| `eval_verify.RtsVerifyRunner` | `CliRtsVerifyRunner` (`rts verify`) | `FakeRunner` |
+| `eval_docker.PatchEvalRunner` | swebench-in-Docker | `FakePatchEvalRunner` |
 
 See [`agent_bench/mcp_bridge.py`](agent_bench/mcp_bridge.py) — the
 single load-bearing component is the bridge that lets Anthropic's

--- a/agent-bench/agent_bench/cli.py
+++ b/agent-bench/agent_bench/cli.py
@@ -19,10 +19,14 @@ report, resume).
 from __future__ import annotations
 
 import argparse
+import json
 import sys
+from collections.abc import Callable
 from importlib.metadata import version as _pkg_version
+from pathlib import Path
+from typing import Any
 
-__all__ = ["main", "estimate_cost"]
+__all__ = ["main", "estimate_cost", "run_command", "report_command"]
 
 
 # Default per-task-run token model. A "run" is one (task, seed, arm)
@@ -111,6 +115,315 @@ How to use what's already shipped:
 """
 
 
+# --- run / report subcommands ------------------------------------
+#
+# `run` orchestrates: corpus load → PRE-FLIGHT budget gate → per
+# (task, arm, seed) isolation + run_one_arm → trajectory JSON → reports.
+# Every external boundary (Anthropic client, git, daemon, MCP bridge,
+# verify CLI) is injected so the whole command is unit-testable with
+# fakes and a fixed run_id. `report` re-renders from stored JSONs with
+# NO client/API.
+
+# Default system prompt for the agent loop. SHA-locked across arms (the
+# only per-arm delta is Arm C's verify nudge, applied inside run.py).
+_DEFAULT_SYSTEM_PROMPT = (
+    "You are a software engineer fixing a bug in a repository. "
+    "Investigate the codebase, make a minimal correct change, and call "
+    "submit_patch with a unified diff once you are confident."
+)
+
+# Each arm name maps to its run.ArmConfig tool profile.
+_ARM_PROFILES = {
+    "baseline": "baseline",
+    "retrieval": "retrieval",
+    "retrieval_verify": "retrieval_verify",
+}
+
+
+def _real_client_factory(model: str) -> Any:
+    """Construct the real anthropic.Anthropic client (real runs only).
+
+    Imported lazily so the test suite — which injects a fake — never
+    needs the SDK configured or an API key present.
+    """
+    import anthropic
+
+    return _AnthropicAdapter(anthropic.Anthropic())
+
+
+class _AnthropicAdapter:
+    """Adapt anthropic.Anthropic to the run-loop's `create(...)` shape."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client.messages.create(**kwargs)
+
+
+def _trajectory_filename(instance_id: str, seed: int) -> str:
+    return f"{instance_id}__seed{seed}.json"
+
+
+def _load_trajectories(raw_dir: Path) -> list[Any]:
+    """Reconstruct ArmTrajectory objects from stored raw JSON files."""
+    from agent_bench.run import ArmTrajectory, ToolCall
+
+    trajs: list[Any] = []
+    for path in sorted(raw_dir.glob("*.json")):
+        body = json.loads(path.read_text())
+        traj = ArmTrajectory(
+            task_id=body["task_id"],
+            arm=body["arm"],
+            model=body["model"],
+            messages=body.get("messages", []),
+            final_patch=body.get("final_patch"),
+            halt_reason=body.get("halt_reason", ""),
+            wall_clock_s=body.get("wall_clock_s", 0.0),
+            input_tokens=body.get("input_tokens", 0),
+            output_tokens=body.get("output_tokens", 0),
+        )
+        for tc in body.get("tool_calls", []):
+            traj.tool_calls.append(
+                ToolCall(
+                    turn=tc["turn"],
+                    name=tc["name"],
+                    arguments=tc.get("arguments", {}),
+                    backend=tc["backend"],
+                    elapsed_s=tc.get("elapsed_s", 0.0),
+                    error=tc.get("error"),
+                )
+            )
+        trajs.append(traj)
+    return trajs
+
+
+def _render_reports(
+    run_dir: Path,
+    arms: list[str],
+    verify_runner: Any,
+) -> None:
+    """Aggregate stored trajectories per arm + render the multi-arm
+    comparison + per-arm summaries. NO client/API."""
+    from agent_bench.eval_docker import task_success_vector
+    from agent_bench.eval_verify import evaluate_arm
+    from agent_bench.report import (
+        aggregate_arm,
+        arm_summary_json,
+        arm_summary_markdown,
+        multi_arm_comparison_json,
+        multi_arm_comparison_markdown,
+    )
+
+    raw_root = run_dir / "raw"
+    aggregates = []
+    verify_metrics: dict[str, dict[str, Any]] = {}
+    success_by_arm: dict[str, list[bool]] = {}
+
+    for arm in arms:
+        raw_dir = raw_root / arm
+        if not raw_dir.is_dir():
+            continue
+        trajs = _load_trajectories(raw_dir)
+        if not trajs:
+            continue
+        agg = aggregate_arm(arm, trajs)
+        aggregates.append(agg)
+        # Per-arm summaries.
+        (run_dir / f"{arm}-summary.json").write_text(
+            json.dumps(arm_summary_json(agg), indent=2)
+        )
+        (run_dir / f"{arm}-summary.md").write_text(arm_summary_markdown(agg))
+        # Verify metrics (offline).
+        verify_metrics[arm] = evaluate_arm(trajs, verify_runner)
+        # Success vector — proxy (submit) when no Docker results present.
+        vec, _proxy = task_success_vector(trajs, None)
+        success_by_arm[arm] = vec
+
+    # McNemar paired contrasts (proxy-labelled). Only emit a contrast when
+    # both arms ran the SAME tasks (equal-length vectors).
+    paired: dict[str, tuple[list[bool], list[bool]]] = {}
+    contrasts = {
+        "B_vs_A": ("baseline", "retrieval"),
+        "C_vs_B": ("retrieval", "retrieval_verify"),
+        "C_vs_A": ("baseline", "retrieval_verify"),
+    }
+    for key, (a_arm, b_arm) in contrasts.items():
+        av = success_by_arm.get(a_arm)
+        bv = success_by_arm.get(b_arm)
+        if av is not None and bv is not None and len(av) == len(bv):
+            paired[key] = (av, bv)
+
+    (run_dir / "comparison.json").write_text(
+        json.dumps(
+            multi_arm_comparison_json(aggregates, paired, verify_metrics), indent=2
+        )
+    )
+    (run_dir / "comparison.md").write_text(
+        multi_arm_comparison_markdown(aggregates, paired, verify_metrics)
+    )
+
+
+def run_command(
+    args: argparse.Namespace,
+    *,
+    client_factory: Callable[[str], Any] | None = None,
+    repo_provider: Any = None,
+    daemon_factory: Callable[[str], Any] | None = None,
+    bridge_factory: Callable[[str, str | None], Any] | None = None,
+    verify_runner: Any = None,
+    run_id: str | None = None,
+) -> int:
+    """Execute a full A/B/C bench run from parsed CLI args.
+
+    Boundaries are injected (defaults wire the real implementations):
+      - `client_factory(model)` → an Anthropic-shaped client.
+      - `repo_provider` → isolation.RepoProvider (git in real runs).
+      - `daemon_factory(arm)` → isolation.DaemonHandle or None (baseline).
+      - `bridge_factory(arm, socket)` → mcp_bridge.McpBridge or None.
+      - `verify_runner` → eval_verify.RtsVerifyRunner.
+      - `run_id` → deterministic id (tests pin it).
+
+    Steps: (1) load corpus; (2) PRE-FLIGHT budget gate — if projected USD
+    exceeds --max-usd, print + return nonzero BEFORE constructing any
+    client / making any call; (3) per (task, arm, seed) prepare_task →
+    run_one_arm → write trajectory JSON; (4) --resume skips tuples whose
+    file exists; (5) aggregate + verify + render reports.
+    """
+    from agent_bench.corpus import load_corpus
+    from agent_bench.isolation import prepare_task
+    from agent_bench.run import ArmConfig, RunConfig, run_one_arm
+
+    arms = [a.strip() for a in str(args.arms).split(",") if a.strip()]
+    for arm in arms:
+        if arm not in _ARM_PROFILES:
+            print(f"error: unknown arm {arm!r}; expected {sorted(_ARM_PROFILES)}", file=sys.stderr)
+            return 2
+
+    tasks = load_corpus(args.corpus, limit=args.limit)
+    if not tasks:
+        print("error: corpus is empty", file=sys.stderr)
+        return 2
+
+    seeds = list(range(args.seeds))
+
+    # (2) PRE-FLIGHT budget gate — BEFORE any client is constructed.
+    est = estimate_cost(
+        tasks=len(tasks),
+        seeds=len(seeds),
+        arms=len(arms),
+    )
+    if est["total_usd"] > args.max_usd:
+        print(
+            f"ABORT: projected spend ${est['total_usd']:.2f} exceeds "
+            f"--max-usd ${args.max_usd:.2f} "
+            f"({est['runs']} runs = {len(tasks)} tasks × {len(seeds)} seeds "
+            f"× {len(arms)} arms). No client constructed; no API call made.",
+            file=sys.stderr,
+        )
+        return 1
+
+    out_root = Path(args.out)
+    rid = run_id or _new_run_id()
+    run_dir = out_root / "runs" / rid
+
+    client_factory = client_factory or _real_client_factory
+    daemon_factory = daemon_factory or (lambda arm: None)
+    repo_provider = repo_provider or _real_repo_provider()
+    verify_runner = verify_runner or _real_verify_runner()
+
+    workdir = run_dir / "work"
+
+    for arm in arms:
+        profile = _ARM_PROFILES[arm]
+        arm_cfg = ArmConfig(arm=arm, tool_profile=profile)
+        raw_dir = run_dir / "raw" / arm
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        for task in tasks:
+            for seed in seeds:
+                out_file = raw_dir / _trajectory_filename(task.instance_id, seed)
+                # (4) resume: skip tuples whose trajectory file exists.
+                if args.resume and out_file.exists():
+                    continue
+
+                config = RunConfig(model=args.model, system_prompt=_DEFAULT_SYSTEM_PROMPT)
+                daemon = daemon_factory(arm)
+                with prepare_task(
+                    task, workdir, repo_provider=repo_provider, daemon=daemon
+                ) as ws:
+                    materialized = _with_repo_dir(task, ws.repo_dir)
+                    bridge = (
+                        bridge_factory(arm, ws.socket) if bridge_factory is not None else None
+                    )
+                    client = client_factory(args.model)
+                    try:
+                        traj = run_one_arm(
+                            client=client,
+                            task=materialized,
+                            arm=arm_cfg,
+                            config=config,
+                            bridge=bridge,
+                        )
+                    finally:
+                        if bridge is not None and hasattr(bridge, "close"):
+                            bridge.close()
+                out_file.write_text(json.dumps(traj.to_dict(), indent=2))
+
+    # (5) aggregate + verify + render reports.
+    _render_reports(run_dir, arms, verify_runner)
+    print(f"run complete: {run_dir}")
+    return 0
+
+
+def report_command(
+    args: argparse.Namespace,
+    *,
+    verify_runner: Any = None,
+) -> int:
+    """Re-render reports from an existing run dir's stored trajectories.
+
+    NO client / NO API. Discovers arms from the `raw/` subdirectories.
+    """
+    run_dir = Path(args.runs)
+    raw_root = run_dir / "raw"
+    if not raw_root.is_dir():
+        print(f"error: no raw/ trajectories under {run_dir}", file=sys.stderr)
+        return 2
+    arms = sorted(p.name for p in raw_root.iterdir() if p.is_dir())
+    # Order canonically (baseline, retrieval, retrieval_verify) when present.
+    order = ["baseline", "retrieval", "retrieval_verify"]
+    arms = [a for a in order if a in arms] + [a for a in arms if a not in order]
+    verify_runner = verify_runner or _real_verify_runner()
+    _render_reports(run_dir, arms, verify_runner)
+    print(f"report rendered: {run_dir}")
+    return 0
+
+
+def _with_repo_dir(task: Any, repo_dir: Path) -> Any:
+    """Return a copy of `task` with `repo_dir` pointed at the workspace."""
+    from dataclasses import replace
+
+    return replace(task, repo_dir=repo_dir)
+
+
+def _new_run_id() -> str:
+    import datetime
+
+    return datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def _real_repo_provider() -> Any:
+    from agent_bench.isolation import GitRepoProvider
+
+    return GitRepoProvider()
+
+
+def _real_verify_runner() -> Any:
+    from agent_bench.eval_verify import CliRtsVerifyRunner
+
+    return CliRtsVerifyRunner()
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="agent-bench",
@@ -154,6 +467,45 @@ def _build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_OUT_PRICE_USD,
         help=f"Output price USD/MTok (default {DEFAULT_OUT_PRICE_USD}; Opus ~75).",
     )
+
+    run_p = sub.add_parser(
+        "run",
+        help="Run the A/B/C bench (budget-gated; needs ANTHROPIC_API_KEY).",
+    )
+    run_p.add_argument("--corpus", required=True, help="Path to a JSON corpus file.")
+    run_p.add_argument(
+        "--arms",
+        default="baseline,retrieval,retrieval_verify",
+        help="CSV of arm names (baseline,retrieval,retrieval_verify).",
+    )
+    run_p.add_argument("--seeds", type=int, default=1, help="Repeats per (task, arm).")
+    run_p.add_argument(
+        "--model",
+        default="claude-sonnet-4-7-20260315",
+        help="Pinned snapshot id (e.g. claude-sonnet-4-7-20260315).",
+    )
+    run_p.add_argument(
+        "--max-usd",
+        type=float,
+        required=True,
+        dest="max_usd",
+        help="Hard budget cap. Run ABORTS before any API call if exceeded.",
+    )
+    run_p.add_argument("--out", required=True, help="Output directory root.")
+    run_p.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip (task, arm, seed) tuples whose trajectory file exists.",
+    )
+    run_p.add_argument(
+        "--limit", type=int, default=None, help="Truncate corpus to first N tasks."
+    )
+
+    rep_p = sub.add_parser(
+        "report",
+        help="Re-render reports from an existing run dir (no API call).",
+    )
+    rep_p.add_argument("--runs", required=True, help="Path to a runs/<run_id> dir.")
     return parser
 
 
@@ -199,6 +551,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if getattr(args, "command", None) == "estimate":
         return _run_estimate(args)
+
+    if getattr(args, "command", None) == "run":
+        return run_command(args)
+
+    if getattr(args, "command", None) == "report":
+        return report_command(args)
 
     print(_BANNER.format(version=v))
 

--- a/agent-bench/agent_bench/cli.py
+++ b/agent-bench/agent_bench/cli.py
@@ -165,6 +165,22 @@ def _trajectory_filename(instance_id: str, seed: int) -> str:
     return f"{instance_id}__seed{seed}.json"
 
 
+def _is_complete_trajectory(path: Path) -> bool:
+    """True iff `path` exists and holds a parseable trajectory JSON object.
+
+    Resume treats only valid files as complete — a truncated/half-written
+    trajectory (process killed mid-write during a long real run) is re-run
+    rather than silently trusted.
+    """
+    if not path.is_file():
+        return False
+    try:
+        obj = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+    return isinstance(obj, dict)
+
+
 def _load_trajectories(raw_dir: Path) -> list[Any]:
     """Reconstruct ArmTrajectory objects from stored raw JSON files."""
     from agent_bench.run import ArmTrajectory, ToolCall
@@ -219,6 +235,7 @@ def _render_reports(
     aggregates = []
     verify_metrics: dict[str, dict[str, Any]] = {}
     success_by_arm: dict[str, list[bool]] = {}
+    success_proxy = False
 
     for arm in arms:
         raw_dir = raw_root / arm
@@ -237,8 +254,10 @@ def _render_reports(
         # Verify metrics (offline).
         verify_metrics[arm] = evaluate_arm(trajs, verify_runner)
         # Success vector — proxy (submit) when no Docker results present.
-        vec, _proxy = task_success_vector(trajs, None)
+        vec, proxy = task_success_vector(trajs, None)
         success_by_arm[arm] = vec
+        # Any arm on the proxy → label the whole comparison as proxy success.
+        success_proxy = success_proxy or proxy
 
     # McNemar paired contrasts (proxy-labelled). Only emit a contrast when
     # both arms ran the SAME tasks (equal-length vectors).
@@ -256,11 +275,16 @@ def _render_reports(
 
     (run_dir / "comparison.json").write_text(
         json.dumps(
-            multi_arm_comparison_json(aggregates, paired, verify_metrics), indent=2
+            multi_arm_comparison_json(
+                aggregates, paired, verify_metrics, success_proxy=success_proxy
+            ),
+            indent=2,
         )
     )
     (run_dir / "comparison.md").write_text(
-        multi_arm_comparison_markdown(aggregates, paired, verify_metrics)
+        multi_arm_comparison_markdown(
+            aggregates, paired, verify_metrics, success_proxy=success_proxy
+        )
     )
 
 
@@ -342,8 +366,11 @@ def run_command(
         for task in tasks:
             for seed in seeds:
                 out_file = raw_dir / _trajectory_filename(task.instance_id, seed)
-                # (4) resume: skip tuples whose trajectory file exists.
-                if args.resume and out_file.exists():
+                # (4) resume: skip tuples whose trajectory file exists AND
+                # parses as valid JSON. A truncated/half-written file (killed
+                # mid-run) is NOT trusted — it's re-run rather than silently
+                # treated as complete.
+                if args.resume and _is_complete_trajectory(out_file):
                     continue
 
                 config = RunConfig(model=args.model, system_prompt=_DEFAULT_SYSTEM_PROMPT)

--- a/agent-bench/agent_bench/corpus.py
+++ b/agent-bench/agent_bench/corpus.py
@@ -1,0 +1,148 @@
+"""Corpus loading — Task records from a checked-in JSON or a dataset id.
+
+Two sources, one entry point:
+
+  - A checked-in JSON corpus (e.g. `corpus/swe-bench-lite-smoke.json`):
+    `load_corpus(path)` parses the file directly.
+  - A dataset id (e.g. `princeton-nlp/SWE-bench_Lite`) behind the
+    `CorpusLoader` boundary: `load_corpus(id, loader=...)`. The real
+    loader pulls from HuggingFace; tests inject a `FakeLoader` so NO
+    network is touched in the suite.
+
+Required fields are validated up front with a clear `ValueError` so a
+malformed corpus fails fast (not deep inside the run loop). `limit`
+truncates deterministically (first N, in file order). The corpus
+version rides on the returned list as `.corpus_version`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from .run import Task
+
+# Fields a corpus row MUST carry. `gold_patch` is optional (Docker eval
+# only; the agent never sees it). `repo_dir` is populated at run time by
+# isolation.prepare_task, so it is NOT required in the corpus.
+_REQUIRED_FIELDS = ("instance_id", "repo", "base_commit", "problem_statement")
+
+
+@runtime_checkable
+class CorpusLoader(Protocol):
+    """Boundary over a dataset source (e.g. HuggingFace).
+
+    `load(source)` returns `(corpus_version, rows)` where `rows` is a
+    list of task dicts. Real impl hits HuggingFace; the test fake returns
+    canned rows so the suite never reaches the network.
+    """
+
+    def load(self, source: str) -> tuple[str, list[dict]]: ...
+
+
+class TaskList(list):
+    """A list of `Task` that also carries the corpus version.
+
+    Subclassing list keeps call sites simple (`for t in tasks`) while
+    letting the run loop record which corpus snapshot produced a result.
+    """
+
+    corpus_version: str = ""
+
+
+# --- Real (HuggingFace) loader ------------------------------------
+
+
+class HuggingFaceLoader:
+    """Real `CorpusLoader` that pulls a split from HuggingFace `datasets`.
+
+    Imports `datasets` lazily so importing this module never drags in the
+    heavy dependency (and so the test suite, which injects a fake, never
+    touches HF). Used only in real runs.
+    """
+
+    def __init__(self, split: str = "test") -> None:
+        self._split = split
+
+    def load(self, source: str) -> tuple[str, list[dict]]:
+        from datasets import load_dataset  # lazy: real-run only
+
+        ds = load_dataset(source, split=self._split)
+        rows = [dict(r) for r in ds]
+        version = f"{source}@{self._split}"
+        return (version, rows)
+
+
+# --- Validation + coercion ----------------------------------------
+
+
+def _row_to_task(row: dict, *, index: int) -> Task:
+    """Validate a corpus row and build a frozen `Task`.
+
+    Raises `ValueError` naming the first missing required field so a
+    malformed corpus fails fast and legibly.
+    """
+    if not isinstance(row, dict):
+        raise ValueError(f"corpus row {index} is not an object: {row!r}")
+    for field_name in _REQUIRED_FIELDS:
+        if field_name not in row or row[field_name] in (None, ""):
+            raise ValueError(
+                f"corpus row {index} ({row.get('instance_id', '?')}) is "
+                f"missing required field {field_name!r}"
+            )
+    return Task(
+        instance_id=str(row["instance_id"]),
+        repo=str(row["repo"]),
+        base_commit=str(row["base_commit"]),
+        problem_statement=str(row["problem_statement"]),
+        # repo_dir is a placeholder; isolation.prepare_task overwrites it.
+        repo_dir=Path("<unmaterialized>"),
+        gold_patch=str(row.get("gold_patch", "")),
+    )
+
+
+def _rows_to_tasks(rows: list[dict], version: str, limit: int | None) -> TaskList:
+    if limit is not None:
+        rows = rows[:limit]
+    tasks = TaskList(_row_to_task(r, index=i) for i, r in enumerate(rows))
+    tasks.corpus_version = version
+    return tasks
+
+
+# --- Entry point --------------------------------------------------
+
+
+def load_corpus(
+    source: str | Path,
+    *,
+    limit: int | None = None,
+    loader: CorpusLoader | None = None,
+) -> TaskList:
+    """Load tasks from a JSON corpus path OR a dataset id via `loader`.
+
+    - When `loader` is None, `source` is a path to a checked-in JSON
+      corpus (`{"name": ..., "tasks": [...]}`); the version is the
+      corpus `name`.
+    - When `loader` is given, `source` is a dataset id passed to
+      `loader.load(...)`, which returns `(corpus_version, rows)`.
+
+    `limit` keeps the first N rows in file/dataset order (deterministic).
+    Malformed rows raise `ValueError`.
+    """
+    if loader is not None:
+        version, rows = loader.load(str(source))
+        return _rows_to_tasks(rows, version, limit)
+
+    path = Path(source)
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"corpus {path} must be a JSON object with a 'tasks' list, "
+            f"got {type(raw).__name__}"
+        )
+    rows = raw.get("tasks")
+    if not isinstance(rows, list):
+        raise ValueError(f"corpus {path} has no 'tasks' list")
+    version = str(raw.get("name", path.stem))
+    return _rows_to_tasks(rows, version, limit)

--- a/agent-bench/agent_bench/eval_docker.py
+++ b/agent-bench/agent_bench/eval_docker.py
@@ -1,0 +1,79 @@
+"""Docker patch evaluation + the task-success notion (U4).
+
+Real success = "did the agent's patch make the failing tests pass?",
+which SWE-bench answers by applying the patch in a per-instance Docker
+image and checking the `FAIL_TO_PASS` set. That path needs **Docker +
+x86_64 + the `swebench` harness + multi-GB per-repo images**, so it is
+reached ONLY through the `PatchEvalRunner` boundary (a Protocol). Tests
+inject a `FakePatchEvalRunner` with canned resolutions — NO Docker, NO
+swebench, NO network in the suite.
+
+`task_success_vector` turns the result map into a per-task boolean
+vector for the success-rate ± Wilson CI and the McNemar contrasts. When
+no Docker results exist (the common build-only / CI-light case), it
+falls back to a PROXY: success iff `halt_reason == "submit"`, flagged
+`proxy=True` so the reporter can label the number as a proxy rather than
+a real resolution.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from .run import ArmTrajectory
+
+
+@runtime_checkable
+class PatchEvalRunner(Protocol):
+    """Boundary over swebench-in-Docker patch evaluation.
+
+    `evaluate(instance_id, patch)` applies `patch` to the instance's
+    base image, runs the test suite, and returns a result dict with at
+    least `{"resolved": bool}` (True iff the FAIL_TO_PASS set now passes
+    and PASS_TO_PASS did not regress).
+
+    Real implementation drives the `swebench` harness (Docker, x86_64,
+    multi-GB images). The test fake returns canned resolutions.
+    """
+
+    def evaluate(self, instance_id: str, patch: str) -> dict: ...
+
+
+def evaluate_patches(
+    trajectories: list[ArmTrajectory],
+    runner: PatchEvalRunner,
+) -> dict[str, dict[str, Any]]:
+    """Evaluate each trajectory's final patch via the runner boundary.
+
+    Returns a map `instance_id -> result dict`. A trajectory with no
+    final patch is recorded `{"resolved": False}` WITHOUT invoking the
+    runner (nothing to apply — Docker is expensive, so skip it).
+    """
+    results: dict[str, dict[str, Any]] = {}
+    for traj in trajectories:
+        patch = traj.final_patch
+        if not patch:
+            results[traj.task_id] = {"instance_id": traj.task_id, "resolved": False}
+            continue
+        results[traj.task_id] = runner.evaluate(traj.task_id, patch)
+    return results
+
+
+def task_success_vector(
+    trajectories: list[ArmTrajectory],
+    results: dict[str, dict[str, Any]] | None,
+) -> tuple[list[bool], bool]:
+    """Per-task success vector + a `proxy` flag.
+
+    - `results` given (real Docker eval): success[i] = results[task]'s
+      `resolved`, missing instances treated as unresolved. `proxy=False`.
+    - `results` None: PROXY fallback — success[i] = (halt_reason ==
+      "submit"). `proxy=True` so the caller labels it as a proxy.
+
+    The vector is aligned to `trajectories` order, so it pairs directly
+    with another arm's vector for McNemar.
+    """
+    if results is None:
+        return ([t.halt_reason == "submit" for t in trajectories], True)
+    vec = [bool(results.get(t.task_id, {}).get("resolved", False)) for t in trajectories]
+    return (vec, False)

--- a/agent-bench/agent_bench/isolation.py
+++ b/agent-bench/agent_bench/isolation.py
@@ -1,0 +1,168 @@
+"""Per-task isolation — materialize a repo + (optionally) a private daemon.
+
+Each (task, arm, seed) run gets its own scratch workspace so concurrent
+runs can't corrupt one another and so a task's edits never leak into the
+next. `prepare_task` is a context manager that:
+
+  1. Creates a guaranteed-cleaned tempdir under `workdir`.
+  2. Materializes the task's repo at `base_commit` via the `RepoProvider`
+     boundary (real = git clone + checkout; test = a fixture tree).
+  3. For arms that need rts tools, starts a per-task daemon on a PRIVATE
+     socket via the `DaemonHandle` boundary (real = spawn rts-daemon;
+     test = a fake socket path). Baseline arms pass `daemon=None` and get
+     `socket=None`.
+
+The tempdir is removed on `__exit__` — including on exception — and any
+daemon is stopped. Both boundaries are Protocols so the whole module is
+unit-testable with NO git, NO daemon, NO network, NO Docker.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from .run import Task
+
+
+@runtime_checkable
+class RepoProvider(Protocol):
+    """Boundary that puts a task's repo at `base_commit` into `dest`.
+
+    Real implementation clones the repo and checks out `base_commit`;
+    the test `FakeRepoProvider` writes a canned fixture tree. `dest` is a
+    fresh directory owned by `prepare_task`.
+    """
+
+    def materialize(self, task: Task, dest: Path) -> None: ...
+
+
+@runtime_checkable
+class DaemonHandle(Protocol):
+    """Boundary over a per-task rts-daemon on a private socket.
+
+    `start(workdir)` brings up a daemon scoped to `workdir` and returns
+    its socket path; `stop()` tears it down. Real implementation spawns
+    `rts-daemon`; the test fake returns a canned socket path. A handle is
+    single-use per `prepare_task` (started once, stopped once).
+    """
+
+    def start(self, workdir: Path) -> str: ...
+
+    def stop(self) -> None: ...
+
+
+@dataclass
+class TaskWorkspace:
+    """A prepared, isolated workspace for one task run.
+
+    `repo_dir` is the materialized repo at `base_commit`. `socket` is the
+    private daemon socket path when a daemon was started (rts arms), else
+    `None` (baseline).
+    """
+
+    task: Task
+    repo_dir: Path
+    socket: str | None = None
+
+
+# --- Real implementations -----------------------------------------
+#
+# These shell out to git / rts-daemon and are used only in real runs;
+# tests never touch them (they inject fakes). Importing this module
+# spawns nothing.
+
+
+class GitRepoProvider:
+    """Real `RepoProvider`: `git clone` + `git checkout <base_commit>`.
+
+    `repo` is rendered into a clone URL via `url_template` (default the
+    public GitHub https form). Shallow-history is avoided because
+    `base_commit` may be deep; a full clone is the safe default.
+    """
+
+    def __init__(self, url_template: str = "https://github.com/{repo}.git") -> None:
+        self._url_template = url_template
+
+    def materialize(self, task: Task, dest: Path) -> None:
+        import subprocess
+
+        url = self._url_template.format(repo=task.repo)
+        dest.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "clone", url, str(dest)], check=True)
+        subprocess.run(
+            ["git", "checkout", task.base_commit], cwd=str(dest), check=True
+        )
+
+
+class RtsDaemonHandle:
+    """Real `DaemonHandle`: spawn `rts-daemon` on a private unix socket.
+
+    The socket lives inside the task workdir so it is removed with the
+    tempdir. `stop()` terminates the process. Used only in real runs.
+    """
+
+    def __init__(self, rts_daemon_bin: str = "rts-daemon") -> None:
+        self._bin = rts_daemon_bin
+        self._proc = None
+
+    def start(self, workdir: Path) -> str:
+        import subprocess
+
+        socket_path = str(workdir / ".rts-daemon.sock")
+        self._proc = subprocess.Popen(  # noqa: S603 — real-run only
+            [self._bin, "--socket", socket_path, "--workspace", str(workdir)],
+        )
+        return socket_path
+
+    def stop(self) -> None:
+        if self._proc is not None:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=10)
+            except Exception:  # noqa: BLE001 — best-effort teardown
+                self._proc.kill()
+            self._proc = None
+
+
+# --- The context manager ------------------------------------------
+
+
+@contextmanager
+def prepare_task(
+    task: Task,
+    workdir: Path,
+    *,
+    repo_provider: RepoProvider,
+    daemon: DaemonHandle | None = None,
+) -> Iterator[TaskWorkspace]:
+    """Materialize an isolated workspace for one task run.
+
+    Creates a scratch tempdir under `workdir`, materializes the repo via
+    `repo_provider`, and — when `daemon` is given — starts a per-task
+    daemon on a private socket. Yields a `TaskWorkspace`. The tempdir is
+    ALWAYS removed and any daemon ALWAYS stopped on exit, including when
+    the body raises.
+    """
+    workdir.mkdir(parents=True, exist_ok=True)
+    scratch = Path(
+        tempfile.mkdtemp(prefix=f"{task.instance_id.replace('/', '_')}__", dir=str(workdir))
+    )
+    repo_dir = scratch / "repo"
+    started_daemon = False
+    try:
+        repo_provider.materialize(task, repo_dir)
+        socket: str | None = None
+        if daemon is not None:
+            socket = daemon.start(repo_dir)
+            started_daemon = True
+        yield TaskWorkspace(task=task, repo_dir=repo_dir, socket=socket)
+    finally:
+        if started_daemon and daemon is not None:
+            daemon.stop()
+        shutil.rmtree(scratch, ignore_errors=True)

--- a/agent-bench/agent_bench/report.py
+++ b/agent-bench/agent_bench/report.py
@@ -447,6 +447,8 @@ def multi_arm_comparison_json(
     aggregates: list[ArmAggregate],
     paired_success: dict[str, tuple[list[bool], list[bool]]],
     verify_metrics: dict[str, dict[str, Any]],
+    *,
+    success_proxy: bool = False,
 ) -> dict[str, Any]:
     """Schema-versioned A/B/C comparison payload.
 
@@ -456,6 +458,9 @@ def multi_arm_comparison_json(
       per-task booleans (the McNemar inputs).
     - `verify_metrics`: maps arm name → that arm's verify-metric block
       (from `eval_verify.evaluate_arm`); attached per arm.
+    - `success_proxy`: True when the success vectors are the
+      `halt_reason=="submit"` PROXY (no Docker patch eval). Surfaced so a
+      reader never mistakes proxy success for real Docker-resolved success.
     """
     arms_payload: list[dict[str, Any]] = []
     arms_by_name: dict[str, dict[str, Any]] = {}
@@ -502,6 +507,7 @@ def multi_arm_comparison_json(
 
     return {
         "schema": MULTI_ARM_SCHEMA,
+        "success_proxy": success_proxy,
         "arms": arms_payload,
         "arms_by_name": arms_by_name,
         "mcnemar": mcnemar_block,
@@ -512,15 +518,29 @@ def multi_arm_comparison_markdown(
     aggregates: list[ArmAggregate],
     paired_success: dict[str, tuple[list[bool], list[bool]]],
     verify_metrics: dict[str, dict[str, Any]],
+    *,
+    success_proxy: bool = False,
 ) -> str:
     """Human-readable A/B/C comparison."""
-    payload = multi_arm_comparison_json(aggregates, paired_success, verify_metrics)
+    payload = multi_arm_comparison_json(
+        aggregates, paired_success, verify_metrics, success_proxy=success_proxy
+    )
+    success_label = "Success (PROXY: submit_patch)" if success_proxy else "Success"
     lines = [
         "# agent-bench A/B/C comparison",
         "",
+    ]
+    if success_proxy:
+        lines += [
+            "> ⚠️ **Success is a PROXY** (`halt_reason == \"submit\"`), NOT real "
+            "Docker patch evaluation. Treat success-rate and the McNemar deltas "
+            "as directional until a real eval (FAIL_TO_PASS) is wired in.",
+            "",
+        ]
+    lines += [
         "## Per-arm summary (Wilson 95% CI)",
         "",
-        "| Arm | Success | Tool-use ratio | Verify calls | Tokens (in/out) | Wall median/p95 |",
+        f"| Arm | {success_label} | Tool-use ratio | Verify calls | Tokens (in/out) | Wall median/p95 |",
         "|-----|---------|----------------|--------------|-----------------|-----------------|",
     ]
     for arm in payload["arms"]:

--- a/agent-bench/tests/test_cli_run.py
+++ b/agent-bench/tests/test_cli_run.py
@@ -272,6 +272,37 @@ class TestResume:
         body = json.loads((raw / "acme__widget-0__seed0.json").read_text())
         assert body["final_patch"] == "preexisting"
 
+    def test_resume_reruns_corrupt_trajectory(self, tmp_path: Path) -> None:
+        # A truncated/half-written trajectory must NOT be trusted as complete.
+        corpus = _write_corpus(tmp_path, n=1)
+        out = tmp_path / "out"
+        raw = out / "runs" / "run-test" / "raw" / "baseline"
+        raw.mkdir(parents=True)
+        (raw / "acme__widget-0__seed0.json").write_text('{"task_id": "acme__widget-0"')  # truncated
+
+        client_calls = {"n": 0}
+
+        def counting_factory(model: str):
+            client_calls["n"] += 1
+            return _submit_client()
+
+        rc = run_command(
+            _make_args(
+                corpus=str(corpus), arms="baseline", seeds=1, out=str(out), resume=True
+            ),
+            client_factory=counting_factory,
+            repo_provider=FakeRepoProvider(),
+            daemon_factory=lambda arm: None,
+            bridge_factory=_bridge_factory_none,
+            verify_runner=FakeVerifyRunner(),
+            run_id="run-test",
+        )
+        assert rc == 0
+        # The corrupt file was re-run (not skipped) → client built once.
+        assert client_calls["n"] == 1
+        # And overwritten with a valid trajectory.
+        json.loads((raw / "acme__widget-0__seed0.json").read_text())
+
 
 # --- report subcommand (offline) ----------------------------------
 
@@ -309,3 +340,8 @@ class TestReportOffline:
         assert (run_dir / "comparison.md").is_file() or (
             run_dir / "comparison.json"
         ).is_file()
+        # Success is the submit proxy (no Docker eval), so the comparison MUST
+        # be labelled proxy — a reader can't mistake it for real resolved.
+        cj = json.loads((run_dir / "comparison.json").read_text())
+        assert cj["success_proxy"] is True
+        assert "PROXY" in (run_dir / "comparison.md").read_text()

--- a/agent-bench/tests/test_cli_run.py
+++ b/agent-bench/tests/test_cli_run.py
@@ -1,0 +1,311 @@
+"""Tests for the `run` + `report` CLI subcommands (U3).
+
+The `run` command: load corpus → PRE-FLIGHT budget gate → per
+(task, arm, seed) prepare_task + run_one_arm → write trajectory JSON →
+aggregate + verify + render reports. The `report` command re-renders
+from existing JSONs with NO client/API.
+
+Everything injectable is faked: FakeAnthropicClient (via client_factory),
+FakeRepoProvider, fake daemon, RtsVerifyRunner fake, and a fixed run_id.
+ZERO real API / daemon / Docker / network.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from agent_bench.cli import report_command, run_command
+from agent_bench.run import Task
+from tests.conftest import FakeAnthropicClient, FakeMessageResponse
+
+PINNED_MODEL = "claude-sonnet-4-7-20260315"
+
+
+# --- Fakes --------------------------------------------------------
+
+
+@dataclass
+class FakeRepoProvider:
+    tree: dict[str, str] = field(default_factory=lambda: {"README.md": "hi\n"})
+
+    def materialize(self, task: Task, dest: Path) -> None:
+        dest.mkdir(parents=True, exist_ok=True)
+        for name, content in self.tree.items():
+            (dest / name).write_text(content)
+
+
+@dataclass
+class FakeDaemon:
+    socket_path: str = "/tmp/fake.sock"
+
+    def start(self, workdir: Path) -> str:
+        return self.socket_path
+
+    def stop(self) -> None:
+        pass
+
+
+@dataclass
+class FakeVerifyRunner:
+    def verify_edit(self, edits: list[dict]) -> dict:
+        return {"verdict": "pass", "findings": [], "files": []}
+
+    def verify_file(self, path: str, content: str) -> dict:
+        return {"hallucinations": []}
+
+
+def _submit_client() -> FakeAnthropicClient:
+    """A client that immediately submits a patch (one turn)."""
+    return FakeAnthropicClient(
+        [
+            FakeMessageResponse(
+                content=[
+                    {
+                        "type": "tool_use",
+                        "id": "t1",
+                        "name": "submit_patch",
+                        "input": {"patch": "--- a\n+++ b\n@@\n-x\n+y\n"},
+                    }
+                ]
+            )
+        ]
+    )
+
+
+@dataclass
+class FakeBridge:
+    """Minimal McpBridge double — advertises the retrieval tools so
+    build_tool_list can compose them, but the agent script never calls
+    one (it submits a patch immediately)."""
+
+    closed: int = 0
+
+    def list_tools(self):
+        from agent_bench.mcp_bridge import McpToolSchema
+
+        return [
+            McpToolSchema(name="find_symbol", description="d", input_schema={"type": "object"}),
+            McpToolSchema(name="grep", description="d", input_schema={"type": "object"}),
+        ]
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+def _bridge_factory(arm, socket):
+    # Baseline needs no bridge; rts arms get a fake bridge.
+    if arm == "baseline":
+        return None
+    return FakeBridge()
+
+
+def _bridge_factory_none(arm, socket):
+    # Baseline-only paths: no bridge ever needed.
+    return None
+
+
+def _write_corpus(tmp_path: Path, n: int = 2) -> Path:
+    rows = [
+        {
+            "instance_id": f"acme__widget-{i}",
+            "repo": "acme/widget",
+            "base_commit": "0" * 40,
+            "problem_statement": f"Fix bug {i}.",
+            "gold_patch": "",
+        }
+        for i in range(n)
+    ]
+    p = tmp_path / "corpus.json"
+    p.write_text(json.dumps({"name": "test-corpus", "tasks": rows}))
+    return p
+
+
+def _make_args(**overrides):
+    import argparse
+
+    ns = argparse.Namespace(
+        corpus=None,
+        arms="baseline",
+        seeds=1,
+        model=PINNED_MODEL,
+        max_usd=1000.0,
+        out=None,
+        resume=False,
+        limit=None,
+    )
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+# --- Budget gate --------------------------------------------------
+
+
+class TestBudgetGate:
+    def test_max_usd_zero_aborts_before_any_client_call(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        corpus = _write_corpus(tmp_path, n=2)
+        out = tmp_path / "out"
+        called = {"made_client": False}
+
+        def boom_factory(model: str):
+            called["made_client"] = True
+            return _submit_client()
+
+        rc = run_command(
+            _make_args(corpus=str(corpus), arms="baseline", out=str(out), max_usd=0.0),
+            client_factory=boom_factory,
+            repo_provider=FakeRepoProvider(),
+            daemon_factory=lambda arm: None,
+            bridge_factory=_bridge_factory_none,
+            verify_runner=FakeVerifyRunner(),
+            run_id="run-test",
+        )
+        assert rc != 0
+        # No client was ever constructed.
+        assert called["made_client"] is False
+        # No trajectory files were written.
+        assert not (out / "runs").exists()
+        captured = capsys.readouterr()
+        err = (captured.out + captured.err).lower()
+        assert "budget" in err or "max-usd" in err or "abort" in err
+
+
+# --- Happy path: trajectories + report ----------------------------
+
+
+class TestRunWritesTrajectoriesAndReport:
+    def test_two_tasks_two_arms_one_seed(self, tmp_path: Path) -> None:
+        corpus = _write_corpus(tmp_path, n=2)
+        out = tmp_path / "out"
+
+        rc = run_command(
+            _make_args(
+                corpus=str(corpus),
+                arms="baseline,retrieval",
+                seeds=1,
+                out=str(out),
+                max_usd=1000.0,
+            ),
+            client_factory=lambda model: _submit_client(),
+            repo_provider=FakeRepoProvider(),
+            daemon_factory=lambda arm: (FakeDaemon() if arm != "baseline" else None),
+            bridge_factory=_bridge_factory,
+            verify_runner=FakeVerifyRunner(),
+            run_id="run-test",
+        )
+        assert rc == 0
+        raw = out / "runs" / "run-test" / "raw"
+        baseline_files = sorted((raw / "baseline").glob("*.json"))
+        retrieval_files = sorted((raw / "retrieval").glob("*.json"))
+        # 2 tasks × 1 seed per arm = 2 files per arm, 4 total.
+        assert len(baseline_files) == 2
+        assert len(retrieval_files) == 2
+        # File naming carries instance + seed.
+        names = {p.name for p in baseline_files}
+        assert "acme__widget-0__seed0.json" in names
+        # Trajectory JSON is run.ArmTrajectory.to_dict() shape.
+        body = json.loads(baseline_files[0].read_text())
+        assert body["arm"] == "baseline"
+        assert body["halt_reason"] == "submit"
+        # A multi-arm report was rendered.
+        run_dir = out / "runs" / "run-test"
+        assert (run_dir / "comparison.json").is_file() or (
+            run_dir / "comparison.md"
+        ).is_file()
+
+
+# --- Resume -------------------------------------------------------
+
+
+class TestResume:
+    def test_resume_skips_completed_tuples(self, tmp_path: Path) -> None:
+        corpus = _write_corpus(tmp_path, n=2)
+        out = tmp_path / "out"
+        raw = out / "runs" / "run-test" / "raw" / "baseline"
+        raw.mkdir(parents=True)
+        # Pre-seed one completed tuple's trajectory file.
+        existing = {
+            "task_id": "acme__widget-0",
+            "arm": "baseline",
+            "model": PINNED_MODEL,
+            "messages": [],
+            "tool_calls": [],
+            "final_patch": "preexisting",
+            "halt_reason": "submit",
+            "wall_clock_s": 0.0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+        }
+        (raw / "acme__widget-0__seed0.json").write_text(json.dumps(existing))
+
+        client_calls = {"n": 0}
+
+        def counting_factory(model: str):
+            client_calls["n"] += 1
+            return _submit_client()
+
+        rc = run_command(
+            _make_args(
+                corpus=str(corpus),
+                arms="baseline",
+                seeds=1,
+                out=str(out),
+                resume=True,
+            ),
+            client_factory=counting_factory,
+            repo_provider=FakeRepoProvider(),
+            daemon_factory=lambda arm: None,
+            bridge_factory=_bridge_factory_none,
+            verify_runner=FakeVerifyRunner(),
+            run_id="run-test",
+        )
+        assert rc == 0
+        # Only the missing task (widget-1) ran → exactly one client built.
+        assert client_calls["n"] == 1
+        # The pre-existing file is untouched.
+        body = json.loads((raw / "acme__widget-0__seed0.json").read_text())
+        assert body["final_patch"] == "preexisting"
+
+
+# --- report subcommand (offline) ----------------------------------
+
+
+class TestReportOffline:
+    def test_report_rerenders_from_existing_jsons(self, tmp_path: Path) -> None:
+        # First do a run to produce trajectories.
+        corpus = _write_corpus(tmp_path, n=2)
+        out = tmp_path / "out"
+        run_command(
+            _make_args(
+                corpus=str(corpus),
+                arms="baseline,retrieval",
+                out=str(out),
+            ),
+            client_factory=lambda model: _submit_client(),
+            repo_provider=FakeRepoProvider(),
+            daemon_factory=lambda arm: None,
+            bridge_factory=_bridge_factory,
+            verify_runner=FakeVerifyRunner(),
+            run_id="run-test",
+        )
+        run_dir = out / "runs" / "run-test"
+        # Remove rendered reports to prove report re-creates them.
+        for f in run_dir.glob("comparison.*"):
+            f.unlink()
+
+        import argparse
+
+        rc = report_command(
+            argparse.Namespace(runs=str(run_dir)),
+            verify_runner=FakeVerifyRunner(),
+        )
+        assert rc == 0
+        assert (run_dir / "comparison.md").is_file() or (
+            run_dir / "comparison.json"
+        ).is_file()

--- a/agent-bench/tests/test_corpus.py
+++ b/agent-bench/tests/test_corpus.py
@@ -1,0 +1,127 @@
+"""Tests for corpus loading (U2).
+
+`load_corpus` loads Task records from a checked-in JSON corpus OR from a
+dataset id behind a `loader` boundary (the HF path, faked here — NO
+network). It validates required fields, truncates deterministically via
+`limit`, and carries `corpus_version`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_bench.corpus import CorpusLoader, load_corpus
+from agent_bench.run import Task
+
+SMOKE = Path(__file__).resolve().parent.parent / "corpus" / "swe-bench-lite-smoke.json"
+
+
+class TestLoadFromJson:
+    def test_loads_smoke_corpus(self) -> None:
+        tasks = load_corpus(SMOKE)
+        assert len(tasks) == 4
+        assert all(isinstance(t, Task) for t in tasks)
+        ids = [t.instance_id for t in tasks]
+        assert "django__django-11099" in ids
+        # Fields carried through.
+        first = tasks[0]
+        assert first.repo == "django/django"
+        assert first.problem_statement
+
+    def test_limit_truncates_deterministically(self) -> None:
+        two = load_corpus(SMOKE, limit=2)
+        assert len(two) == 2
+        # Deterministic: same first two as the unlimited load, in order.
+        full = load_corpus(SMOKE)
+        assert [t.instance_id for t in two] == [t.instance_id for t in full[:2]]
+
+    def test_carries_corpus_version(self) -> None:
+        tasks = load_corpus(SMOKE)
+        # corpus_version is attached as an attribute on the returned list
+        # wrapper OR accessible via load_corpus return; we expose it on
+        # each Task is not desired (Task is frozen + shared), so the
+        # version rides on the list object.
+        assert getattr(tasks, "corpus_version", None) == "swe-bench-lite-smoke"
+
+    def test_malformed_missing_field_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text(
+            json.dumps(
+                {
+                    "name": "broken",
+                    "tasks": [{"instance_id": "x", "repo": "a/b"}],  # missing fields
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="base_commit"):
+            load_corpus(bad)
+
+    def test_malformed_not_a_dict_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text(json.dumps([1, 2, 3]))
+        with pytest.raises(ValueError):
+            load_corpus(bad)
+
+
+class FakeLoader:
+    """Canned CorpusLoader — returns task dicts without touching HF."""
+
+    def __init__(self, rows: list[dict]) -> None:
+        self.rows = rows
+        self.requested: list[str] = []
+
+    def load(self, source: str) -> tuple[str, list[dict]]:
+        self.requested.append(source)
+        return ("fake-dataset-v1", list(self.rows))
+
+
+class TestLoadViaLoader:
+    def test_fake_loader_returns_canned_tasks(self) -> None:
+        loader = FakeLoader(
+            rows=[
+                {
+                    "instance_id": "fake__1",
+                    "repo": "fake/repo",
+                    "base_commit": "abc",
+                    "problem_statement": "do it",
+                    "gold_patch": "",
+                },
+                {
+                    "instance_id": "fake__2",
+                    "repo": "fake/repo",
+                    "base_commit": "def",
+                    "problem_statement": "do it again",
+                },
+            ]
+        )
+        tasks = load_corpus("princeton-nlp/SWE-bench_Lite", loader=loader)
+        assert loader.requested == ["princeton-nlp/SWE-bench_Lite"]
+        assert [t.instance_id for t in tasks] == ["fake__1", "fake__2"]
+        assert getattr(tasks, "corpus_version", None) == "fake-dataset-v1"
+
+    def test_loader_path_respects_limit(self) -> None:
+        loader = FakeLoader(
+            rows=[
+                {
+                    "instance_id": f"fake__{i}",
+                    "repo": "fake/repo",
+                    "base_commit": "c",
+                    "problem_statement": "p",
+                }
+                for i in range(5)
+            ]
+        )
+        tasks = load_corpus("ds", loader=loader, limit=2)
+        assert [t.instance_id for t in tasks] == ["fake__0", "fake__1"]
+
+    def test_loader_malformed_raises(self) -> None:
+        loader = FakeLoader(rows=[{"instance_id": "x"}])
+        with pytest.raises(ValueError):
+            load_corpus("ds", loader=loader)
+
+
+def test_corpus_loader_protocol_importable() -> None:
+    assert CorpusLoader is not None

--- a/agent-bench/tests/test_eval_docker.py
+++ b/agent-bench/tests/test_eval_docker.py
@@ -1,0 +1,96 @@
+"""Tests for Docker patch evaluation + success vectors (U4).
+
+`evaluate_patches` runs each trajectory's final patch through the
+`PatchEvalRunner` boundary (real = swebench-in-Docker FAIL_TO_PASS; test
+= a `FakePatchEvalRunner` with canned resolutions). `task_success_vector`
+turns a result map into a per-task success vector — or, when no Docker
+results exist, falls back to a `halt_reason == "submit"` PROXY flagged
+`proxy=True`.
+
+NO Docker, NO swebench, NO network in this suite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from agent_bench.eval_docker import (
+    PatchEvalRunner,
+    evaluate_patches,
+    task_success_vector,
+)
+from agent_bench.run import ArmTrajectory
+
+PINNED_MODEL = "claude-sonnet-4-7-20260315"
+
+
+def _traj(task_id: str, patch: str | None, halt: str = "submit") -> ArmTrajectory:
+    t = ArmTrajectory(task_id=task_id, arm="A", model=PINNED_MODEL)
+    t.final_patch = patch
+    t.halt_reason = halt
+    return t
+
+
+@dataclass
+class FakePatchEvalRunner:
+    """Canned PatchEvalRunner. Maps instance_id → resolved bool."""
+
+    resolved: dict[str, bool] = field(default_factory=dict)
+    calls: list[str] = field(default_factory=list)
+
+    def evaluate(self, instance_id: str, patch: str) -> dict:
+        self.calls.append(instance_id)
+        return {"instance_id": instance_id, "resolved": self.resolved.get(instance_id, False)}
+
+
+class TestEvaluatePatches:
+    def test_fake_runner_drives_resolution_map(self) -> None:
+        trajs = [_traj("a", "patch-a"), _traj("b", "patch-b")]
+        runner = FakePatchEvalRunner(resolved={"a": True, "b": False})
+        results = evaluate_patches(trajs, runner)
+        assert results["a"]["resolved"] is True
+        assert results["b"]["resolved"] is False
+        assert runner.calls == ["a", "b"]
+
+    def test_empty_patch_is_unresolved_without_calling_runner(self) -> None:
+        trajs = [_traj("a", None, halt="no_patch")]
+        runner = FakePatchEvalRunner(resolved={"a": True})
+        results = evaluate_patches(trajs, runner)
+        # No patch → cannot resolve; runner not invoked for it.
+        assert results["a"]["resolved"] is False
+        assert runner.calls == []
+
+
+class TestSuccessVector:
+    def test_real_results_drive_success_no_proxy(self) -> None:
+        trajs = [_traj("a", "p"), _traj("b", "p"), _traj("c", "p")]
+        results = {
+            "a": {"resolved": True},
+            "b": {"resolved": False},
+            "c": {"resolved": True},
+        }
+        vec, proxy = task_success_vector(trajs, results)
+        assert vec == [True, False, True]
+        assert proxy is False
+
+    def test_none_results_fall_back_to_submit_proxy(self) -> None:
+        trajs = [
+            _traj("a", "p", halt="submit"),
+            _traj("b", None, halt="no_patch"),
+            _traj("c", "p", halt="turn_cap"),
+        ]
+        vec, proxy = task_success_vector(trajs, None)
+        # Proxy: success iff halt_reason == "submit".
+        assert vec == [True, False, False]
+        assert proxy is True
+
+    def test_proxy_flag_labels_the_vector(self) -> None:
+        trajs = [_traj("a", "p", halt="submit")]
+        _, proxy_real = task_success_vector(trajs, {"a": {"resolved": True}})
+        _, proxy_fallback = task_success_vector(trajs, None)
+        assert proxy_real is False
+        assert proxy_fallback is True
+
+
+def test_patch_eval_runner_protocol_importable() -> None:
+    assert PatchEvalRunner is not None

--- a/agent-bench/tests/test_isolation.py
+++ b/agent-bench/tests/test_isolation.py
@@ -1,0 +1,130 @@
+"""Tests for per-task isolation (U1).
+
+`prepare_task` is a context manager that materializes a task's repo at
+`base_commit` (via the RepoProvider boundary) into a guaranteed-cleaned
+tempdir, and — for arms that need rts tools — spins up a per-task daemon
+(via the DaemonHandle boundary) on a private socket.
+
+Both boundaries are Protocols so tests inject fakes: NO git clone, NO
+daemon spawn, NO network, NO Docker.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from agent_bench.isolation import (
+    DaemonHandle,
+    RepoProvider,
+    TaskWorkspace,
+    prepare_task,
+)
+from agent_bench.run import Task
+
+PINNED_MODEL = "claude-sonnet-4-7-20260315"
+
+
+def _task(tmp_path: Path) -> Task:
+    return Task(
+        instance_id="acme__widget-42",
+        repo="acme/widget",
+        base_commit="0" * 40,
+        problem_statement="Fix the widget.",
+        repo_dir=tmp_path / "unused",  # overwritten by prepare_task
+    )
+
+
+@dataclass
+class FakeRepoProvider:
+    """Writes a canned fixture tree instead of cloning a real repo."""
+
+    tree: dict[str, str] = field(default_factory=lambda: {"README.md": "hi\n"})
+    calls: list[tuple[str, str, str]] = field(default_factory=list)
+
+    def materialize(self, task: Task, dest: Path) -> None:
+        self.calls.append((task.repo, task.base_commit, str(dest)))
+        dest.mkdir(parents=True, exist_ok=True)
+        for name, content in self.tree.items():
+            p = dest / name
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content)
+
+
+@dataclass
+class FakeDaemonHandle:
+    """Hands back a fake socket path instead of spawning rts-daemon."""
+
+    socket_path: str = "/tmp/fake-rts.sock"
+    started: list[Path] = field(default_factory=list)
+    stopped: int = 0
+
+    def start(self, workdir: Path) -> str:
+        self.started.append(workdir)
+        return self.socket_path
+
+    def stop(self) -> None:
+        self.stopped += 1
+
+
+class TestPrepareTask:
+    def test_repo_materialized_at_base_commit(self, tmp_path: Path) -> None:
+        provider = FakeRepoProvider(tree={"src/lib.py": "x = 1\n"})
+        task = _task(tmp_path)
+        with prepare_task(task, tmp_path / "work", repo_provider=provider) as ws:
+            assert isinstance(ws, TaskWorkspace)
+            assert ws.repo_dir.is_dir()
+            assert (ws.repo_dir / "src" / "lib.py").read_text() == "x = 1\n"
+            # The provider saw the right repo + commit.
+            assert provider.calls[0][0] == "acme/widget"
+            assert provider.calls[0][1] == "0" * 40
+
+    def test_baseline_needs_no_daemon(self, tmp_path: Path) -> None:
+        provider = FakeRepoProvider()
+        task = _task(tmp_path)
+        with prepare_task(task, tmp_path / "work", repo_provider=provider) as ws:
+            assert ws.socket is None
+
+    def test_rts_arm_gets_a_socket(self, tmp_path: Path) -> None:
+        provider = FakeRepoProvider()
+        daemon = FakeDaemonHandle(socket_path="/tmp/task.sock")
+        task = _task(tmp_path)
+        with prepare_task(
+            task, tmp_path / "work", repo_provider=provider, daemon=daemon
+        ) as ws:
+            assert ws.socket == "/tmp/task.sock"
+            assert daemon.started  # daemon was started against the repo workdir
+        # Cleaned up on exit.
+        assert daemon.stopped == 1
+
+    def test_cleanup_on_exception(self, tmp_path: Path) -> None:
+        provider = FakeRepoProvider()
+        daemon = FakeDaemonHandle()
+        task = _task(tmp_path)
+        captured: list[Path] = []
+        with pytest.raises(RuntimeError, match="boom"), prepare_task(
+            task, tmp_path / "work", repo_provider=provider, daemon=daemon
+        ) as ws:
+            captured.append(ws.repo_dir)
+            assert ws.repo_dir.is_dir()
+            raise RuntimeError("boom")
+        # Tempdir removed even though the body raised.
+        assert not captured[0].exists()
+        # Daemon stopped even on exception.
+        assert daemon.stopped == 1
+
+    def test_tempdir_removed_on_normal_exit(self, tmp_path: Path) -> None:
+        provider = FakeRepoProvider()
+        task = _task(tmp_path)
+        seen: list[Path] = []
+        with prepare_task(task, tmp_path / "work", repo_provider=provider) as ws:
+            seen.append(ws.repo_dir)
+        assert not seen[0].exists()
+
+
+def test_protocols_are_importable() -> None:
+    # RepoProvider + DaemonHandle are the injectable boundaries.
+    assert hasattr(RepoProvider, "materialize") or RepoProvider is not None
+    assert hasattr(DaemonHandle, "start") or DaemonHandle is not None

--- a/changelog.d/167-feat-agent-bench-run-infra.md
+++ b/changelog.d/167-feat-agent-bench-run-infra.md
@@ -1,0 +1,54 @@
+### Feat: agent-bench run infrastructure (build-only)
+
+Wires `agent-bench` from a collection of units into an end-to-end harness that
+runs a full A/B/C bench from a single `agent-bench run` command. This is
+BUILD-ONLY — the harness runs **end-to-end with a fake client** (see
+`tests/test_cli_run.py`) and every external boundary is a `Protocol` injected
+with a test fake; there is ZERO real model/API/daemon/Docker/network in the
+suite. A real run is gated on a budget cap (`--max-usd`) plus live infra
+(ANTHROPIC_API_KEY + git + Docker/x86_64).
+
+- **Per-task isolation** (`agent_bench/isolation.py`) — `prepare_task(task,
+  workdir, *, repo_provider, daemon=None)` is a context manager yielding a
+  `TaskWorkspace` (`repo_dir`, plus `socket` when a daemon is started). The repo
+  is materialized at `base_commit` via the `RepoProvider` boundary
+  (`GitRepoProvider` = clone + checkout; tests write a fixture tree). rts arms
+  get a private per-task daemon socket via the `DaemonHandle` boundary
+  (`RtsDaemonHandle` spawns rts-daemon; tests return a fake socket); baseline
+  arms pass `daemon=None` and get `socket=None`. The scratch tempdir is removed
+  and any daemon stopped on exit — **including on exception**.
+
+- **Corpus loading** (`agent_bench/corpus.py`) — `load_corpus(source, *,
+  limit=None, loader=None)` loads `Task` records from a checked-in JSON corpus or
+  from a dataset id behind the `CorpusLoader` boundary (`HuggingFaceLoader` real;
+  tests inject a fake — no network). Required fields are validated with a clear
+  `ValueError`; `limit` truncates deterministically (first N in order); the
+  corpus version rides on the returned list as `.corpus_version`.
+
+- **`run` + `report` CLI** (`agent_bench/cli.py`) — `agent-bench run --corpus
+  --arms --seeds --model --max-usd --out [--resume] [--limit N]`. (1) loads the
+  corpus; (2) **PRE-FLIGHT budget gate**: computes `estimate_cost` and, if the
+  projection exceeds `--max-usd`, prints an `ABORT:` line and exits nonzero
+  **before any client is constructed / any API call is made**; (3) per
+  `(task, arm, seed)`: `prepare_task` → `run_one_arm` → writes the trajectory
+  `to_dict()` JSON to `<out>/runs/<run_id>/raw/<arm>/<instance_id>__seed<seed>.json`;
+  (4) `--resume` skips tuples whose trajectory file already exists; (5)
+  aggregates per arm + `eval_verify.evaluate_arm` + renders
+  `multi_arm_comparison_*` and per-arm summaries. `agent-bench report --runs
+  <dir>` re-renders from existing JSONs with NO client/API. The client, repo
+  provider, daemon, MCP bridge, verify runner, and `run_id` are all injectable
+  for deterministic offline tests.
+
+- **Docker patch eval + success notion** (`agent_bench/eval_docker.py`) —
+  `evaluate_patches(trajectories, runner)` behind the `PatchEvalRunner` Protocol
+  (real = swebench-in-Docker FAIL_TO_PASS; tests inject canned resolutions).
+  `task_success_vector(trajectories, results)` maps real results → success =
+  resolved, or — when `results is None` — falls back to a `halt_reason ==
+  "submit"` **proxy** flagged `proxy=True`. This success notion feeds the
+  success-rate ± Wilson CI and the McNemar vectors (real when present, proxy
+  otherwise, labelled). The real path requires Docker + x86_64 + the `swebench`
+  harness + multi-GB per-repo images.
+
+All boundaries (`AnthropicClient`, `RepoProvider`, `DaemonHandle`,
+`CorpusLoader`, `RtsVerifyRunner`, `PatchEvalRunner`) have a documented real
+implementation and a test fake; the full suite stays offline.

--- a/docs/plans/2026-06-19-004-feat-agent-bench-run-infra-plan.md
+++ b/docs/plans/2026-06-19-004-feat-agent-bench-run-infra-plan.md
@@ -1,0 +1,56 @@
+---
+title: "feat: agent-bench run infrastructure (PR-B, build-only)"
+type: feat
+status: draft
+date: 2026-06-19
+origin: docs/plans/2026-06-19-003-feat-abc-benchmark-harness-plan.md
+---
+
+# feat: agent-bench run infrastructure (PR-B)
+
+**Goal:** Make the A/B/C benchmark actually *runnable end-to-end* — `agent_bench run` over a corpus × arms × seeds → trajectories → 3-arm report + per-arm verify metrics → optional Docker patch eval — so the only thing standing between here and headline numbers is (a) a real API key + budget and (b) Docker. BUILD-ONLY: every test uses the existing `FakeAnthropicClient` and injectable fakes for git/daemon/Docker; **no real model, daemon, or Docker in the test suite.**
+
+## Grounding
+P4 already shipped arm profiles (A/B/C), `eval_verify`, the McNemar/3-arm report, and `estimate`. `run_one_arm` (run.py:416) executes one arm against a `Task` with a `repo_dir`. Still missing (agent-bench U2.5–U2.10): per-task isolation (build the `repo_dir` + a daemon), the corpus loader, the `run`/`report` CLI wiring, a hard cost cap, resume, and Docker patch eval. cli.py is a scaffold + the `estimate` subcommand.
+
+## Implementation Units (build-only, pytest-mocked)
+
+### U1 — Per-task isolation (`isolation.py`)
+`prepare_task(task, workdir) -> TaskWorkspace`: materialize the task's repo at `base_commit` into an isolated dir (git clone/worktree + checkout, OR copy a provided fixture), and (for the rts arms) spawn a per-task `rts-daemon` over it on a private socket; yield the workspace; tear everything down. Define a `RepoProvider` boundary (real = git; tests = a `FakeRepoProvider` that lays down a fixture tree) and a `DaemonHandle` boundary (real = spawn; tests = fake) so the unit tests need neither network nor a daemon. Context-manager API (`with prepare_task(...) as ws:`), guaranteed cleanup on error. Tests: a fixture repo is materialized at the right commit; cleanup removes the tempdir even on exception; the rts arms get a socket path, baseline doesn't.
+
+### U2 — Corpus loader (`corpus.py`)
+`load_corpus(path_or_name, limit=None) -> list[Task]`: load tasks from a checked-in JSON (the `swe-bench-lite-smoke.json` P4 added, plus a `swe-bench-lite-v1.json` curated set if available) OR a HuggingFace dataset id (behind a boundary so tests don't hit the network — inject a fake loader). Validate each task has the required fields; pin a `corpus_version`. Tests: loads the smoke JSON into `Task`s; `limit` truncates deterministically; a malformed entry raises a clear error; the HF path is exercised via a fake loader (no network).
+
+### U3 — `run` + `report` CLI wiring + cost cap + resume
+`agent_bench run --corpus <c> --arms a,b,c --seeds S --model <id> --max-usd <cap> --out <dir> [--resume]`:
+- Pre-flight: compute the `estimate` (P4) and **hard-abort if it exceeds `--max-usd`** before any API call (the budget guardrail — U2.6).
+- For each (task, arm, seed): `prepare_task` → `run_one_arm` (real `AnthropicClient` in prod; `FakeAnthropicClient` in tests) → persist the trajectory JSON under `--out/runs/<run-id>/raw/<arm>/<task>__<seed>.json`.
+- **Resume** (U2.7): on `--resume`, skip (task, arm, seed) tuples whose trajectory JSON already exists; a `preds`/manifest records progress.
+- After the runs: aggregate per arm, run `eval_verify` per arm, render the 3-arm report (`multi_arm_comparison_*`) + per-arm summaries to `--out`.
+`agent_bench report --runs <dir>`: re-render the report from existing trajectories (no API). Tests (FakeAnthropicClient, fake isolation): a 2-task × 3-arm × 1-seed run produces 6 trajectory files + a 3-arm report; `--max-usd` below the estimate aborts with no client calls; `--resume` skips existing tuples; `report` re-renders without the client.
+
+### U4 — Docker patch-eval boundary (`eval_docker.py`)
+`evaluate_patches(trajectories, runner) -> dict[task_id, Resolved]`: behind a `PatchEvalRunner` boundary (real = shells to the `swebench` harness in Docker to check FAIL_TO_PASS; tests = `FakePatchEvalRunner` with canned resolved/unresolved). Wire per-task success into the report's success-rate ± Wilson CI and the McNemar paired vectors (replacing the `halt_reason=="submit"` proxy when real eval is available; fall back to the proxy + a clear "proxy success" label when Docker isn't configured). Document that the real path needs Docker + x86_64 Linux + the swebench package + pulled task images. Tests: fake runner → per-task resolved feeds success-rate + McNemar; absent runner → proxy success, clearly labelled.
+
+### U5 — Docs + changelog
+Update `agent-bench/README.md` (the run/report commands, the budget cap, what a real run needs: API key + Docker + the deferred image pulls) and a root changelog fragment. Note this is build-only: the harness runs end-to-end with a fake client; a real run is the budget+Docker-gated step.
+
+## Acceptance criteria
+- `agent_bench run` executes A/B/C over a corpus end-to-end with `FakeAnthropicClient`, producing trajectories + a 3-arm report + per-arm verify metrics.
+- `--max-usd` aborts before any client call when the estimate exceeds the cap.
+- `--resume` skips completed tuples; `report` re-renders offline.
+- Isolation/corpus/Docker-eval all behind injectable boundaries; **zero real model/daemon/Docker/network in tests**; `uv run pytest` green.
+
+## Deferred (the actual run — C, budget+infra-gated)
+- A real model run (needs an API key + budget; `--max-usd` + `estimate` gate it).
+- Real Docker patch eval (needs Docker + x86_64 + multi-GB task images).
+- The full curated 30-task corpus content + the first committed baseline result + the CI cadence (`agent-bench.yml`).
+
+## Requirements trace
+| agent-bench unit | Covered by |
+| :-- | :-- |
+| U2.5 isolation | U1 |
+| U2.6 cost cap | U3 (`--max-usd` pre-flight abort) |
+| U2.7 resume | U3 |
+| U2.9 corpus | U2 (loader + smoke/pinned JSON) |
+| U2.10 Docker eval | U4 (boundary; real path documented, gated) |


### PR DESCRIPTION
## Summary

The run infrastructure that makes the A/B/C benchmark **runnable end-to-end** — `agent_bench run` over a corpus × arms × seeds → trajectories → 3-arm report + per-arm verify metrics → optional Docker patch eval. **Build-only**: the whole pipeline runs end-to-end with a fake client; every git/daemon/Docker/HF boundary is injectable + faked in tests (zero real model/daemon/Docker/network). A real run is the budget+Docker-gated step (C).

Plan: `docs/plans/2026-06-19-004-feat-agent-bench-run-infra-plan.md`.

## What's in it
- **`isolation.py`** — `prepare_task` context manager: materializes a task's repo at `base_commit` (via a `RepoProvider` boundary) and optionally spawns a per-task daemon (`DaemonHandle`), with guaranteed cleanup on error.
- **`corpus.py`** — `load_corpus` from a checked-in JSON or a dataset id (behind a faked `CorpusLoader`); field validation; deterministic `--limit`.
- **`cli.py` `run` / `report`** — `run` does a **pre-flight budget gate** (`--max-usd`: if the `tasks×seeds×arms` projection exceeds the cap, abort **before any client/clone/daemon**), per-(task,arm,seed) execution + trajectory persistence, `--resume` (skips only valid completed files), then aggregate + `eval_verify` + the 3-arm comparison. `report` re-renders offline.
- **`eval_docker.py`** — `evaluate_patches` behind a `PatchEvalRunner` (real = swebench-in-Docker FAIL_TO_PASS; tests faked); `task_success_vector` is real-or-**proxy** (`halt_reason=="submit"`) with the proxy clearly labelled in the report.

## Process
Subagent-driven (implementer + spec/quality review). The review verified the **budget gate aborts before any client call** (the real-money guard) and **zero real infra in tests**, and caught one Important issue — the proxy-success flag was dropped before the report — fixed here (the A/B/C comparison now carries a prominent `success_proxy` label so proxy success can't be mistaken for real Docker-resolved success), plus resume now re-runs truncated files.

## Test plan
- [x] `uv run pytest` (from `agent-bench/`) — 84 passed, 5 skipped (the real-daemon `test_mcp_bridge` tests, skipped without binaries)
- [x] Budget gate aborts pre-client (test asserts the client factory was never called + no files written)
- [x] Zero real API/daemon/Docker/network in the suite; ruff-clean on touched files

## Deferred (the actual run — C, budget+infra-gated)
- A real model run (needs `ANTHROPIC_API_KEY` + budget; `--max-usd`/`estimate` gate it).
- Real Docker patch eval (Docker + x86_64 + swebench + multi-GB images).
- The full curated corpus content + first committed baseline + CI cadence.