### PR TITLE
feat(agent-bench): --max-turns/--max-input-tokens flags + submit-before-budget prompt

### DIFF
--- a/agent-bench/agent_bench/cli.py
+++ b/agent-bench/agent_bench/cli.py
@@ -128,8 +128,11 @@ How to use what's already shipped:
 # only per-arm delta is Arm C's verify nudge, applied inside run.py).
 _DEFAULT_SYSTEM_PROMPT = (
     "You are a software engineer fixing a bug in a repository. "
-    "Investigate the codebase, make a minimal correct change, and call "
-    "submit_patch with a unified diff once you are confident."
+    "Investigate the codebase efficiently, then make a minimal correct change "
+    "and call submit_patch with a unified diff. Budget your turns: do not "
+    "explore indefinitely. Before you run low on turns, ALWAYS call "
+    "submit_patch with your best-effort unified diff rather than leaving it "
+    "unsubmitted — a best attempt is far better than no patch."
 )
 
 # Each arm name maps to its run.ArmConfig tool profile.
@@ -484,7 +487,16 @@ def run_command(
                 ):
                     continue
 
-                config = RunConfig(model=args.model, system_prompt=_DEFAULT_SYSTEM_PROMPT)
+                rc_kwargs: dict[str, Any] = {}
+                if getattr(args, "max_turns", None) is not None:
+                    rc_kwargs["max_turns"] = args.max_turns
+                if getattr(args, "max_input_tokens", None) is not None:
+                    rc_kwargs["max_input_tokens"] = args.max_input_tokens
+                config = RunConfig(
+                    model=args.model,
+                    system_prompt=_DEFAULT_SYSTEM_PROMPT,
+                    **rc_kwargs,
+                )
                 daemon = daemon_factory(arm)
                 with prepare_task(
                     task, workdir, repo_provider=repo_provider, daemon=daemon
@@ -677,6 +689,20 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     run_p.add_argument(
         "--limit", type=int, default=None, help="Truncate corpus to first N tasks."
+    )
+    run_p.add_argument(
+        "--max-turns",
+        type=int,
+        default=None,
+        dest="max_turns",
+        help="Max agent turns per (task, arm, seed). Default: RunConfig default.",
+    )
+    run_p.add_argument(
+        "--max-input-tokens",
+        type=int,
+        default=None,
+        dest="max_input_tokens",
+        help="Max accumulated input tokens per run. Default: RunConfig default.",
     )
 
     rep_p = sub.add_parser(

--- a/agent-bench/tests/test_cli_run.py
+++ b/agent-bench/tests/test_cli_run.py
@@ -309,6 +309,51 @@ class TestResume:
         json.loads((raw / "acme__widget-0__seed0.json").read_text())
 
 
+class TestBudgetFlags:
+    def _capture_config(self, monkeypatch):
+        # `run_command` does `from agent_bench.run import run_one_arm` locally,
+        # so patch the source module.
+        seen = {}
+        import agent_bench.run as runmod
+
+        real = runmod.run_one_arm
+
+        def capturing(*, client, task, arm, config, bridge):
+            seen["max_turns"] = config.max_turns
+            seen["max_input_tokens"] = config.max_input_tokens
+            return real(client=client, task=task, arm=arm, config=config, bridge=bridge)
+
+        monkeypatch.setattr(runmod, "run_one_arm", capturing)
+        return seen
+
+    def _run(self, tmp_path, monkeypatch, **extra):
+        corpus = _write_corpus(tmp_path, n=1)
+        seen = self._capture_config(monkeypatch)
+        rc = run_command(
+            _make_args(corpus=str(corpus), arms="baseline", out=str(tmp_path / "o"), **extra),
+            client_factory=lambda model: _submit_client(),
+            repo_provider=FakeRepoProvider(),
+            daemon_factory=lambda arm: None,
+            bridge_factory=_bridge_factory_none,
+            verify_runner=FakeVerifyRunner(),
+            run_id="run-test",
+        )
+        assert rc == 0
+        return seen
+
+    def test_flags_flow_into_runconfig(self, tmp_path, monkeypatch) -> None:
+        seen = self._run(tmp_path, monkeypatch, max_turns=40, max_input_tokens=350000)
+        assert seen["max_turns"] == 40
+        assert seen["max_input_tokens"] == 350000
+
+    def test_absent_flags_keep_runconfig_defaults(self, tmp_path, monkeypatch) -> None:
+        from agent_bench.run import DEFAULT_MAX_INPUT_TOKENS, DEFAULT_MAX_TURNS
+
+        seen = self._run(tmp_path, monkeypatch)  # no flags on the Namespace
+        assert seen["max_turns"] == DEFAULT_MAX_TURNS
+        assert seen["max_input_tokens"] == DEFAULT_MAX_INPUT_TOKENS
+
+
 # --- report subcommand (offline) ----------------------------------
 
 


### PR DESCRIPTION
## Summary
A real `agent_bench run` capped at the `RunConfig` defaults (20 turns / 200k input tokens) with no way to raise them, so on real SWE-bench-lite tasks the agent hit the cap mid-exploration and never submitted a patch (null success/verify/Docker dims). Add `--max-turns` / `--max-input-tokens` (getattr-guarded so existing tests keep the defaults) and strengthen the default system prompt to ALWAYS submit a best-effort patch before running low on turns.

Found while running a real 3-task pilot: even at 40 turns / 350k tokens the agent still token-caps without submitting on flask tasks — confirming the binding constraint is the (minimal) agent loop, not the budget. These flags make the budget configurable for future scaffolding experiments.

## Test plan
- [x] `uv run pytest` green; new tests assert the flags flow into `RunConfig` and that absent flags keep the defaults
- [x] ruff clean; argparse accepts the flags