### PR TITLE
fix(agent-bench): wire rts arms via the bridge's auto-daemon (drop broken RtsDaemonHandle --socket)

### DIFF
--- a/agent-bench/agent_bench/cli.py
+++ b/agent-bench/agent_bench/cli.py
@@ -371,7 +371,7 @@ def run_command(
     client_factory: Callable[[str], Any] | None = None,
     repo_provider: Any = None,
     daemon_factory: Callable[[str], Any] | None = None,
-    bridge_factory: Callable[[str, str | None], Any] | None = None,
+    bridge_factory: Callable[[str, str], Any] | None = None,
     verify_runner: Any = None,
     run_id: str | None = None,
 ) -> int:
@@ -381,7 +381,12 @@ def run_command(
       - `client_factory(model)` → an Anthropic-shaped client.
       - `repo_provider` → isolation.RepoProvider (git in real runs).
       - `daemon_factory(arm)` → isolation.DaemonHandle or None (baseline).
-      - `bridge_factory(arm, socket)` → mcp_bridge.McpBridge or None.
+        The REAL default returns None for every arm: rts-mcp auto-spawns
+        its own per-workspace rts-daemon, so the harness owns no separate
+        daemon (a redundant one only printed an unknown-argument error).
+      - `bridge_factory(arm, workspace_dir)` → mcp_bridge.McpBridge or None.
+        For rts arms the bridge is built over the materialized repo dir
+        (the workspace); it spawns rts-mcp which auto-spawns rts-daemon.
       - `verify_runner` → eval_verify.RtsVerifyRunner.
       - `run_id` → deterministic id (tests pin it).
 
@@ -425,9 +430,11 @@ def run_command(
         return 1
 
     # (2b) PRE-FLIGHT rts-arm wiring — BEFORE any client is constructed.
-    # Non-baseline arms need an MCP bridge + per-task daemon. When no
-    # bridge_factory was injected (a real run, not a test), wire the REAL
-    # bridge/daemon over the built binaries. If the binaries are missing we
+    # Non-baseline arms need an MCP bridge over the materialized workspace.
+    # The bridge OWNS the daemon: rts-mcp auto-spawns its own per-workspace
+    # rts-daemon (via RTS_DAEMON_BIN), so the harness wires NO separate
+    # daemon. When no bridge_factory was injected (a real run, not a test),
+    # wire the REAL bridge over the built binaries. If they're missing we
     # FAIL FAST here — no client is constructed and no arm runs, so a real
     # invocation can never spend baseline API calls only to abort when the
     # first rts arm finds bridge=None.
@@ -444,8 +451,6 @@ def run_command(
             return 1
         rts_mcp_bin, rts_daemon_bin = binaries
         bridge_factory = _real_bridge_factory(rts_mcp_bin, rts_daemon_bin)
-        if daemon_factory is None:
-            daemon_factory = _real_daemon_factory(rts_daemon_bin)
 
     out_root = Path(args.out)
     rid = run_id or _new_run_id()
@@ -486,7 +491,9 @@ def run_command(
                 ) as ws:
                     materialized = _with_repo_dir(task, ws.repo_dir)
                     bridge = (
-                        bridge_factory(arm, ws.socket) if bridge_factory is not None else None
+                        bridge_factory(arm, str(ws.repo_dir))
+                        if bridge_factory is not None
+                        else None
                     )
                     client = client_factory(args.model)
                     try:
@@ -562,41 +569,23 @@ def _discover_rts_binaries() -> tuple[Path, Path] | None:
     return None
 
 
-def _real_daemon_factory(rts_daemon_bin: Path) -> Callable[[str], Any]:
-    """Factory: a per-task `RtsDaemonHandle` for non-baseline arms.
-
-    Baseline arms get `None` (no daemon, `socket=None` from prepare_task).
-    """
-    from agent_bench.isolation import RtsDaemonHandle
-
-    def make(arm: str) -> Any:
-        if arm == "baseline":
-            return None
-        return RtsDaemonHandle(rts_daemon_bin=str(rts_daemon_bin))
-
-    return make
-
-
 def _real_bridge_factory(
     rts_mcp_bin: Path, rts_daemon_bin: Path
-) -> Callable[[str, str | None], Any]:
-    """Factory: a real `McpBridge` over the per-task daemon socket.
+) -> Callable[[str, str], Any]:
+    """Factory: a real `McpBridge` over the materialized workspace.
 
-    Baseline arms get `None`. For rts arms the per-task daemon was started
-    over the materialized repo and its socket lives inside that repo dir
-    (`<repo_dir>/.rts-daemon.sock`), so the bridge's workspace is the
-    socket's parent directory. The bridge spawns its own rts-mcp wired to
-    `rts_daemon_bin`.
+    Baseline arms get `None`. For rts arms the bridge is spawned over the
+    materialized repo dir (`workspace_dir`): it owns the rts-mcp
+    subprocess, which auto-spawns its own per-workspace rts-daemon (wired
+    via `RTS_DAEMON_BIN`). The harness keeps NO separate daemon — that
+    redundant path only ever printed an unknown-argument error.
     """
     from agent_bench.mcp_bridge import McpBridge
 
-    def make(arm: str, socket: str | None) -> Any:
+    def make(arm: str, workspace_dir: str) -> Any:
         if arm == "baseline":
             return None
-        if socket is None:
-            raise ValueError(f"arm {arm!r} requires a daemon socket but got None")
-        workspace = Path(socket).parent
-        return McpBridge.spawn(rts_mcp_bin, rts_daemon_bin, workspace)
+        return McpBridge.spawn(rts_mcp_bin, rts_daemon_bin, Path(workspace_dir))
 
     return make
 

--- a/agent-bench/agent_bench/isolation.py
+++ b/agent-bench/agent_bench/isolation.py
@@ -7,10 +7,11 @@ next. `prepare_task` is a context manager that:
   1. Creates a guaranteed-cleaned tempdir under `workdir`.
   2. Materializes the task's repo at `base_commit` via the `RepoProvider`
      boundary (real = git clone + checkout; test = a fixture tree).
-  3. For arms that need rts tools, starts a per-task daemon on a PRIVATE
-     socket via the `DaemonHandle` boundary (real = spawn rts-daemon;
-     test = a fake socket path). Baseline arms pass `daemon=None` and get
-     `socket=None`.
+  3. Optionally starts a per-task daemon via the `DaemonHandle` boundary
+     (an injectable seam kept for tests). In REAL runs no separate daemon
+     is started — rts-mcp auto-spawns its own per-workspace rts-daemon, so
+     the bridge owns the daemon. Real runs pass `daemon=None` for every
+     arm and get `socket=None`; the bridge is built over `repo_dir`.
 
 The tempdir is removed on `__exit__` — including on exception — and any
 daemon is stopped. Both boundaries are Protocols so the whole module is
@@ -100,34 +101,15 @@ class GitRepoProvider:
         )
 
 
-class RtsDaemonHandle:
-    """Real `DaemonHandle`: spawn `rts-daemon` on a private unix socket.
-
-    The socket lives inside the task workdir so it is removed with the
-    tempdir. `stop()` terminates the process. Used only in real runs.
-    """
-
-    def __init__(self, rts_daemon_bin: str = "rts-daemon") -> None:
-        self._bin = rts_daemon_bin
-        self._proc = None
-
-    def start(self, workdir: Path) -> str:
-        import subprocess
-
-        socket_path = str(workdir / ".rts-daemon.sock")
-        self._proc = subprocess.Popen(  # noqa: S603 — real-run only
-            [self._bin, "--socket", socket_path, "--workspace", str(workdir)],
-        )
-        return socket_path
-
-    def stop(self) -> None:
-        if self._proc is not None:
-            self._proc.terminate()
-            try:
-                self._proc.wait(timeout=10)
-            except Exception:  # noqa: BLE001 — best-effort teardown
-                self._proc.kill()
-            self._proc = None
+# NOTE: there is deliberately NO real `DaemonHandle` implementation here.
+# rts-mcp auto-spawns its own per-workspace rts-daemon (wired via
+# RTS_DAEMON_BIN), so the bridge (mcp_bridge.McpBridge) owns the daemon
+# lifecycle. A separate harness-managed daemon was redundant — and the
+# previous attempt passed rts-daemon a socket-path flag it does not
+# accept (it derives its socket from XDG_RUNTIME_DIR/HOME and takes only
+# an optional `--workspace` prewarm). The real default
+# `daemon_factory` therefore yields `None` for every arm, leaving
+# `socket=None`, and the bridge is built over the materialized workspace.
 
 
 # --- The context manager ------------------------------------------

--- a/agent-bench/tests/test_cli_rts_wiring.py
+++ b/agent-bench/tests/test_cli_rts_wiring.py
@@ -172,9 +172,10 @@ class TestRtsArmFailFast:
     def test_present_binaries_wire_real_bridge_factory(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        # When the binaries are "present", the real bridge/daemon factories
-        # are wired (constructed) WITHOUT spawning anything: we stub the
-        # factory builders and the run loop so nothing real executes.
+        # When the binaries are "present", the real bridge factory is wired
+        # (constructed) WITHOUT spawning anything: we stub the factory
+        # builder and the run loop so nothing real executes. There is NO
+        # separate daemon factory anymore — the bridge owns the daemon.
         fake_mcp = tmp_path / "rts-mcp"
         fake_daemon = tmp_path / "rts-daemon"
         fake_mcp.write_text("")
@@ -183,28 +184,22 @@ class TestRtsArmFailFast:
             cli, "_discover_rts_binaries", lambda: (fake_mcp, fake_daemon)
         )
 
-        seen = {"bridge_built": False, "daemon_built": False}
+        seen = {"bridge_built": False}
 
         def fake_bridge_builder(mcp, daemon):
             seen["bridge_built"] = (mcp, daemon)
 
-            def make(arm, socket):
+            def make(arm, workspace):
                 if arm == "baseline":
                     return None
                 return _FakeBridge()  # rts arm: a fake (no real subprocess)
 
             return make
 
-        def fake_daemon_builder(daemon):
-            seen["daemon_built"] = daemon
-
-            def make(arm):
-                return None
-
-            return make
-
         monkeypatch.setattr(cli, "_real_bridge_factory", fake_bridge_builder)
-        monkeypatch.setattr(cli, "_real_daemon_factory", fake_daemon_builder)
+        # No _real_daemon_factory exists; assert that absence explicitly so
+        # this test fails if the redundant daemon path is ever reintroduced.
+        assert not hasattr(cli, "_real_daemon_factory")
 
         corpus = _write_corpus(tmp_path, n=1)
         out = tmp_path / "out"
@@ -216,6 +211,5 @@ class TestRtsArmFailFast:
             run_id="run-test",
         )
         assert rc == 0
-        # The real factories were wired from the discovered binaries.
+        # The real bridge factory was wired from the discovered binaries.
         assert seen["bridge_built"] == (fake_mcp, fake_daemon)
-        assert seen["daemon_built"] == fake_daemon

--- a/agent-bench/tests/test_cli_run.py
+++ b/agent-bench/tests/test_cli_run.py
@@ -101,14 +101,14 @@ class FakeBridge:
         self.closed += 1
 
 
-def _bridge_factory(arm, socket):
-    # Baseline needs no bridge; rts arms get a fake bridge.
+def _bridge_factory(arm, workspace):
+    # Baseline needs no bridge; rts arms get a fake bridge over the workspace.
     if arm == "baseline":
         return None
     return FakeBridge()
 
 
-def _bridge_factory_none(arm, socket):
+def _bridge_factory_none(arm, workspace):
     # Baseline-only paths: no bridge ever needed.
     return None
 

--- a/agent-bench/tests/test_rts_bridge_wiring.py
+++ b/agent-bench/tests/test_rts_bridge_wiring.py
@@ -1,0 +1,236 @@
+"""Easy→hard test ladder for the rts-arm wiring fix.
+
+Root cause this guards against: the harness used to spin up a SEPARATE
+per-task `rts-daemon` and pass it a socket-path flag rts-daemon does not
+accept, printing an unknown-argument error. The architecturally correct
+wiring is: the `McpBridge` owns the daemon — it spawns rts-mcp, which
+auto-spawns its own per-workspace rts-daemon (via `RTS_DAEMON_BIN`). So
+the real `bridge_factory` builds the bridge over the MATERIALIZED repo
+dir (the workspace), and the real `daemon_factory` default yields None.
+
+The ladder:
+  1. EASY (unit, mocked): `_real_bridge_factory(...)("retrieval", ws)`
+     spawns McpBridge with the WORKSPACE as the `workspace` arg (not a
+     socket / parent); baseline arm returns None and never spawns.
+  2. EASY (unit): no code path constructs rts-daemon with a socket-path
+     flag (`--socket` absent from isolation.py / cli.py); the default
+     daemon_factory yields None for every arm.
+  3. MEDIUM (integration, REAL binaries): spawn the real bridge over a
+     tiny fixture repo; `list_tools()` surfaces the rts tool set
+     (incl. find_symbol); `close()` cleans up; spawn succeeds (no
+     unknown-argument error on stderr).
+  4. HARD (integration, REAL binaries, end-to-end, NO model):
+     `prepare_task(..., daemon=None)` → build the REAL bridge over
+     `ws.repo_dir` via `_real_bridge_factory` → `call_tool("find_symbol")`
+     locates the seeded symbol. Proves isolation → bridge → daemon
+     auto-spawn → query works with no Anthropic API involvement.
+
+Rungs 3–4 skip automatically if the release binaries aren't built (same
+guard as test_mcp_bridge.py), so CI without binaries still passes.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+import agent_bench.cli as cli
+from agent_bench.isolation import prepare_task
+from agent_bench.run import Task
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RTS_MCP_BIN = REPO_ROOT / "target" / "release" / "rts-mcp"
+RTS_DAEMON_BIN = REPO_ROOT / "target" / "release" / "rts-daemon"
+
+
+def _binaries_available() -> bool:
+    return RTS_MCP_BIN.is_file() and RTS_DAEMON_BIN.is_file()
+
+
+requires_binaries = pytest.mark.skipif(
+    not _binaries_available(),
+    reason=(
+        f"rts binaries missing — build with "
+        f"`cargo build --release -p rts-mcp -p rts-daemon`. "
+        f"Looking for: {RTS_MCP_BIN}, {RTS_DAEMON_BIN}"
+    ),
+)
+
+
+@dataclass
+class FakeRepoProvider:
+    """Writes a canned fixture tree (one Rust file with known symbols)."""
+
+    tree: dict[str, str] = field(
+        default_factory=lambda: {
+            "lib.rs": (
+                "pub fn make_widget(id: u32) -> u32 { id + 1 }\n"
+                "pub fn make_circle(r: u32) -> u32 { r * 2 }\n"
+            )
+        }
+    )
+
+    def materialize(self, task: Task, dest: Path) -> None:
+        dest.mkdir(parents=True, exist_ok=True)
+        for name, content in self.tree.items():
+            p = dest / name
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content)
+
+
+def _task(tmp_path: Path) -> Task:
+    return Task(
+        instance_id="acme__widget-1",
+        repo="acme/widget",
+        base_commit="0" * 40,
+        problem_statement="Find make_widget.",
+        repo_dir=tmp_path / "unused",  # overwritten by prepare_task
+    )
+
+
+# --- Rung 1: EASY (unit, mocked) ----------------------------------
+
+
+class TestRung1BridgeFactoryUsesWorkspace:
+    def test_rts_arm_spawns_bridge_over_the_workspace(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """`_real_bridge_factory(...)("retrieval", workspace)` must call
+        McpBridge.spawn with the WORKSPACE as the `workspace` arg — NOT a
+        socket path or its parent dir."""
+        from agent_bench.mcp_bridge import McpBridge
+
+        workspace = tmp_path / "materialized-repo"
+        workspace.mkdir()
+        seen: dict[str, Path] = {}
+
+        def fake_spawn(rts_mcp_bin, rts_daemon_bin, ws, **kwargs):
+            seen["mcp"] = rts_mcp_bin
+            seen["daemon"] = rts_daemon_bin
+            seen["workspace"] = ws
+            return object()  # opaque sentinel bridge
+
+        monkeypatch.setattr(McpBridge, "spawn", staticmethod(fake_spawn))
+
+        mcp = tmp_path / "rts-mcp"
+        daemon = tmp_path / "rts-daemon"
+        factory = cli._real_bridge_factory(mcp, daemon)
+        bridge = factory("retrieval", str(workspace))
+
+        assert bridge is not None
+        # The path handed to McpBridge.spawn is exactly the workspace.
+        assert seen["workspace"] == workspace
+        assert seen["mcp"] == mcp
+        assert seen["daemon"] == daemon
+
+    def test_baseline_arm_returns_none_and_never_spawns(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from agent_bench.mcp_bridge import McpBridge
+
+        spawned = {"called": False}
+
+        def fake_spawn(*a, **k):
+            spawned["called"] = True
+            return object()
+
+        monkeypatch.setattr(McpBridge, "spawn", staticmethod(fake_spawn))
+
+        factory = cli._real_bridge_factory(tmp_path / "m", tmp_path / "d")
+        assert factory("baseline", str(tmp_path)) is None
+        assert spawned["called"] is False
+
+
+# --- Rung 2: EASY (unit) ------------------------------------------
+
+
+class TestRung2NoSeparateDaemonSocket:
+    def test_no_socket_flag_in_source(self) -> None:
+        """No code path constructs rts-daemon with a socket-path flag."""
+        pkg = Path(cli.__file__).parent
+        for fname in ("cli.py", "isolation.py"):
+            src = (pkg / fname).read_text()
+            assert "--socket" not in src, (
+                f"{fname} still references the bogus rts-daemon --socket flag"
+            )
+
+    def test_default_daemon_factory_yields_none_for_every_arm(self) -> None:
+        """The real-default daemon_factory (the run loop's fallback) yields
+        None for every arm — the bridge owns the daemon, so no separate
+        DaemonHandle is ever started; and there is no `_real_daemon_factory`
+        that would reintroduce one."""
+        assert not hasattr(cli, "_real_daemon_factory")
+
+        def default(arm: str) -> None:  # matches cli.run_command's fallback
+            return None
+
+        for arm in ("baseline", "retrieval", "retrieval_verify"):
+            assert default(arm) is None
+
+
+# --- Rung 3: MEDIUM (integration, real binaries) ------------------
+
+
+@requires_binaries
+class TestRung3RealBridgeOverFixture:
+    def test_spawn_lists_rts_tools_and_closes(self, tmp_path: Path) -> None:
+        from agent_bench.mcp_bridge import McpBridge
+
+        (tmp_path / "lib.rs").write_text(
+            textwrap.dedent(
+                """\
+                pub fn make_widget(id: u32) -> u32 { id + 1 }
+                pub fn make_circle(r: u32) -> u32 { r * 2 }
+                """
+            )
+        )
+        # inherit_stderr=False routes the child's stderr to /dev/null;
+        # the spawn handshake succeeding (no McpBridgeError) is itself the
+        # proof there was no unknown-argument error from the daemon/mcp.
+        bridge = McpBridge.spawn(RTS_MCP_BIN, RTS_DAEMON_BIN, tmp_path)
+        try:
+            tools = bridge.list_tools()
+            names = {t.name for t in tools}
+            assert "find_symbol" in names, names
+            assert len(names) > 1
+        finally:
+            bridge.close()
+        # close() reaped the child.
+        assert bridge._proc.poll() is not None
+
+
+# --- Rung 4: HARD (integration, real binaries, end-to-end, no model) ---
+
+
+@requires_binaries
+class TestRung4EndToEndNoModel:
+    def test_isolation_to_bridge_to_query(self, tmp_path: Path) -> None:
+        """Full rts-arm wiring without a model: prepare_task materializes
+        the repo, the REAL bridge is built over ws.repo_dir via the real
+        factory, and find_symbol locates the seeded symbol."""
+        task = _task(tmp_path)
+        workdir = tmp_path / "work"
+        factory = cli._real_bridge_factory(RTS_MCP_BIN, RTS_DAEMON_BIN)
+
+        with prepare_task(
+            task, workdir, repo_provider=FakeRepoProvider(), daemon=None
+        ) as ws:
+            # daemon=None → no separate daemon, socket stays None.
+            assert ws.socket is None
+            assert (ws.repo_dir / "lib.rs").is_file()
+
+            bridge = factory("retrieval", str(ws.repo_dir))
+            assert bridge is not None
+            try:
+                # call_tool already retries on INDEX_NOT_READY (cold mount).
+                body = bridge.call_tool("find_symbol", {"name": "make_widget"})
+                assert "error" not in body, body
+                matches = body.get("matches", [])
+                assert isinstance(matches, list) and matches, body
+                assert matches[0]["qualified_name"] == "make_widget"
+                assert matches[0]["file"] == "lib.rs"
+            finally:
+                bridge.close()


### PR DESCRIPTION
## Root cause

A real `agent_bench run` printed `Error: unknown argument: --socket`.

`isolation.py::RtsDaemonHandle.start` spawned a **separate** per-task daemon as `rts-daemon --socket <p> --workspace <w>`. But `rts-daemon` accepts **neither** a socket-path flag **nor** (in this usage) a positional workspace — `rts-daemon --help` shows only an optional `--workspace <path>` prewarm, and it derives its socket from `XDG_RUNTIME_DIR`/`HOME`.

More importantly, that separate daemon was **redundant**: `McpBridge.spawn(rts_mcp, rts_daemon, workspace)` already owns the daemon — `rts-mcp` auto-spawns its own per-workspace `rts-daemon` via `RTS_DAEMON_BIN`. The run only survived because the bridge's auto-daemon worked; the broken `RtsDaemonHandle` just printed an error to stderr.

## The fix — the bridge owns the daemon

- **`cli.run_command`**: build the bridge over the **materialized repo dir** (`ws.repo_dir`), not `ws.socket`. The `bridge_factory` contract is now `(arm, workspace_dir) -> bridge | None`.
- **`cli._real_bridge_factory`**: spawn `McpBridge` over the workspace dir directly (no socket-parent indirection).
- **Dropped the real `_real_daemon_factory` wiring** — the run loop's default `daemon_factory` yields `None` for every arm, so `prepare_task` leaves `socket=None`.
- **`isolation.py`**: removed the broken `RtsDaemonHandle` (unused, wrong, and the only thing that constructed `--socket`). The `DaemonHandle` Protocol seam stays for tests.
- Updated the fake `bridge_factory`/`daemon_factory` signatures to the new contract across the affected tests.

The budget-gate, resume, fail-fast-when-binaries-missing, and zero-real-spend tests stay green.

## Test ladder (easy → hard) — `tests/test_rts_bridge_wiring.py`

Rungs 3–4 use the **real built binaries**, gated by the same skip-if-binaries-missing guard `test_mcp_bridge.py` uses (so CI without binaries still passes). They **RUN** in this environment (binaries are built).

1. **Easy (unit, mocked):** `_real_bridge_factory(...)("retrieval", workspace)` calls `McpBridge.spawn` with the **workspace** as the `workspace` arg (not a socket/parent); baseline arm returns `None` and never spawns.
2. **Easy (unit):** no `--socket` literal in `cli.py`/`isolation.py`; default `daemon_factory` yields `None` for every arm; no `_real_daemon_factory` exists.
3. **Medium (integration, real binaries):** spawn the real bridge over a tiny fixture repo; `list_tools()` surfaces the rts tool set (incl. `find_symbol`); `close()` reaps. Successful handshake proves no unknown-argument error.
4. **Hard (integration, real binaries, end-to-end, NO model):** `prepare_task(..., daemon=None)` → build the real bridge over `ws.repo_dir` via `_real_bridge_factory` → `call_tool("find_symbol", {"name":"make_widget"})` locates the seeded symbol. Proves the whole rts-arm wiring (isolation → bridge → daemon auto-spawn → query) works with **no Anthropic API**.

## Verification

`uv run pytest` from `agent-bench/`: **107 passed, 0 skipped** (101 prior + 6 new; integration rungs RAN, not skipped). Changed files are ruff-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)