### PR TITLE
fix(agent-bench): wire rts-arm bridge + harden resume/McNemar (Codex P1/P2)

### DIFF
--- a/agent-bench/agent_bench/cli.py
+++ b/agent-bench/agent_bench/cli.py
@@ -165,12 +165,36 @@ def _trajectory_filename(instance_id: str, seed: int) -> str:
     return f"{instance_id}__seed{seed}.json"
 
 
-def _is_complete_trajectory(path: Path) -> bool:
-    """True iff `path` exists and holds a parseable trajectory JSON object.
+# Fields a stored trajectory MUST carry for resume to trust it as
+# complete. These are exactly what `_load_trajectories` / `aggregate_arm`
+# read back; a file missing any of them would crash or silently aggregate
+# stale data, so it is treated as INCOMPLETE and re-run.
+_REQUIRED_TRAJECTORY_FIELDS = (
+    "task_id",
+    "arm",
+    "model",
+    "halt_reason",
+    "input_tokens",
+    "output_tokens",
+)
 
-    Resume treats only valid files as complete — a truncated/half-written
-    trajectory (process killed mid-write during a long real run) is re-run
-    rather than silently trusted.
+
+def _is_complete_trajectory(
+    path: Path,
+    *,
+    task_id: str | None = None,
+    arm: str | None = None,
+    model: str | None = None,
+) -> bool:
+    """True iff `path` holds a complete trajectory matching this identity.
+
+    Resume treats a file as complete only when it (a) parses as a JSON
+    object, (b) carries the full trajectory schema the loader/aggregator
+    read (`_REQUIRED_TRAJECTORY_FIELDS`), and (c) matches the CURRENT
+    (task_id, arm, model) when those are supplied. A truncated, bare
+    (`{}`), incomplete, or mismatched file is treated as INCOMPLETE and
+    re-run rather than silently trusted (which would crash the loader or
+    aggregate stale data from a different task/arm/model).
     """
     if not path.is_file():
         return False
@@ -178,7 +202,44 @@ def _is_complete_trajectory(path: Path) -> bool:
         obj = json.loads(path.read_text())
     except (json.JSONDecodeError, OSError):
         return False
-    return isinstance(obj, dict)
+    if not isinstance(obj, dict):
+        return False
+    if any(field not in obj for field in _REQUIRED_TRAJECTORY_FIELDS):
+        return False
+    # Identity must match the CURRENT (task_id, arm, model) when supplied —
+    # a leftover record from a different task/arm/model is NOT complete.
+    expected = {"task_id": task_id, "arm": arm, "model": model}
+    return all(
+        want is None or obj.get(field) == want for field, want in expected.items()
+    )
+
+
+def _trajectory_keys(raw_dir: Path) -> list[tuple[str, int]]:
+    """Per-task identity keys aligned with `_load_trajectories(raw_dir)`.
+
+    Returns `(instance_id, seed)` for each stored trajectory in the SAME
+    sorted order `_load_trajectories` yields, so the keys zip directly with
+    a success vector. The seed is recovered from the filename
+    (`<instance_id>__seed<seed>.json`); `instance_id` may itself contain
+    `__`, so we split on the final `__seed` marker.
+    """
+    keys: list[tuple[str, int]] = []
+    for path in sorted(raw_dir.glob("*.json")):
+        stem = path.stem  # drops ".json"
+        marker = "__seed"
+        idx = stem.rfind(marker)
+        if idx == -1:
+            # No recognizable seed suffix — key on the bare stem, seed 0.
+            keys.append((stem, 0))
+            continue
+        instance_id = stem[:idx]
+        seed_str = stem[idx + len(marker):]
+        try:
+            seed = int(seed_str)
+        except ValueError:
+            seed = 0
+        keys.append((instance_id, seed))
+    return keys
 
 
 def _load_trajectories(raw_dir: Path) -> list[Any]:
@@ -234,7 +295,10 @@ def _render_reports(
     raw_root = run_dir / "raw"
     aggregates = []
     verify_metrics: dict[str, dict[str, Any]] = {}
-    success_by_arm: dict[str, list[bool]] = {}
+    # Per arm: map each task key (instance_id, seed) → success bool. Keyed
+    # by identity (NOT position) so contrasts pair the SAME task across
+    # arms regardless of file order or which tasks each arm happened to run.
+    success_by_arm: dict[str, dict[tuple[str, int], bool]] = {}
     success_proxy = False
 
     for arm in arms:
@@ -254,13 +318,20 @@ def _render_reports(
         # Verify metrics (offline).
         verify_metrics[arm] = evaluate_arm(trajs, verify_runner)
         # Success vector — proxy (submit) when no Docker results present.
+        # `_trajectory_keys` is aligned with `_load_trajectories`, so the
+        # keys zip 1:1 with the success vector.
         vec, proxy = task_success_vector(trajs, None)
-        success_by_arm[arm] = vec
+        keys = _trajectory_keys(raw_dir)
+        success_by_arm[arm] = dict(zip(keys, vec, strict=True))
         # Any arm on the proxy → label the whole comparison as proxy success.
         success_proxy = success_proxy or proxy
 
-    # McNemar paired contrasts (proxy-labelled). Only emit a contrast when
-    # both arms ran the SAME tasks (equal-length vectors).
+    # McNemar paired contrasts (proxy-labelled). Pair the two arms by task
+    # IDENTITY over the INTERSECTION of keys present in BOTH arms, sorted
+    # deterministically. Equal vector LENGTH no longer implies pairing — two
+    # arms that ran different tasks (offline report / resumed runs with
+    # missing files) won't be spuriously matched. A contrast with an empty
+    # intersection is skipped.
     paired: dict[str, tuple[list[bool], list[bool]]] = {}
     contrasts = {
         "B_vs_A": ("baseline", "retrieval"),
@@ -268,10 +339,16 @@ def _render_reports(
         "C_vs_A": ("baseline", "retrieval_verify"),
     }
     for key, (a_arm, b_arm) in contrasts.items():
-        av = success_by_arm.get(a_arm)
-        bv = success_by_arm.get(b_arm)
-        if av is not None and bv is not None and len(av) == len(bv):
-            paired[key] = (av, bv)
+        a_map = success_by_arm.get(a_arm)
+        b_map = success_by_arm.get(b_arm)
+        if a_map is None or b_map is None:
+            continue
+        shared = sorted(a_map.keys() & b_map.keys())
+        if not shared:
+            continue
+        av = [a_map[k] for k in shared]
+        bv = [b_map[k] for k in shared]
+        paired[key] = (av, bv)
 
     (run_dir / "comparison.json").write_text(
         json.dumps(
@@ -347,6 +424,29 @@ def run_command(
         )
         return 1
 
+    # (2b) PRE-FLIGHT rts-arm wiring — BEFORE any client is constructed.
+    # Non-baseline arms need an MCP bridge + per-task daemon. When no
+    # bridge_factory was injected (a real run, not a test), wire the REAL
+    # bridge/daemon over the built binaries. If the binaries are missing we
+    # FAIL FAST here — no client is constructed and no arm runs, so a real
+    # invocation can never spend baseline API calls only to abort when the
+    # first rts arm finds bridge=None.
+    needs_rts = any(arm != "baseline" for arm in arms)
+    if needs_rts and bridge_factory is None:
+        binaries = _discover_rts_binaries()
+        if binaries is None:
+            print(
+                "error: rts arms require built rts-mcp/rts-daemon binaries: "
+                "cargo build --release -p rts-mcp -p rts-daemon; none found. "
+                "No client constructed; no API call made.",
+                file=sys.stderr,
+            )
+            return 1
+        rts_mcp_bin, rts_daemon_bin = binaries
+        bridge_factory = _real_bridge_factory(rts_mcp_bin, rts_daemon_bin)
+        if daemon_factory is None:
+            daemon_factory = _real_daemon_factory(rts_daemon_bin)
+
     out_root = Path(args.out)
     rid = run_id or _new_run_id()
     run_dir = out_root / "runs" / rid
@@ -366,11 +466,17 @@ def run_command(
         for task in tasks:
             for seed in seeds:
                 out_file = raw_dir / _trajectory_filename(task.instance_id, seed)
-                # (4) resume: skip tuples whose trajectory file exists AND
-                # parses as valid JSON. A truncated/half-written file (killed
-                # mid-run) is NOT trusted — it's re-run rather than silently
-                # treated as complete.
-                if args.resume and _is_complete_trajectory(out_file):
+                # (4) resume: skip tuples whose trajectory file is a COMPLETE
+                # record matching this exact (task, arm, model). A truncated,
+                # bare, or mismatched file (killed mid-run, or left over from a
+                # different arm/model) is NOT trusted — it's re-run rather than
+                # silently treated as complete.
+                if args.resume and _is_complete_trajectory(
+                    out_file,
+                    task_id=task.instance_id,
+                    arm=arm,
+                    model=args.model,
+                ):
                     continue
 
                 config = RunConfig(model=args.model, system_prompt=_DEFAULT_SYSTEM_PROMPT)
@@ -437,6 +543,62 @@ def _new_run_id() -> str:
     import datetime
 
     return datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def _discover_rts_binaries() -> tuple[Path, Path] | None:
+    """Locate the built `rts-mcp`/`rts-daemon` release binaries.
+
+    Mirrors `tests/test_mcp_bridge.py`: the binaries live under
+    `<repo>/target/release/{rts-mcp,rts-daemon}`, where `<repo>` is the
+    workspace root two levels above this package. Returns
+    `(rts_mcp, rts_daemon)` when BOTH are present, else None (so the
+    caller can fail fast before any spend).
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    rts_mcp = repo_root / "target" / "release" / "rts-mcp"
+    rts_daemon = repo_root / "target" / "release" / "rts-daemon"
+    if rts_mcp.is_file() and rts_daemon.is_file():
+        return (rts_mcp, rts_daemon)
+    return None
+
+
+def _real_daemon_factory(rts_daemon_bin: Path) -> Callable[[str], Any]:
+    """Factory: a per-task `RtsDaemonHandle` for non-baseline arms.
+
+    Baseline arms get `None` (no daemon, `socket=None` from prepare_task).
+    """
+    from agent_bench.isolation import RtsDaemonHandle
+
+    def make(arm: str) -> Any:
+        if arm == "baseline":
+            return None
+        return RtsDaemonHandle(rts_daemon_bin=str(rts_daemon_bin))
+
+    return make
+
+
+def _real_bridge_factory(
+    rts_mcp_bin: Path, rts_daemon_bin: Path
+) -> Callable[[str, str | None], Any]:
+    """Factory: a real `McpBridge` over the per-task daemon socket.
+
+    Baseline arms get `None`. For rts arms the per-task daemon was started
+    over the materialized repo and its socket lives inside that repo dir
+    (`<repo_dir>/.rts-daemon.sock`), so the bridge's workspace is the
+    socket's parent directory. The bridge spawns its own rts-mcp wired to
+    `rts_daemon_bin`.
+    """
+    from agent_bench.mcp_bridge import McpBridge
+
+    def make(arm: str, socket: str | None) -> Any:
+        if arm == "baseline":
+            return None
+        if socket is None:
+            raise ValueError(f"arm {arm!r} requires a daemon socket but got None")
+        workspace = Path(socket).parent
+        return McpBridge.spawn(rts_mcp_bin, rts_daemon_bin, workspace)
+
+    return make
 
 
 def _real_repo_provider() -> Any:

--- a/agent-bench/tests/test_cli_rts_wiring.py
+++ b/agent-bench/tests/test_cli_rts_wiring.py
@@ -1,0 +1,221 @@
+"""Fix 1 (P1): rts-arm bridge/daemon wiring + fail-fast BEFORE any spend.
+
+A real `run` with a non-baseline arm needs an MCP bridge + per-task
+daemon. When no `bridge_factory` is injected (a real invocation, not a
+test) the CLI wires the REAL bridge/daemon over the built binaries — but
+if those binaries are missing it must FAIL FAST: print a clear error and
+return nonzero BEFORE constructing any client or running any arm, so no
+baseline API call is ever spent.
+
+ZERO real API / daemon / Docker / network — the only thing exercised here
+is the pre-flight gate (binaries are absent on the test host) and the
+injected-fake path (which never wires the real bridge).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+import agent_bench.cli as cli
+from agent_bench.cli import run_command
+from agent_bench.run import Task
+from tests.conftest import FakeAnthropicClient, FakeMessageResponse
+
+PINNED_MODEL = "claude-sonnet-4-7-20260315"
+
+
+@dataclass
+class FakeRepoProvider:
+    tree: dict[str, str] = field(default_factory=lambda: {"README.md": "hi\n"})
+
+    def materialize(self, task: Task, dest: Path) -> None:
+        dest.mkdir(parents=True, exist_ok=True)
+        for name, content in self.tree.items():
+            (dest / name).write_text(content)
+
+
+@dataclass
+class FakeVerifyRunner:
+    def verify_edit(self, edits: list[dict]) -> dict:
+        return {"verdict": "pass", "findings": [], "files": []}
+
+    def verify_file(self, path: str, content: str) -> dict:
+        return {"hallucinations": []}
+
+
+@dataclass
+class _FakeBridge:
+    """Minimal McpBridge double — advertises retrieval tools; never called."""
+
+    closed: int = 0
+
+    def list_tools(self):
+        from agent_bench.mcp_bridge import McpToolSchema
+
+        return [
+            McpToolSchema(name="find_symbol", description="d", input_schema={"type": "object"}),
+            McpToolSchema(name="grep", description="d", input_schema={"type": "object"}),
+        ]
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+def _submit_client() -> FakeAnthropicClient:
+    return FakeAnthropicClient(
+        [
+            FakeMessageResponse(
+                content=[
+                    {
+                        "type": "tool_use",
+                        "id": "t1",
+                        "name": "submit_patch",
+                        "input": {"patch": "--- a\n+++ b\n@@\n-x\n+y\n"},
+                    }
+                ]
+            )
+        ]
+    )
+
+
+def _write_corpus(tmp_path: Path, n: int = 2) -> Path:
+    rows = [
+        {
+            "instance_id": f"acme__widget-{i}",
+            "repo": "acme/widget",
+            "base_commit": "0" * 40,
+            "problem_statement": f"Fix bug {i}.",
+            "gold_patch": "",
+        }
+        for i in range(n)
+    ]
+    p = tmp_path / "corpus.json"
+    p.write_text(json.dumps({"name": "test-corpus", "tasks": rows}))
+    return p
+
+
+def _make_args(**overrides):
+    import argparse
+
+    ns = argparse.Namespace(
+        corpus=None,
+        arms="baseline",
+        seeds=1,
+        model=PINNED_MODEL,
+        max_usd=1000.0,
+        out=None,
+        resume=False,
+        limit=None,
+    )
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+class TestRtsArmFailFast:
+    def test_missing_binaries_fail_fast_before_any_spend(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch
+    ) -> None:
+        # Force the binary discovery to report "missing" so the test is
+        # deterministic regardless of whether the host has built rts.
+        monkeypatch.setattr(cli, "_discover_rts_binaries", lambda: None)
+
+        corpus = _write_corpus(tmp_path, n=2)
+        out = tmp_path / "out"
+        called = {"made_client": False}
+
+        def boom_factory(model: str):
+            called["made_client"] = True
+            return _submit_client()
+
+        rc = run_command(
+            _make_args(corpus=str(corpus), arms="baseline,retrieval", out=str(out)),
+            client_factory=boom_factory,
+            repo_provider=FakeRepoProvider(),
+            # NOTE: no bridge_factory injected → real-wiring path → fail-fast.
+            verify_runner=FakeVerifyRunner(),
+            run_id="run-test",
+        )
+        assert rc != 0
+        # Fail-fast happened BEFORE any client was constructed (no spend).
+        assert called["made_client"] is False
+        # No trajectory files written.
+        assert not (out / "runs").exists()
+        err = (capsys.readouterr().err).lower()
+        assert "rts-mcp" in err and "rts-daemon" in err
+        assert "no api call made" in err
+
+    def test_baseline_only_does_not_require_binaries(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Even with no binaries and no bridge_factory, a baseline-only run
+        # must proceed: baseline needs no bridge.
+        monkeypatch.setattr(cli, "_discover_rts_binaries", lambda: None)
+
+        corpus = _write_corpus(tmp_path, n=1)
+        out = tmp_path / "out"
+        rc = run_command(
+            _make_args(corpus=str(corpus), arms="baseline", out=str(out)),
+            client_factory=lambda model: _submit_client(),
+            repo_provider=FakeRepoProvider(),
+            verify_runner=FakeVerifyRunner(),
+            run_id="run-test",
+        )
+        assert rc == 0
+        raw = out / "runs" / "run-test" / "raw" / "baseline"
+        assert len(sorted(raw.glob("*.json"))) == 1
+
+    def test_present_binaries_wire_real_bridge_factory(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # When the binaries are "present", the real bridge/daemon factories
+        # are wired (constructed) WITHOUT spawning anything: we stub the
+        # factory builders and the run loop so nothing real executes.
+        fake_mcp = tmp_path / "rts-mcp"
+        fake_daemon = tmp_path / "rts-daemon"
+        fake_mcp.write_text("")
+        fake_daemon.write_text("")
+        monkeypatch.setattr(
+            cli, "_discover_rts_binaries", lambda: (fake_mcp, fake_daemon)
+        )
+
+        seen = {"bridge_built": False, "daemon_built": False}
+
+        def fake_bridge_builder(mcp, daemon):
+            seen["bridge_built"] = (mcp, daemon)
+
+            def make(arm, socket):
+                if arm == "baseline":
+                    return None
+                return _FakeBridge()  # rts arm: a fake (no real subprocess)
+
+            return make
+
+        def fake_daemon_builder(daemon):
+            seen["daemon_built"] = daemon
+
+            def make(arm):
+                return None
+
+            return make
+
+        monkeypatch.setattr(cli, "_real_bridge_factory", fake_bridge_builder)
+        monkeypatch.setattr(cli, "_real_daemon_factory", fake_daemon_builder)
+
+        corpus = _write_corpus(tmp_path, n=1)
+        out = tmp_path / "out"
+        rc = run_command(
+            _make_args(corpus=str(corpus), arms="baseline,retrieval", out=str(out)),
+            client_factory=lambda model: _submit_client(),
+            repo_provider=FakeRepoProvider(),
+            verify_runner=FakeVerifyRunner(),
+            run_id="run-test",
+        )
+        assert rc == 0
+        # The real factories were wired from the discovered binaries.
+        assert seen["bridge_built"] == (fake_mcp, fake_daemon)
+        assert seen["daemon_built"] == fake_daemon

--- a/agent-bench/tests/test_cli_run.py
+++ b/agent-bench/tests/test_cli_run.py
@@ -18,7 +18,12 @@ from pathlib import Path
 
 import pytest
 
-from agent_bench.cli import report_command, run_command
+from agent_bench.cli import (
+    _is_complete_trajectory,
+    _render_reports,
+    report_command,
+    run_command,
+)
 from agent_bench.run import Task
 from tests.conftest import FakeAnthropicClient, FakeMessageResponse
 
@@ -345,3 +350,177 @@ class TestReportOffline:
         cj = json.loads((run_dir / "comparison.json").read_text())
         assert cj["success_proxy"] is True
         assert "PROXY" in (run_dir / "comparison.md").read_text()
+
+
+# --- Fix 2: resume validates schema + identity --------------------
+
+
+def _full_record(
+    *, task_id: str, arm: str, model: str, halt_reason: str = "submit"
+) -> dict:
+    return {
+        "task_id": task_id,
+        "arm": arm,
+        "model": model,
+        "messages": [],
+        "tool_calls": [],
+        "final_patch": "p",
+        "halt_reason": halt_reason,
+        "wall_clock_s": 0.0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+    }
+
+
+class TestIsCompleteTrajectory:
+    def test_bare_object_is_incomplete(self, tmp_path: Path) -> None:
+        p = tmp_path / "t.json"
+        p.write_text("{}")
+        assert _is_complete_trajectory(
+            p, task_id="x", arm="baseline", model=PINNED_MODEL
+        ) is False
+
+    def test_partial_object_is_incomplete(self, tmp_path: Path) -> None:
+        p = tmp_path / "t.json"
+        p.write_text(json.dumps({"task_id": "x"}))
+        assert _is_complete_trajectory(
+            p, task_id="x", arm="baseline", model=PINNED_MODEL
+        ) is False
+
+    def test_wrong_arm_is_incomplete(self, tmp_path: Path) -> None:
+        p = tmp_path / "t.json"
+        p.write_text(json.dumps(_full_record(task_id="x", arm="retrieval", model=PINNED_MODEL)))
+        # Same schema but the arm doesn't match → re-run.
+        assert _is_complete_trajectory(
+            p, task_id="x", arm="baseline", model=PINNED_MODEL
+        ) is False
+
+    def test_wrong_model_is_incomplete(self, tmp_path: Path) -> None:
+        p = tmp_path / "t.json"
+        p.write_text(json.dumps(_full_record(task_id="x", arm="baseline", model="claude-opus-4-7-20260101")))
+        assert _is_complete_trajectory(
+            p, task_id="x", arm="baseline", model=PINNED_MODEL
+        ) is False
+
+    def test_full_matching_record_is_complete(self, tmp_path: Path) -> None:
+        p = tmp_path / "t.json"
+        p.write_text(json.dumps(_full_record(task_id="x", arm="baseline", model=PINNED_MODEL)))
+        assert _is_complete_trajectory(
+            p, task_id="x", arm="baseline", model=PINNED_MODEL
+        ) is True
+
+
+class TestResumeIdentity:
+    def test_resume_reruns_mismatched_model_record(self, tmp_path: Path) -> None:
+        # A complete-looking file left over from a DIFFERENT model must be
+        # re-run, not skipped (it would aggregate stale data).
+        corpus = _write_corpus(tmp_path, n=1)
+        out = tmp_path / "out"
+        raw = out / "runs" / "run-test" / "raw" / "baseline"
+        raw.mkdir(parents=True)
+        stale = _full_record(
+            task_id="acme__widget-0",
+            arm="baseline",
+            model="claude-opus-4-7-20260101",
+        )
+        (raw / "acme__widget-0__seed0.json").write_text(json.dumps(stale))
+
+        client_calls = {"n": 0}
+
+        def counting_factory(model: str):
+            client_calls["n"] += 1
+            return _submit_client()
+
+        rc = run_command(
+            _make_args(
+                corpus=str(corpus), arms="baseline", seeds=1, out=str(out), resume=True
+            ),
+            client_factory=counting_factory,
+            repo_provider=FakeRepoProvider(),
+            daemon_factory=lambda arm: None,
+            bridge_factory=_bridge_factory_none,
+            verify_runner=FakeVerifyRunner(),
+            run_id="run-test",
+        )
+        assert rc == 0
+        # Mismatched-model file was re-run.
+        assert client_calls["n"] == 1
+        body = json.loads((raw / "acme__widget-0__seed0.json").read_text())
+        assert body["model"] == PINNED_MODEL
+
+
+# --- Fix 3: McNemar pairs by task identity, not vector length -----
+
+
+def _seed_raw(raw_dir: Path, instance_id: str, seed: int, arm: str, *, submit: bool) -> None:
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    rec = _full_record(
+        task_id=instance_id,
+        arm=arm,
+        model=PINNED_MODEL,
+        halt_reason="submit" if submit else "no_patch",
+    )
+    (raw_dir / f"{instance_id}__seed{seed}.json").write_text(json.dumps(rec))
+
+
+class TestMcNemarPairsByIdentity:
+    def test_disjoint_task_ids_are_not_spuriously_paired(self, tmp_path: Path) -> None:
+        # Two arms, same COUNT (2 each) but DISJOINT task ids. Length-based
+        # pairing would emit a bogus contrast; identity pairing must skip it
+        # (empty intersection).
+        run_dir = tmp_path / "runs" / "r"
+        a = run_dir / "raw" / "baseline"
+        b = run_dir / "raw" / "retrieval"
+        _seed_raw(a, "acme__widget-0", 0, "baseline", submit=True)
+        _seed_raw(a, "acme__widget-1", 0, "baseline", submit=True)
+        _seed_raw(b, "acme__gadget-0", 0, "retrieval", submit=False)
+        _seed_raw(b, "acme__gadget-1", 0, "retrieval", submit=False)
+
+        _render_reports(run_dir, ["baseline", "retrieval"], FakeVerifyRunner())
+
+        cj = json.loads((run_dir / "comparison.json").read_text())
+        # No shared task ids → no B_vs_A contrast at all.
+        assert "B_vs_A" not in cj["mcnemar"]
+
+    def test_same_ids_different_file_order_pair_by_id(self, tmp_path: Path) -> None:
+        # Both arms ran the same two tasks. Arm A: widget-0 submit,
+        # widget-1 no-submit. Arm B: BOTH submit. Identity pairing must
+        # match widget-0↔widget-0 and widget-1↔widget-1 regardless of the
+        # (sorted) filename order.
+        run_dir = tmp_path / "runs" / "r"
+        a = run_dir / "raw" / "baseline"
+        b = run_dir / "raw" / "retrieval"
+        _seed_raw(a, "acme__widget-0", 0, "baseline", submit=True)
+        _seed_raw(a, "acme__widget-1", 0, "baseline", submit=False)
+        _seed_raw(b, "acme__widget-0", 0, "retrieval", submit=True)
+        _seed_raw(b, "acme__widget-1", 0, "retrieval", submit=True)
+
+        _render_reports(run_dir, ["baseline", "retrieval"], FakeVerifyRunner())
+
+        cj = json.loads((run_dir / "comparison.json").read_text())
+        assert "B_vs_A" in cj["mcnemar"]
+        block = cj["mcnemar"]["B_vs_A"]
+        # Contrast is (A=baseline, B=retrieval). widget-0: A=T,B=T
+        # (concordant). widget-1: A=F,B=T → b01 (a fail, b pass) = 1, b10 = 0.
+        # If the tasks were mispaired by order this would be wrong.
+        assert block["b01"] == 1
+        assert block["b10"] == 0
+
+    def test_partial_overlap_pairs_only_intersection(self, tmp_path: Path) -> None:
+        # Arm A ran widget-0,1; arm B ran widget-1,2 (resume with a missing
+        # file). Only widget-1 is shared → contrast over exactly 1 pair.
+        run_dir = tmp_path / "runs" / "r"
+        a = run_dir / "raw" / "baseline"
+        b = run_dir / "raw" / "retrieval"
+        _seed_raw(a, "acme__widget-0", 0, "baseline", submit=True)
+        _seed_raw(a, "acme__widget-1", 0, "baseline", submit=True)
+        _seed_raw(b, "acme__widget-1", 0, "retrieval", submit=True)
+        _seed_raw(b, "acme__widget-2", 0, "retrieval", submit=True)
+
+        _render_reports(run_dir, ["baseline", "retrieval"], FakeVerifyRunner())
+
+        cj = json.loads((run_dir / "comparison.json").read_text())
+        # Only widget-1 is shared, and it's T/T → concordant (b01=b10=0).
+        # The contrast is emitted (intersection non-empty) over that 1 pair.
+        block = cj["mcnemar"]["B_vs_A"]
+        assert block["b01"] == 0 and block["b10"] == 0


### PR DESCRIPTION
Fixes three Codex reviewer findings on the `agent-bench` `run`/`report` path. All changes are in `agent_bench/cli.py` (+ tests). HARD CONSTRAINT honored: ZERO real model/daemon/Docker/network in tests.

## Fix 1 (P1, C-blocker) — wire the real bridge/daemon for rts arms, or fail fast BEFORE any spend
Previously `run_command` defaulted `daemon_factory` to `lambda arm: None` and left `bridge_factory` None, so `retrieval`/`retrieval_verify` arms got `bridge=None` → `build_tool_list` raised `ValueError` — but only AFTER baseline arms had already spent API calls.

Now a pre-flight runs **after the budget gate and before any client is constructed or any arm runs**:
- If a non-baseline arm is requested and no `bridge_factory` was injected, discover the built `rts-mcp`/`rts-daemon` release binaries under `<repo>/target/release/...` (mirrors `tests/test_mcp_bridge.py`).
- **Missing** → print `rts arms require built rts-mcp/rts-daemon binaries: cargo build --release -p rts-mcp -p rts-daemon; none found. No client constructed; no API call made.` and return nonzero — no client, no `runs/` files.
- **Present** → wire a real `McpBridge` factory (workspace = the per-task daemon socket's parent dir, matching `prepare_task`'s contract) + a real `RtsDaemonHandle` factory for non-baseline arms (baseline stays `None`).
- All injected (test) factories are left untouched.

## Fix 2 (P2) — validate resumed trajectories against schema + identity
`_is_complete_trajectory` accepted any dict (even `{}`), so resume could skip a file the loader/aggregator would then crash on or aggregate as stale. It now requires the full trajectory schema the loader reads (`task_id`, `arm`, `model`, `halt_reason`, token fields) AND matches the CURRENT `(task_id, arm, model)` (passed in at the call site). Bare/partial/mismatched files are treated as INCOMPLETE → re-run.

## Fix 3 (P2) — pair McNemar inputs by task identity, not vector length
`_render_reports` paired arm success vectors by equal LENGTH, which can pair unrelated tasks (offline report / resumed runs with missing files). Each success bool is now carried with its `(instance_id, seed)` key per arm; each contrast emits the McNemar delta over the **intersection** of keys present in BOTH arms (sorted deterministically), skipping the contrast when the intersection is empty.

## Test plan (`uv run pytest`, 96 passed / 5 skipped)
- `tests/test_cli_rts_wiring.py`: missing binaries → nonzero, client never constructed, no `runs/` written; baseline-only run proceeds without binaries; present binaries wire the real bridge/daemon factories.
- `tests/test_cli_run.py`: `TestIsCompleteTrajectory` (`{}`, `{"task_id":"x"}`, wrong arm, wrong model → incomplete; full match → complete); `TestResumeIdentity` (mismatched-model record is re-run); `TestMcNemarPairsByIdentity` (disjoint same-length ids → no spurious contrast; same ids different file order → paired by id; partial overlap → contrast over the intersection only).
- Existing injected-fake tests stay green. The 5 skips are the pre-existing `test_mcp_bridge.py` integration tests (no built binaries on this host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)