### PR TITLE
test(deadline): minimum 1ms deadline to eliminate the closure-render flake

### DIFF
--- a/crates/rts-daemon/tests/deadline.rs
+++ b/crates/rts-daemon/tests/deadline.rs
@@ -724,6 +724,12 @@ async fn deadline_interrupts_read_symbol_dependency_closure() -> anyhow::Result<
     // 5ms deadline fires (a CI-only flake).
     wait_for_closure_ready(&mut stream, &hub_name, leaf_count, Duration::from_secs(120)).await?;
 
+    // Use the MINIMUM valid deadline (1ms). The readiness barrier above
+    // guarantees a full ~`leaf_count` closure to render; rendering it cannot
+    // complete within 1ms on any machine, so the only outcome is
+    // DEADLINE_EXCEEDED. A larger budget (e.g. 5ms) raced the render and
+    // flaked on fast CI runners where the full render occasionally finished in
+    // time.
     let resp = round_trip(
         &mut stream,
         "2",
@@ -733,7 +739,7 @@ async fn deadline_interrupts_read_symbol_dependency_closure() -> anyhow::Result<
             "include_dependencies": true,
             "token_budget": 200_000,
         }),
-        Some(&[("deadline_ms", json!(5u64))]),
+        Some(&[("deadline_ms", json!(1u64))]),
     )
     .await?;
 


### PR DESCRIPTION
## Summary
`deadline_interrupts_read_symbol_dependency_closure` flaked on CI again (after #167's readiness barrier reduced but didn't eliminate it). Root cause: a 5ms wall-clock deadline races the closure render — on fast CI runners the full 4000-leaf render occasionally finishes within 5ms, so the response is a success rather than `DEADLINE_EXCEEDED`.

Fix: use the **minimum valid deadline (1ms)** (the accepted range is `1..=600000`). The #167 barrier already guarantees a full ~`leaf_count` closure is built before the query; rendering it cannot complete within 1ms on any machine, so `DEADLINE_EXCEEDED` is the only possible outcome. A smaller deadline strictly increases reliability — it can never cause a non-deadline result.

Test-only; the other two deadline tests (impact_of/outline) are untouched (passing).

## Test plan
- [x] 6/6 local in release (the faster/flakier build)
- [x] `cargo fmt --check` clean